### PR TITLE
Fix farmhash bug

### DIFF
--- a/sds/Cargo.lock
+++ b/sds/Cargo.lock
@@ -420,8 +420,7 @@ dependencies = [
 [[package]]
 name = "farmhash"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35ce9c8fb9891c75ceadbc330752951a4e369b50af10775955aeb9af3eee34b"
+source = "git+https://github.com/fuchsnj/rust-farmhash?rev=82d80b689d65fbd378b13deff10cdd07794df64e#82d80b689d65fbd378b13deff10cdd07794df64e"
 
 [[package]]
 name = "fnv"

--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -42,3 +42,8 @@ hyperscan = { version = "0.3.2", features = ["static"] }
 [[bench]]
 name = "bench"
 harness = false
+
+
+[patch.crates-io]
+# https://github.com/seiflotfy/rust-farmhash/pull/16
+farmhash = { git = "https://github.com/fuchsnj/rust-farmhash", rev="82d80b689d65fbd378b13deff10cdd07794df64e"}

--- a/sds/src/match_action.rs
+++ b/sds/src/match_action.rs
@@ -405,4 +405,17 @@ mod test {
             })
         );
     }
+
+    #[test]
+    fn test_farmhash_bugfix() {
+        // Testing the bugfix from https://github.com/seiflotfy/rust-farmhash/pull/16
+        assert_eq!(
+            MatchAction::Hash.get_replacement(&"x".repeat(128)),
+            Some(Replacement {
+                start: 0,
+                end: 128,
+                replacement: "5170af09fd870c17".into()
+            })
+        );
+    }
 }


### PR DESCRIPTION
A bug was found in the `farmhash` crate which is used for hashing in SDS.

A [fix](https://github.com/seiflotfy/rust-farmhash/pull/16) was submitted to the `farmhash` crate, but since there has been no activity on that repo for over 8 years the chance of this PR actually being merged is minimal, so I forked the repo and switched this over to the fixed version.