### PR TITLE
Expose labels for observability

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -20,6 +20,7 @@ mod simple_event;
 pub use encoding::{EncodeIndices, Encoding, Utf8Encoding};
 pub use event::{Event, EventVisitor, VisitStringResult};
 pub use match_action::{MatchAction, PartialRedactDirection};
+pub use observability::labels;
 pub use path::{Path, PathSegment};
 pub use rule::{ProximityKeywordsConfig, RuleConfig, RuleConfigBuilder, Scope, SecondaryValidator};
 pub use rule_match::{ReplacementType, RuleMatch};

--- a/sds/src/observability/mod.rs
+++ b/sds/src/observability/mod.rs
@@ -1,1 +1,1 @@
-pub(crate) mod labels;
+pub mod labels;


### PR DESCRIPTION
Expose `labels` publicly in the library API as it should be possible to use them in `Scanner::new_with_labels`