### PR TITLE
sds-go: expose secondary validators rule configuration API through the `ExtraConfig` struct

### DIFF
--- a/sds-go/go/rule.go
+++ b/sds-go/go/rule.go
@@ -32,33 +32,34 @@ type Rule struct {
 	Id                 string                   `json:"id"`
 	Pattern            string                   `json:"pattern"`
 	MatchAction        MatchAction              `json:"match_action"`
-	ProximityKeywords  *proximityKeywordsConfig `json:"proximity_keywords,omitempty"`
-	SecondaryValidator *SecondaryValidator      `json:"secondary_validator,omitempty"`
+	ProximityKeywords  *ProximityKeywordsConfig `json:"proximity_keywords,omitempty"`
+	SecondaryValidator SecondaryValidator       `json:"secondary_validator,omitempty"`
 }
 
 // ExtraConfig is used to provide more configuration while creating the rules.
 type ExtraConfig struct {
-	ProximityKeywords *proximityKeywordsConfig
+	ProximityKeywords  *ProximityKeywordsConfig
+	SecondaryValidator SecondaryValidator
 }
 
 // CreateProximityKeywordsConfig creates a ProximityKeywordsConfig.
-func CreateProximityKeywordsConfig(lookAheadCharaceterCount uint32, includedKeywords []string, excludedKeywords []string) *proximityKeywordsConfig {
+func CreateProximityKeywordsConfig(lookAheadCharaceterCount uint32, includedKeywords []string, excludedKeywords []string) *ProximityKeywordsConfig {
 	if includedKeywords == nil {
 		includedKeywords = []string{}
 	}
 	if excludedKeywords == nil {
 		excludedKeywords = []string{}
 	}
-	return &proximityKeywordsConfig{
+	return &ProximityKeywordsConfig{
 		LookAheadCharacterCount: lookAheadCharaceterCount,
 		IncludedKeywords:        includedKeywords,
 		ExcludedKeywords:        excludedKeywords,
 	}
 }
 
-// proximityKeywordsConfig represents the proximity keyword matching
+// ProximityKeywordsConfig represents the proximity keyword matching
 // for the core library.
-type proximityKeywordsConfig struct {
+type ProximityKeywordsConfig struct {
 	LookAheadCharacterCount uint32   `json:"look_ahead_character_count"`
 	IncludedKeywords        []string `json:"included_keywords"`
 	ExcludedKeywords        []string `json:"excluded_keywords"`
@@ -95,6 +96,7 @@ func NewMatchingRule(id string, pattern string, extraConfig ExtraConfig) Rule {
 			Type: MatchActionNone,
 		},
 		ProximityKeywords: extraConfig.ProximityKeywords,
+		SecondaryValidator: extraConfig.SecondaryValidator,
 	}
 }
 
@@ -108,6 +110,7 @@ func NewRedactingRule(id string, pattern string, redactionValue string, extraCon
 			RedactionValue: redactionValue,
 		},
 		ProximityKeywords: extraConfig.ProximityKeywords,
+		SecondaryValidator: extraConfig.SecondaryValidator,
 	}
 }
 
@@ -120,6 +123,7 @@ func NewHashRule(id string, pattern string, extraConfig ExtraConfig) Rule {
 			Type: MatchActionHash,
 		},
 		ProximityKeywords: extraConfig.ProximityKeywords,
+		SecondaryValidator: extraConfig.SecondaryValidator,
 	}
 }
 
@@ -134,6 +138,7 @@ func NewPartialRedactRule(id string, pattern string, characterCount uint32, dire
 			Direction:      direction,
 		},
 		ProximityKeywords: extraConfig.ProximityKeywords,
+		SecondaryValidator: extraConfig.SecondaryValidator,
 	}
 }
 

--- a/sds-go/go/rule.go
+++ b/sds-go/go/rule.go
@@ -33,7 +33,7 @@ type Rule struct {
 	Pattern            string                   `json:"pattern"`
 	MatchAction        MatchAction              `json:"match_action"`
 	ProximityKeywords  *ProximityKeywordsConfig `json:"proximity_keywords,omitempty"`
-	SecondaryValidator SecondaryValidator       `json:"secondary_validator,omitempty"`
+	SecondaryValidator SecondaryValidator       `json:"validator,omitempty"`
 }
 
 // ExtraConfig is used to provide more configuration while creating the rules.
@@ -73,7 +73,7 @@ type RuleMatch struct {
 	ReplacementType   MatchAction
 	StartIndex        uint32
 	EndIndexExclusive uint32
-	ShiftOffset       uint32
+	ShiftOffset       int32
 }
 
 // MatchAction is used to configure the rules.
@@ -95,7 +95,7 @@ func NewMatchingRule(id string, pattern string, extraConfig ExtraConfig) Rule {
 		MatchAction: MatchAction{
 			Type: MatchActionNone,
 		},
-		ProximityKeywords: extraConfig.ProximityKeywords,
+		ProximityKeywords:  extraConfig.ProximityKeywords,
 		SecondaryValidator: extraConfig.SecondaryValidator,
 	}
 }
@@ -109,7 +109,7 @@ func NewRedactingRule(id string, pattern string, redactionValue string, extraCon
 			Type:           MatchActionRedact,
 			RedactionValue: redactionValue,
 		},
-		ProximityKeywords: extraConfig.ProximityKeywords,
+		ProximityKeywords:  extraConfig.ProximityKeywords,
 		SecondaryValidator: extraConfig.SecondaryValidator,
 	}
 }
@@ -122,7 +122,7 @@ func NewHashRule(id string, pattern string, extraConfig ExtraConfig) Rule {
 		MatchAction: MatchAction{
 			Type: MatchActionHash,
 		},
-		ProximityKeywords: extraConfig.ProximityKeywords,
+		ProximityKeywords:  extraConfig.ProximityKeywords,
 		SecondaryValidator: extraConfig.SecondaryValidator,
 	}
 }
@@ -137,7 +137,7 @@ func NewPartialRedactRule(id string, pattern string, characterCount uint32, dire
 			CharacterCount: characterCount,
 			Direction:      direction,
 		},
-		ProximityKeywords: extraConfig.ProximityKeywords,
+		ProximityKeywords:  extraConfig.ProximityKeywords,
 		SecondaryValidator: extraConfig.SecondaryValidator,
 	}
 }

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -257,7 +257,7 @@ func decodeResponse(rawData []byte) ([]byte, []RuleMatch, error) {
 
 			startIndex := binary.BigEndian.Uint32(buf.Next(4))
 			endIndexExclusive := binary.BigEndian.Uint32(buf.Next(4))
-			shiftOffset := binary.BigEndian.Uint32(buf.Next(4))
+			shiftOffset := int32(binary.BigEndian.Uint32(buf.Next(4)))
 
 			ruleMatches = append(ruleMatches, RuleMatch{
 				RuleIdx:           ruleIdx,


### PR DESCRIPTION
Also, do not use a pointer to the string but the string itself. If the string is empty, the Go JSON marshaling will automatically discard this field from the final output thanks to the `omitempty` flag, and let directly use the SecondaryValitor consts in callers.

And have the ProximityKeywordsConfig public in case someone wants to use it without the `New*Rule` helpers.

Fix `ShiftOffset` being an `int32` and not an `uint32`.