### PR TITLE
Downgrade thiserror version

### DIFF
--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -23,7 +23,7 @@ regex-automata = "0.4.4"
 regex-syntax = "0.7.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "3.6.1"
-thiserror = "1.0.59"
+thiserror = "1.0.58"
 metrics = "=0.22.1"
 crc32fast = "1.4.0"
 base62 = "2.0.2"


### PR DESCRIPTION
Running into errors while building the shared-library.

<img width="1276" alt="image" src="https://github.com/DataDog/dd-sensitive-data-scanner/assets/38605430/d6fb5b1e-61a5-4522-9ef7-d2f597857583">
