### PR TITLE
Remove leading zeros from hash result

### DIFF
--- a/sds/src/match_action.rs
+++ b/sds/src/match_action.rs
@@ -34,7 +34,6 @@ pub enum PartialRedactDirection {
 }
 
 const PARTIAL_REDACT_CHARACTER: char = '*';
-const HASH_LEN: usize = 16;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum MatchActionValidationError {
@@ -130,7 +129,7 @@ impl MatchAction {
 
     fn hash(match_result: &str) -> String {
         let hash = farmhash::fingerprint64(match_result.as_bytes());
-        format!("{hash:0HASH_LEN$x}")
+        format!("{hash:x}")
     }
 
     #[cfg(feature = "utf16_hash_match_action")]
@@ -139,6 +138,7 @@ impl MatchAction {
             .encode_utf16()
             .flat_map(u16::to_le_bytes)
             .collect::<Vec<_>>();
+        println!("Raw bytes: {:?}", utf16_bytes);
         let hash = farmhash::fingerprint64(&utf16_bytes);
         format!("{hash:0HASH_LEN$x}")
     }

--- a/sds/src/match_action.rs
+++ b/sds/src/match_action.rs
@@ -138,7 +138,6 @@ impl MatchAction {
             .encode_utf16()
             .flat_map(u16::to_le_bytes)
             .collect::<Vec<_>>();
-        println!("Raw bytes: {:?}", utf16_bytes);
         let hash = farmhash::fingerprint64(&utf16_bytes);
         format!("{hash:0HASH_LEN$x}")
     }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -1106,4 +1106,22 @@ mod test {
         let matches = scanner.scan(&mut content);
         assert_eq!(matches.len(), 2);
     }
+
+    #[test]
+    fn test_hash_with_leading_zero() {
+        let rule_0 = RuleConfig::builder(".+".to_owned())
+            .match_action(MatchAction::Hash)
+            .build();
+
+        let scanner = Scanner::new(&[rule_0]).unwrap();
+
+        let mut content =
+            SimpleEvent::String("rand string that has a leading zero after hashing: y".to_string());
+
+        let matches = scanner.scan(&mut content);
+        assert_eq!(matches.len(), 1);
+
+        // normally 09d99e4b6ad0d289, but the leading 0 is removed
+        assert_eq!(content, SimpleEvent::String("9d99e4b6ad0d289".to_string()));
+    }
 }


### PR DESCRIPTION
The hash result should not have leading zeros. This fixes that.