### PR TITLE
Add labels in RuleConfig

### DIFF
--- a/sds/Cargo.lock
+++ b/sds/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
  "regex_generate",
  "serde",
  "serde_json",
+ "serde_test",
  "serde_with",
 ]
 
@@ -984,6 +985,15 @@ checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2f49ace1498612d14f7e0b8245519584db8299541dfe31a06374a828d620ab"
+dependencies = [
  "serde",
 ]
 

--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -33,6 +33,7 @@ regex_generate = "0.2.3"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 luhn = "1.0.1"
 serde_json = "1.0.114"
+serde_test = "1.0.176"
 
 [target.'cfg(target_arch = "x86_64")'.dev-dependencies]
 hyperscan = { version = "0.3.2", features = ["static"] }

--- a/sds/src/observability/labels.rs
+++ b/sds/src/observability/labels.rs
@@ -1,21 +1,21 @@
 use metrics::{IntoLabels, Label, SharedString};
+use std::fmt;
+
+use serde::de::{Deserializer, Error, SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Serialize, Serializer};
 
 /// Holder of multiple [Label] providing some methods to easily clone and adds new labels in it.
+#[derive(Clone, Debug, PartialEq)]
 pub struct Labels(Vec<Label>);
 
 pub const NO_LABEL: Labels = Labels(vec![]);
 
 impl Labels {
     /// Clone the actual [Labels] with additional key-value labels
-    pub fn clone_with_labels(
-        &self,
-        additional_labels: &[(
-            impl Into<SharedString> + Clone,
-            impl Into<SharedString> + Clone,
-        )],
-    ) -> Labels {
+    pub fn clone_with_labels(&self, additional_labels: Labels) -> Labels {
         let mut tags = self.0.clone();
-        tags.extend(additional_labels.iter().map(Label::from));
+        tags.extend(additional_labels.into_labels());
         Labels(tags)
     }
 
@@ -27,11 +27,83 @@ impl Labels {
     ) -> Self {
         Labels(labels.iter().map(Label::from).collect())
     }
+
+    pub fn empty() -> Self {
+        NO_LABEL
+    }
+}
+
+impl Default for Labels {
+    fn default() -> Self {
+        Self::empty()
+    }
 }
 
 impl IntoLabels for Labels {
     fn into_labels(self) -> Vec<Label> {
         self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Labels {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct LabelsVisitor;
+
+        impl<'de> Visitor<'de> for LabelsVisitor {
+            type Value = Labels;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("List of pairs of strings")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut label_list: Vec<(String, String)> =
+                    Vec::with_capacity(seq.size_hint().unwrap_or(0));
+
+                // While there are elements remaining in the input, add them
+                // into our list.
+                while let Some(element) = seq.next_element::<Vec<String>>()? {
+                    if element.len() < 2 {
+                        return Err(Error::custom(format!(
+                            "list `{:?}` contains a single element, two elements (key and value) are required",
+                            element
+                        )));
+                    }
+                    if element.len() > 2 {
+                        return Err(Error::custom(format!(
+                            "list `{:?}` contains more than two elements, only two elements (key and value) are allowed",
+                            element
+                        )));
+                    }
+                    label_list.push((
+                        element.first().unwrap().clone(),
+                        element.last().unwrap().clone(),
+                    ))
+                }
+
+                Ok(Labels::new(&label_list))
+            }
+        }
+        deserializer.deserialize_seq(LabelsVisitor)
+    }
+}
+
+impl Serialize for Labels {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for label in self.clone().into_labels() {
+            seq.serialize_element(&vec![label.key(), label.value()])?;
+        }
+        seq.end()
     }
 }
 
