### PR TITLE
Add build.go to store compilation flags

### DIFF
--- a/sds-go/go/build.go
+++ b/sds-go/go/build.go
@@ -1,0 +1,9 @@
+package sds
+
+/*
+#cgo LDFLAGS: -L../rust/target/release -lsds_go
+
+#include <stdlib.h>
+#include <sds.h>
+*/
+import "C"

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -9,9 +9,8 @@ import (
 )
 
 /*
-#cgo LDFLAGS: -L../rust/target/release -lsds_go
 #include <stdlib.h>
-#include "sds.h"
+#include <sds.h>
 */
 import "C"
 

--- a/sds-go/go/staticcheck.conf
+++ b/sds-go/go/staticcheck.conf
@@ -1,5 +1,3 @@
-# copide from dd-go
-
 checks = [
     # go vet checks
     "asmdecl", "assign", "atomic", "bools", "buildtag", "cgocall", "composites", "copylocks", "errorsas", "framepointer", "httpresponse", "ifaceassert", "loopclosure", "lostcancel", "nilfunc", "printf", "shift", "sigchanyzer", "stdmethods", "stringintconv", "structtag", "tests", "testinggoroutine", "unmarshal", "unreachable", "unsafeptr", "unusedresult",


### PR DESCRIPTION
Move compilation flags to a dedicated file so it's easier to update/replace when needed