### PR TITLE
Remove leading zeros from hash result (UTF16)

### DIFF
--- a/sds/src/match_action.rs
+++ b/sds/src/match_action.rs
@@ -34,7 +34,6 @@ pub enum PartialRedactDirection {
 }
 
 const PARTIAL_REDACT_CHARACTER: char = '*';
-const HASH_LEN: usize = 16;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum MatchActionValidationError {
@@ -130,7 +129,7 @@ impl MatchAction {
 
     fn hash(match_result: &str) -> String {
         let hash = farmhash::fingerprint64(match_result.as_bytes());
-        format!("{hash:0HASH_LEN$x}")
+        format!("{hash:x}")
     }
 
     #[cfg(feature = "utf16_hash_match_action")]
@@ -139,6 +138,7 @@ impl MatchAction {
             .encode_utf16()
             .flat_map(u16::to_le_bytes)
             .collect::<Vec<_>>();
+        println!("Raw bytes: {:?}", utf16_bytes);
         let hash = farmhash::fingerprint64(&utf16_bytes);
         format!("{hash:0HASH_LEN$x}")
     }

--- a/sds/src/match_action.rs
+++ b/sds/src/match_action.rs
@@ -138,7 +138,6 @@ impl MatchAction {
             .encode_utf16()
             .flat_map(u16::to_le_bytes)
             .collect::<Vec<_>>();
-        println!("Raw bytes: {:?}", utf16_bytes);
         let hash = farmhash::fingerprint64(&utf16_bytes);
         format!("{hash:0HASH_LEN$x}")
     }

--- a/sds/src/match_action.rs
+++ b/sds/src/match_action.rs
@@ -18,7 +18,7 @@ pub enum MatchAction {
     #[deprecated(
         note = "Support hash from UTF-16 encoded bytes for backward compatibility. Users should use instead hash match action."
     )]
-    #[cfg(feature = "utf16_hash_match_action")]
+    #[cfg(any(test, feature = "utf16_hash_match_action"))]
     Utf16Hash,
     /// Replace the first or last n characters with asterisks.
     PartialRedact {
@@ -57,7 +57,7 @@ impl MatchAction {
             MatchAction::None | MatchAction::Redact { replacement: _ } | MatchAction::Hash => {
                 Ok(())
             }
-            #[cfg(feature = "utf16_hash_match_action")]
+            #[cfg(any(test, feature = "utf16_hash_match_action"))]
             #[allow(deprecated)]
             MatchAction::Utf16Hash => Ok(()),
         }
@@ -69,7 +69,7 @@ impl MatchAction {
             MatchAction::None => false,
             MatchAction::Redact { .. } => true,
             MatchAction::Hash { .. } => true,
-            #[cfg(feature = "utf16_hash_match_action")]
+            #[cfg(any(test, feature = "utf16_hash_match_action"))]
             #[allow(deprecated)]
             MatchAction::Utf16Hash { .. } => true,
             MatchAction::PartialRedact { .. } => true,
@@ -81,7 +81,7 @@ impl MatchAction {
             MatchAction::None => ReplacementType::None,
             MatchAction::Redact { .. } => ReplacementType::Placeholder,
             MatchAction::Hash { .. } => ReplacementType::Hash,
-            #[cfg(feature = "utf16_hash_match_action")]
+            #[cfg(any(test, feature = "utf16_hash_match_action"))]
             #[allow(deprecated)]
             MatchAction::Utf16Hash { .. } => ReplacementType::Hash,
             MatchAction::PartialRedact { direction, .. } => match direction {
@@ -104,7 +104,7 @@ impl MatchAction {
                 end: matched_content.len(),
                 replacement: Cow::Owned(Self::hash(matched_content)),
             }),
-            #[cfg(feature = "utf16_hash_match_action")]
+            #[cfg(any(test, feature = "utf16_hash_match_action"))]
             #[allow(deprecated)]
             MatchAction::Utf16Hash => Some(Replacement {
                 start: 0,
@@ -132,14 +132,14 @@ impl MatchAction {
         format!("{hash:x}")
     }
 
-    #[cfg(feature = "utf16_hash_match_action")]
+    #[cfg(any(test, feature = "utf16_hash_match_action"))]
     fn utf16_hash(match_result: &str) -> String {
         let utf16_bytes = match_result
             .encode_utf16()
             .flat_map(u16::to_le_bytes)
             .collect::<Vec<_>>();
         let hash = farmhash::fingerprint64(&utf16_bytes);
-        format!("{hash:0HASH_LEN$x}")
+        format!("{hash:x}")
     }
 
     fn partial_redaction_first(

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -1124,4 +1124,21 @@ mod test {
         // normally 09d99e4b6ad0d289, but the leading 0 is removed
         assert_eq!(content, SimpleEvent::String("9d99e4b6ad0d289".to_string()));
     }
+
+    #[test]
+    fn test_hash_with_leading_zero_utf16() {
+        let rule_0 = RuleConfig::builder(".+".to_owned())
+            .match_action(MatchAction::Utf16Hash)
+            .build();
+
+        let scanner = Scanner::new(&[rule_0]).unwrap();
+
+        let mut content = "rand string that has a leading zero after hashing: S".to_string();
+
+        let matches = scanner.scan(&mut content);
+        assert_eq!(matches.len(), 1);
+
+        // normally 08c3ad1a22e2edb1, but the leading 0 is removed
+        assert_eq!(content, "8c3ad1a22e2edb1");
+    }
 }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -1106,4 +1106,22 @@ mod test {
         let matches = scanner.scan(&mut content);
         assert_eq!(matches.len(), 2);
     }
+
+    #[test]
+    fn test_hash_with_leading_zero() {
+        let rule_0 = RuleConfig::builder(".+".to_owned())
+            .match_action(MatchAction::Hash)
+            .build();
+
+        let scanner = Scanner::new(&[rule_0]).unwrap();
+
+        let mut content =
+            SimpleEvent::String("rand string that has a leading zero after hashing: y".to_string());
+
+        let matches = scanner.scan(&mut content);
+        assert_eq!(matches.len(), 1);
+
+        // normally 09d99e4b6ad0d289, but the leading 0 is removed
+        assert_eq!(content, SimpleEvent::String("9d99e4b6ad0d289".to_string()));
+    }
 }


### PR DESCRIPTION
same as https://github.com/DataDog/dd-sensitive-data-scanner/pull/20 but for UTF16 hashing