@@ -44,16 +116,89 @@ mod test {
     fn test_clone_labels() {
         let labels = Labels::new(&[("key_1", "value_1")]);
 
-        let labels_2 = labels.clone_with_labels(&[("key_2", "value_2")]);
+        let labels_2 = labels.clone_with_labels(Labels::new(&[("key_2", "value_2")]));
         let label_list = labels_2.into_labels();
         assert!(label_list.contains(&Label::new("key_1", "value_1")));
         assert!(label_list.contains(&Label::new("key_2", "value_2")));
 
-        let labels_3 = labels.clone_with_labels(&[("key_3", "value_3"), ("key_4", "value_4")]);
+        let labels_3 =
+            labels.clone_with_labels(Labels::new(&[("key_3", "value_3"), ("key_4", "value_4")]));
         let label_list = labels_3.into_labels();
         assert!(label_list.contains(&Label::new("key_1", "value_1")));
         assert!(!label_list.contains(&Label::new("key_2", "value_2")));
         assert!(label_list.contains(&Label::new("key_3", "value_3")));
         assert!(label_list.contains(&Label::new("key_4", "value_4")));
+    }
+
+    use crate::labels::NO_LABEL;
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+
+    #[test]
+    fn test_deserialization_empty() {
+        assert_tokens(&NO_LABEL, &[Token::Seq { len: Some(0) }, Token::SeqEnd]);
+    }
+
+    #[test]
+    fn test_ser_de() {
+        let labels = Labels::new(&[("key_1", "value_1"), ("key_2", "value_2")]);
+
+        assert_tokens(
+            &labels,
+            &[
+                Token::Seq { len: Some(2) },
+                Token::Seq { len: Some(2) },
+                Token::String("key_1"),
+                Token::String("value_1"),
+                Token::SeqEnd,
+                Token::Seq { len: Some(2) },
+                Token::String("key_2"),
+                Token::String("value_2"),
+                Token::SeqEnd,
+                Token::SeqEnd,
+            ],
+        );
+    }
+    #[test]
+    fn test_too_many_elements_for_a_label_should_fail_de() {
+        assert_de_tokens_error::<Labels>(
+            &[
+                Token::Seq { len: Some(1) },
+                Token::Seq { len: Some(3) },
+                Token::String("key_1"),
+                Token::String("value_1"),
+                Token::String("value_2"),
+                Token::SeqEnd,
+                Token::SeqEnd,
+            ],
+            "list `[\"key_1\", \"value_1\", \"value_2\"]` contains more than two elements, only two elements (key and value) are allowed",
+        );
+    }
+    #[test]
+    fn test_single_element_for_a_label_should_fail_de() {
+        assert_de_tokens_error::<Labels>(
+            &[
+                Token::Seq { len: Some(1) },
+                Token::Seq { len: Some(1) },
+                Token::String("key_1"),
+                Token::SeqEnd,
+                Token::SeqEnd,
+            ],
+            "list `[\"key_1\"]` contains a single element, two elements (key and value) are required",
+        );
+    }
+    #[test]
+    fn test_non_string_element_for_a_label_should_fail_de() {
+        assert_de_tokens_error::<Labels>(
+            &[
+                Token::Seq { len: Some(1) },
+                Token::Seq { len: Some(2) },
+                Token::String("key_1"),
+                Token::I8(1),
+                // assert_de_tokens_error requires no remaining token after the failure, so last two tokens should be skipped
+                // Token::SeqEnd,
+                // Token::SeqEnd,
+            ],
+            "invalid type: integer `1`, expected a string",
+        );
     }
 }

--- a/sds/src/proximity_keywords.rs
+++ b/sds/src/proximity_keywords.rs
@@ -111,11 +111,11 @@ impl Metrics {
         Metrics {
             false_positive_included_keywords: counter!(
                 "false_positive.proximity_keywords",
-                labels.clone_with_labels(&[(TYPE, "included_keywords".to_string())])
+                labels.clone_with_labels(Labels::new(&[(TYPE, "included_keywords".to_string())]))
             ),
             false_positive_excluded_keywords: counter!(
                 "false_positive.proximity_keywords",
-                labels.clone_with_labels(&[(TYPE, "excluded_keywords".to_string())])
+                labels.clone_with_labels(Labels::new(&[(TYPE, "excluded_keywords".to_string())]))
             ),
         }
     }

--- a/sds/src/rule.rs
+++ b/sds/src/rule.rs
@@ -4,6 +4,7 @@ use crate::match_action::MatchAction;
 use crate::path::Path;
 use serde_with::{serde_as, DefaultOnNull};
 
+#[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct RuleConfig {
     pub pattern: String,
