### PR TITLE
Enforce quantifier lower bound limit

### DIFF
--- a/sds/src/parser/error.rs
+++ b/sds/src/parser/error.rs
@@ -7,7 +7,7 @@ use nom::error::{Error, ErrorKind};
 pub enum ParseError {
     InvalidSyntax,
     ExceededDepthLimit,
-    ExceededLowerBoundQuantifierLimit,
+    ExceededQuantifierLimit,
 }
 
 impl<'a> nom::error::ParseError<Input<'a>> for ParseError {

--- a/sds/src/parser/error.rs
+++ b/sds/src/parser/error.rs
@@ -7,6 +7,7 @@ use nom::error::{Error, ErrorKind};
 pub enum ParseError {
     InvalidSyntax,
     ExceededDepthLimit,
+    ExceededLowerBoundQuantifierLimit,
 }
 
 impl<'a> nom::error::ParseError<Input<'a>> for ParseError {

--- a/sds/src/scanner/error.rs
+++ b/sds/src/scanner/error.rs
@@ -74,11 +74,11 @@ mod test {
         );
         test_error(
             CreateScannerError::InvalidRegex(RegexValidationError::ExceededDepthLimit),
-            "The regex pattern was nested too deeply",
+            "The regex pattern is nested too deeply",
         );
         test_error(
             CreateScannerError::InvalidRegex(RegexValidationError::TooComplex),
-            "The regex has exceeded the complexity limit (i.e. it might be too slow)",
+            "The regex has exceeded the complexity limit (try simplifying the regex)",
         );
         test_error(
             CreateScannerError::InvalidRegex(RegexValidationError::MatchesEmptyString),


### PR DESCRIPTION
[Jira](https://datadoghq.atlassian.net/browse/SDS-192)

This adds a reasonably large limit to the lower bound of quantifiers. When a regex is compiled into a [DFA](https://en.wikipedia.org/wiki/Deterministic_finite_automaton) the size of the graph used for repetition is roughly proportional with size of the quantifier used. We already have "complexity" limits which validates a regex based on the overall DFA size generated, but having a hard cap for the quantifier values can make it easier for users to understand the limits. 

This does not affect unbounded quantifiers (e.g. `.{5,}` or `.+`).