### PR TITLE
Block accidental use of `println`

### DIFF
--- a/sds-bindings-utils/src/lib.rs
+++ b/sds-bindings-utils/src/lib.rs
@@ -1,3 +1,7 @@
+// This blocks accidental use of `println`. If one is actually needed, you can
+// override with `#[allow(clippy::print_stdout)]`.
+#![deny(clippy::print_stdout)]
+
 mod binary_encoding;
 
 pub use binary_encoding::{encode_response, BinaryEvent};

--- a/sds-go/rust/src/lib.rs
+++ b/sds-go/rust/src/lib.rs
@@ -1,1 +1,5 @@
+// This blocks accidental use of `println`. If one is actually needed, you can
+// override with `#[allow(clippy::print_stdout)]`.
+#![deny(clippy::print_stdout)]
+
 mod native;

--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -1,3 +1,7 @@
+// This blocks accidental use of `println`. If one is actually needed, you can
+// override with `#[allow(clippy::print_stdout)]`.
+#![deny(clippy::print_stdout)]
+
 mod encoding;
 mod event;
 mod match_action;


### PR DESCRIPTION
[JIRA](https://datadoghq.atlassian.net/browse/SDS-263)

This enables a `clippy` feature to prevent accidental `println` use. If this is needed (usually in tests), you can add a `#[allow(clippy::print_stdout)]` to allow it in specific places. This will run in CI.