@@ -12,6 +13,9 @@ pub struct RuleConfig {
     pub scope: Scope,
     pub proximity_keywords: Option<ProximityKeywordsConfig>,
     pub validator: Option<SecondaryValidator>,
+    #[serde_as(deserialize_as = "DefaultOnNull")]
+    #[serde(default)]
+    pub labels: Vec<(String, String)>,
 }
 
 impl RuleConfig {
@@ -23,6 +27,7 @@ impl RuleConfig {
             scope: Scope::all(),
             proximity_keywords: None,
             validator: None,
+            labels: vec![],
         }
     }
 }
@@ -99,6 +104,7 @@ pub struct RuleConfigBuilder {
     scope: Scope,
     proximity_keywords: Option<ProximityKeywordsConfig>,
     validator: Option<SecondaryValidator>,
+    labels: Vec<(String, String)>,
 }
 
 impl RuleConfigBuilder {
@@ -128,6 +134,11 @@ impl RuleConfigBuilder {
         self
     }
 
+    pub fn labels(mut self, labels: Vec<(String, String)>) -> RuleConfigBuilder {
+        self.labels = labels;
+        self
+    }
+
     pub fn from(rule: &RuleConfig) -> RuleConfigBuilder {
         RuleConfigBuilder {
             pattern: rule.pattern.clone(),
@@ -135,6 +146,7 @@ impl RuleConfigBuilder {
             scope: rule.scope.clone(),
             proximity_keywords: rule.proximity_keywords.clone(),
             validator: rule.validator.clone(),
+            labels: rule.labels.clone(),
         }
     }
 
@@ -145,6 +157,7 @@ impl RuleConfigBuilder {
             scope: self.scope,
             proximity_keywords: self.proximity_keywords,
             validator: self.validator,
+            labels: self.labels,
         }
     }
 }
@@ -172,6 +185,7 @@ mod test {
                 scope: Scope::all(),
                 proximity_keywords: None,
                 validator: None,
+                labels: vec![],
             }
         );
     }

--- a/sds/src/rule.rs
+++ b/sds/src/rule.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::labels::{Labels, NO_LABEL};
 use crate::match_action::MatchAction;
 use crate::path::Path;
 use serde_with::{serde_as, DefaultOnNull};
@@ -15,7 +16,7 @@ pub struct RuleConfig {
     pub validator: Option<SecondaryValidator>,
     #[serde_as(deserialize_as = "DefaultOnNull")]
     #[serde(default)]
-    pub labels: Vec<(String, String)>,
+    pub labels: Labels,
 }
 
 impl RuleConfig {
@@ -27,7 +28,7 @@ impl RuleConfig {
             scope: Scope::all(),
             proximity_keywords: None,
             validator: None,
-            labels: vec![],
+            labels: NO_LABEL,
         }
     }
 }
@@ -104,7 +105,7 @@ pub struct RuleConfigBuilder {
     scope: Scope,
     proximity_keywords: Option<ProximityKeywordsConfig>,
     validator: Option<SecondaryValidator>,
-    labels: Vec<(String, String)>,
+    labels: Labels,
 }
 
 impl RuleConfigBuilder {
@@ -134,7 +135,7 @@ impl RuleConfigBuilder {
         self
     }
 
-    pub fn labels(mut self, labels: Vec<(String, String)>) -> RuleConfigBuilder {
+    pub fn labels(mut self, labels: Labels) -> RuleConfigBuilder {
         self.labels = labels;
         self
     }
@@ -164,6 +165,7 @@ impl RuleConfigBuilder {
 
 #[cfg(test)]
 mod test {
+    use crate::labels::NO_LABEL;
     use crate::{MatchAction, ProximityKeywordsConfig, RuleConfig, Scope};
 
     #[test]
@@ -185,7 +187,7 @@ mod test {
                 scope: Scope::all(),
                 proximity_keywords: None,
                 validator: None,
-                labels: vec![],
+                labels: NO_LABEL,
             }
         );
     }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -51,7 +51,7 @@ impl Scanner {
                 let regex = validate_and_create_regex(&config.pattern)?;
                 config.match_action.validate()?;
 
-                let rule_labels = scanner_labels.clone_with_labels(&config.labels);
+                let rule_labels = scanner_labels.clone_with_labels(config.labels.clone());
 
                 let compiled_keywords = config
                     .proximity_keywords


### PR DESCRIPTION
Some labels can be specific to the rule itself (`rule_id` for instance), the goal of this PR is to attach labels to `RuleConfig`. [ticket](https://datadoghq.atlassian.net/browse/SDS-123)