### PR TITLE
Sort matches before calling `calculate_indices`

### DIFF
--- a/sds/src/encoding.rs
+++ b/sds/src/encoding.rs
@@ -10,6 +10,7 @@ pub trait Encoding: Sized {
     fn get_shift(value: &Self::IndexShift, utf8_shift: isize) -> isize;
 
     /// A iterator of indices. You are given the UTF-8 indices, and need to calculate the "custom" indices.
+    /// The UTF-8 indices are guaranteed to be sorted in ascending order by the start index.
     fn calculate_indices<'a>(
         content: &str,
         match_visitor: impl Iterator<Item = EncodeIndices<'a, Self>>,

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -1035,7 +1035,7 @@ mod test {
     }
 
     #[test]
-    fn panic_test() {
+    fn test_calculate_indices_is_called_with_sorted_start_index() {
         // A custom "Event" implementation is used here to use a different encoding that asserts the indices are in order
         struct OrderAssertEvent(SimpleEvent);
 


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SDS-218

Some `Encoding` implementations (e.g. `Utf16Encoding`) requires that the indices passed to it are in order, but this was not well-documented / enforced so it was broken in some recent refactoring. This is now fixed, documentation was added, and a test was added.