### PR TITLE
✨ [SDS-194] Add validation of included keywords using the absolute path of the match

### DIFF
--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -72,7 +72,7 @@ func CreateScanner(rules []Rule) (*Scanner, error) {
 
 	var errorString *C.char
 
-	id := C.create_scanner(cdata, &errorString)
+	id := C.create_scanner(cdata, &errorString, C.bool(false) /* should_keywords_match_event_paths */)
 
 	if id < 0 {
 		switch id {

--- a/sds-go/go/sds.h
+++ b/sds-go/go/sds.h
@@ -1,8 +1,9 @@
 // From the Go documentation, it's recommended to include stdlib.h if we need
 // to use C.free.
 #include <stdlib.h>
+#include <stdbool.h>
 
-long create_scanner(const char* rules_as_json, const char** error);
+long create_scanner(const char* rules_as_json, const char** error, bool should_keywords_match_event_paths);
 void delete_scanner(long scanner_id);
 
 // event is a non-null terminated TODO

--- a/sds-go/rust/src/native/mod.rs
+++ b/sds-go/rust/src/native/mod.rs
@@ -22,6 +22,6 @@ pub fn convert_panic_to_error<R>(f: impl FnOnce() -> R + UnwindSafe) -> Result<R
             };
 
             Err(Error { message })
-        },
+        }
     }
 }

--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -33,7 +33,8 @@ pub use rule::{
 pub use rule_match::{ReplacementType, RuleMatch};
 pub use scanner::cache_pool::{CachePool, CachePoolBuilder, CachePoolGuard};
 pub use scanner::{
-    error::CreateScannerError, CompiledRuleTrait, MatchEmitter, Scanner, StringMatch,
+    error::CreateScannerError, CompiledRuleTrait, MatchEmitter, Scanner, ScannerFeatures,
+    StringMatch,
 };
 pub use scoped_ruleset::ExclusionCheck;
 pub use validation::{

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -59,7 +59,7 @@ impl<'a> Path<'a> {
                 if i != 0 {
                     sanitized_path.push(UNIFIED_LINK_CHAR);
                 }
-                standardize_path_chars(field.chars().collect(), |c| {
+                standardize_path_chars(field, |c| {
                     sanitized_path.push(c.to_ascii_lowercase());
                 });
             }

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -3,6 +3,8 @@ use std::fmt::{Debug, Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
+const UNIFIED_LINK_CHAR: &str = ".";
+
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Path<'a> {
     pub segments: Vec<PathSegment<'a>>,
@@ -51,7 +53,7 @@ impl<'a> Path<'a> {
         true
     }
 
-    pub fn to_string(&self) -> String {
+    pub fn absolute_path(&self) -> String {
         self.segments
             .iter()
             .filter_map(|segment| match segment {
@@ -59,7 +61,7 @@ impl<'a> Path<'a> {
                 _ => None,
             })
             .collect::<Vec<String>>()
-            .join(".")
+            .join(UNIFIED_LINK_CHAR)
     }
 }
 

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -52,7 +52,7 @@ impl<'a> Path<'a> {
         true
     }
 
-    pub fn absolute_path(&self) -> String {
+    pub fn sanitize(&self) -> String {
         self.segments
             .iter()
             .filter_map(|segment| match segment {
@@ -146,11 +146,11 @@ mod test {
     #[test]
     fn test_absolute_path() {
         assert_eq!(
-            Path::from(vec!["hello".into(), 0.into(), "world".into()]).absolute_path(),
+            Path::from(vec!["hello".into(), 0.into(), "world".into()]).sanitize(),
             "hello.world"
         );
         assert_eq!(
-            Path::from(vec!["hello".into(), 1.into(), "CHICKEN".into(), 2.into()]).absolute_path(),
+            Path::from(vec!["hello".into(), 1.into(), "CHICKEN".into(), 2.into()]).sanitize(),
             "hello.chicken"
         );
         assert_eq!(
@@ -160,7 +160,7 @@ mod test {
                 "CHICKEN".into(),
                 2.into(),
             ])
-            .absolute_path(),
+            .sanitize(),
             "hello.world.of.chicken"
         );
     }

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -50,6 +50,17 @@ impl<'a> Path<'a> {
         }
         true
     }
+
+    pub fn to_string(&self) -> String {
+        self.segments
+            .iter()
+            .filter_map(|segment| match segment {
+                PathSegment::Field(field) => Some(field.to_string().to_ascii_lowercase()),
+                _ => None,
+            })
+            .collect::<Vec<String>>()
+            .join(".")
+    }
 }
 
 impl<'a> PathSegment<'a> {
@@ -121,5 +132,17 @@ mod test {
         assert!(foo.starts_with(&foo));
         assert!(!foo.starts_with(&array_foo));
         assert!(!array_foo.starts_with(&foo));
+    }
+
+    #[test]
+    fn test_to_string() {
+        assert_eq!(
+            Path::from(vec!["hello".into(), 0.into(), "world".into()]).to_string(),
+            "hello.world"
+        );
+        assert_eq!(
+            Path::from(vec!["hello".into(), 1.into(), "CHICKEN".into(), 2.into()]).to_string(),
+            "hello.chicken"
+        );
     }
 }

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -53,20 +53,23 @@ impl<'a> Path<'a> {
     }
 
     pub fn sanitize(&self) -> String {
+        let mut sanitized_path = "".to_string();
         self.segments
             .iter()
-            .filter_map(|segment| match segment {
+            .enumerate()
+            .for_each(|(i, segment)| match segment {
                 PathSegment::Field(field) => {
-                    let mut sanitized_segment: Vec<char> = vec![];
+                    if i != 0 {
+                        sanitized_path.push(UNIFIED_LINK_CHAR);
+                    }
                     standardize_path_chars(field.chars().collect(), |c| {
-                        sanitized_segment.push(c.to_ascii_lowercase());
+                        sanitized_path.push(c.to_ascii_lowercase());
                     });
-                    return Some(sanitized_segment.iter().collect());
                 }
-                _ => None,
-            })
-            .collect::<Vec<String>>()
-            .join(UNIFIED_LINK_CHAR.to_string().as_str())
+                _ => (),
+            });
+
+        sanitized_path
     }
 }
 

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -54,20 +54,16 @@ impl<'a> Path<'a> {
 
     pub fn sanitize(&self) -> String {
         let mut sanitized_path = "".to_string();
-        self.segments
-            .iter()
-            .enumerate()
-            .for_each(|(i, segment)| match segment {
-                PathSegment::Field(field) => {
-                    if i != 0 {
-                        sanitized_path.push(UNIFIED_LINK_CHAR);
-                    }
-                    standardize_path_chars(field.chars().collect(), |c| {
-                        sanitized_path.push(c.to_ascii_lowercase());
-                    });
+        self.segments.iter().enumerate().for_each(|(i, segment)| {
+            if let PathSegment::Field(field) = segment {
+                if i != 0 {
+                    sanitized_path.push(UNIFIED_LINK_CHAR);
                 }
-                _ => (),
-            });
+                standardize_path_chars(field.chars().collect(), |c| {
+                    sanitized_path.push(c.to_ascii_lowercase());
+                });
+            }
+        });
 
         sanitized_path
     }

--- a/sds/src/proximity_keywords.rs
+++ b/sds/src/proximity_keywords.rs
@@ -54,19 +54,17 @@ impl CompiledProximityKeywords {
                     return false;
                 }
 
-                let is_valid_from_content = contains_keyword_match(
+                let is_false_positive_from_content = !contains_keyword_match(
                     content,
                     match_start,
                     self.look_ahead_character_count,
                     included_keywords,
                 );
 
-                let is_false_positive = !(is_valid_from_path || is_valid_from_content);
-
-                if is_false_positive {
+                if is_false_positive_from_content {
                     self.metrics.false_positive_included_keywords.increment(1);
                 }
-                is_false_positive
+                is_false_positive_from_content
             }
             (None, Some(excluded_keywords)) => {
                 let is_false_positive = contains_keyword_match(

--- a/sds/src/proximity_keywords.rs
+++ b/sds/src/proximity_keywords.rs
@@ -45,7 +45,7 @@ impl CompiledProximityKeywords {
     pub fn is_false_positive_match(
         &self,
         content: &str,
-        sanitized_path: Option<&str>,
+        sanitized_path: Option<String>,
         match_start: usize,
     ) -> bool {
         match (
@@ -55,7 +55,7 @@ impl CompiledProximityKeywords {
             (Some(included_keywords), _) => {
                 if let Some(sanitized_path) = sanitized_path {
                     let is_valid_from_path =
-                        self.contains_keyword_in_path(sanitized_path, included_keywords);
+                        self.contains_keyword_in_path(&sanitized_path, included_keywords);
 
                     if is_valid_from_path {
                         return false;
@@ -566,29 +566,37 @@ mod test {
 
         // Should match
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("aws.access.key.id"), 0),
+            proximity_keywords.is_false_positive_match(
+                "",
+                Some("aws.access.key.id".to_string()),
+                0
+            ),
             false
         );
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("aws.access.key"), 0),
+            proximity_keywords.is_false_positive_match("", Some("aws.access.key".to_string()), 0),
             false
         );
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("aws.access.keys"), 0),
+            proximity_keywords.is_false_positive_match("", Some("aws.access.keys".to_string()), 0),
             false
         );
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("aws.access%key"), 0),
-            false
-        );
-        assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("aws.access.key.identity"), 0),
+            proximity_keywords.is_false_positive_match("", Some("aws.access%key".to_string()), 0),
             false
         );
         assert_eq!(
             proximity_keywords.is_false_positive_match(
                 "",
-                Some("access.key.aws.another.long.keyword"),
+                Some("aws.access.key.identity".to_string()),
+                0
+            ),
+            false
+        );
+        assert_eq!(
+            proximity_keywords.is_false_positive_match(
+                "",
+                Some("access.key.aws.another.long.keyword".to_string()),
                 0,
             ),
             false
@@ -596,27 +604,27 @@ mod test {
 
         // Should not match
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("aws.key"), 0),
+            proximity_keywords.is_false_positive_match("", Some("aws.key".to_string()), 0),
             true
         );
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("key"), 0),
+            proximity_keywords.is_false_positive_match("", Some("key".to_string()), 0),
             true
         );
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("aws.app.key"), 0),
+            proximity_keywords.is_false_positive_match("", Some("aws.app.key".to_string()), 0),
             true
         );
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("aws.accessible"), 0),
+            proximity_keywords.is_false_positive_match("", Some("aws.accessible".to_string()), 0),
             true
         );
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("access#key"), 0),
+            proximity_keywords.is_false_positive_match("", Some("access#key".to_string()), 0),
             true
         );
         assert_eq!(
-            proximity_keywords.is_false_positive_match("", Some("key.access.aws"), 0),
+            proximity_keywords.is_false_positive_match("", Some("key.access.aws".to_string()), 0),
             true
         );
     }

--- a/sds/src/proximity_keywords.rs
+++ b/sds/src/proximity_keywords.rs
@@ -48,18 +48,20 @@ impl CompiledProximityKeywords {
             &self.excluded_keywords_pattern,
         ) {
             (Some(included_keywords), _) => {
-                let is_false_positive_from_content = !contains_keyword_match(
+                let is_valid_from_path = contains_keyword_in_path(path, included_keywords);
+
+                if is_valid_from_path {
+                    return false;
+                }
+
+                let is_valid_from_content = contains_keyword_match(
                     content,
                     match_start,
                     self.look_ahead_character_count,
                     included_keywords,
                 );
 
-                let is_false_positive_from_path =
-                    !contains_keyword_in_path(path, included_keywords);
-
-                let is_false_positive =
-                    is_false_positive_from_content && is_false_positive_from_path;
+                let is_false_positive = !(is_valid_from_path || is_valid_from_content);
 
                 if is_false_positive {
                     self.metrics.false_positive_included_keywords.increment(1);

--- a/sds/src/proximity_keywords.rs
+++ b/sds/src/proximity_keywords.rs
@@ -370,7 +370,7 @@ fn get_char_type(c: &char) -> CharType {
     }
 }
 
-fn standardize_path_chars<F>(chars: Vec<char>, mut push_character: F)
+pub fn standardize_path_chars<F>(chars: Vec<char>, mut push_character: F)
 where
     F: FnMut(&char),
 {

--- a/sds/src/proximity_keywords.rs
+++ b/sds/src/proximity_keywords.rs
@@ -379,21 +379,21 @@ fn get_char_type(c: &char) -> CharType {
 
 /// Function that standardizes a list of characters, by pushing characters one by one in a standard way.
 /// Takes a closure that will be called when a character is to be pushed
-pub fn standardize_path_chars<F>(chars: Vec<char>, mut push_character: F)
+pub fn standardize_path_chars<F>(chars: &str, mut push_character: F)
 where
     F: FnMut(&char),
 {
     let kw_length = chars.len();
 
-    if chars.is_empty() {
+    if let Some(c) = chars.chars().next() {
+        push_character(&c);
+    } else {
         return;
     }
 
-    push_character(&chars[0]);
-
-    for (i, chars) in chars.windows(2).enumerate() {
-        let current = &chars[1];
-        let prev_char = get_char_type(&chars[0]);
+    for (i, chars) in chars.as_bytes().windows(2).enumerate() {
+        let current = &(chars[1] as char);
+        let prev_char = get_char_type(&(chars[0] as char));
         let current_char = get_char_type(current);
 
         let is_last_char = i == kw_length - 2;
@@ -436,9 +436,7 @@ fn calculate_keyword_path_pattern(keyword: &str) -> Ast {
         keyword_pattern.push(word_boundary())
     }
 
-    let char_list: Vec<char> = keyword.chars().collect();
-
-    standardize_path_chars(char_list, |c| {
+    standardize_path_chars(keyword, |c| {
         keyword_pattern.push(Ast::Literal(literal_ast(c.to_ascii_lowercase())));
     });
 
@@ -569,7 +567,7 @@ mod test {
             proximity_keywords.is_false_positive_match(
                 "",
                 Some("aws.access.key.id".to_string()),
-                0
+                0,
             ),
             false
         );
@@ -589,7 +587,7 @@ mod test {
             proximity_keywords.is_false_positive_match(
                 "",
                 Some("aws.access.key.identity".to_string()),
-                0
+                0,
             ),
             false
         );

--- a/sds/src/proximity_keywords.rs
+++ b/sds/src/proximity_keywords.rs
@@ -32,9 +32,9 @@ const EXCLUDED_KEYWORDS_REMOVED_CHARS: &[char] = &['-', '_'];
 /// Characters that are considered to be links between keyword words.
 /// Example: '-' in "aws-access" is considered to be a link character.
 /// Example: '.' in "my.path" is considered to be a link character.
-const MULTI_WORD_KEYWORDS_LINK_CHARS: &[char] = &['-', '_', '.', ' ', '/'];
+pub const MULTI_WORD_KEYWORDS_LINK_CHARS: &[char] = &['-', '_', '.', ' ', '/'];
 
-const UNIFIED_LINK_CHAR: char = '.';
+pub const UNIFIED_LINK_CHAR: char = '.';
 
 struct ProximityKeywordsRegex<const EXCLUDED_CHARS: bool> {
     content_regex: meta::Regex,

--- a/sds/src/proximity_keywords.rs
+++ b/sds/src/proximity_keywords.rs
@@ -370,6 +370,8 @@ fn get_char_type(c: &char) -> CharType {
     }
 }
 
+/// Function that standardizes a list of characters, by pushing characters one by one in a standard way.
+/// Takes a closure that will be called when a character is to be pushed
 pub fn standardize_path_chars<F>(chars: Vec<char>, mut push_character: F)
 where
     F: FnMut(&char),

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -459,7 +459,7 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
 
                 rule.get_string_matches(
                     content,
-                    &path.absolute_path(),
+                    &path.sanitize(),
                     &mut self.caches,
                     &exclusion_check,
                     self.excluded_matches,

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -33,8 +33,8 @@ pub trait MatchEmitter {
 // This implements MatchEmitter for mutable closures (so you can use a closure instead of a custom
 // struct that implements MatchEmitter)
 impl<F> MatchEmitter for F
-    where
-        F: FnMut(StringMatch),
+where
+    F: FnMut(StringMatch),
 {
     fn emit(&mut self, string_match: StringMatch) {
         // This just calls the closure (itself)
@@ -138,8 +138,8 @@ impl RuleConfigTrait for Box<dyn RuleConfigTrait> {
 }
 
 impl<T> RuleConfigTrait for Box<T>
-    where
-        T: RuleConfigTrait,
+where
+    T: RuleConfigTrait,
 {
     fn convert_to_compiled_rule(
         &self,
@@ -620,7 +620,7 @@ mod test {
                     .build(),
             ) as Box<dyn RuleConfigTrait>,
         ])
-            .unwrap();
+        .unwrap();
 
         let mut input = "this is a dumbss with random data and a secret".to_owned();
 
@@ -640,7 +640,7 @@ mod test {
                 replacement: "[REDACTED]".to_string(),
             })
             .build()])
-            .unwrap();
+        .unwrap();
 
         let mut input = "text with secret".to_owned();
 
@@ -660,7 +660,7 @@ mod test {
                 .build()],
             Labels::new(&[("key".to_string(), "value".to_string())]),
         )
-            .unwrap();
+        .unwrap();
 
         let mut input = "text with secret".to_owned();
 
@@ -705,7 +705,7 @@ mod test {
                 replacement: "[REDACTED]".to_string(),
             })
             .build()])
-            .unwrap();
+        .unwrap();
 
         let mut content = "testing 1 2 3".to_string();
 
@@ -721,7 +721,7 @@ mod test {
             RegexRuleConfig::builder("a".to_owned()).build(),
             RegexRuleConfig::builder("b".to_owned()).build(),
         ])
-            .unwrap();
+        .unwrap();
 
         let mut content = "a b".to_string();
 
@@ -877,14 +877,54 @@ mod test {
 
         content = SimpleEvent::Map(BTreeMap::from([(
             "aws".to_string(),
-            SimpleEvent::Map(BTreeMap::from([(
-                "KEY".to_string(),
-                SimpleEvent::String("hello world".to_string()),
-            )])),
+            SimpleEvent::List(vec![
+                SimpleEvent::Map(BTreeMap::from([(
+                    "key".to_string(),
+                    SimpleEvent::String("hello world".to_string()),
+                )])),
+                SimpleEvent::Map(BTreeMap::from([(
+                    "access".to_string(),
+                    SimpleEvent::String("hello".to_string()),
+                )])),
+            ]),
         )]));
 
         let matches = scanner.scan(&mut content);
         assert_eq!(matches.len(), 0);
+
+        content = SimpleEvent::Map(BTreeMap::from([(
+            "aws%access".to_string(),
+            SimpleEvent::String("hello".to_string()),
+        )]));
+
+        let matches = scanner.scan(&mut content);
+        assert_eq!(matches.len(), 0);
+
+        content = SimpleEvent::Map(BTreeMap::from([(
+            "aws".to_string(),
+            SimpleEvent::List(vec![
+                SimpleEvent::Map(BTreeMap::from([(
+                    "key".to_string(),
+                    SimpleEvent::String("hello world".to_string()),
+                )])),
+                SimpleEvent::Map(BTreeMap::from([
+                    (
+                        "access".to_string(),
+                        SimpleEvent::Map(BTreeMap::from([(
+                            "random_key".to_string(),
+                            SimpleEvent::String("hello world".to_string()),
+                        )])),
+                    ),
+                    (
+                        "another_key".to_string(),
+                        SimpleEvent::String("hello world".to_string()),
+                    ),
+                ])),
+            ]),
+        )]));
+
+        let matches = scanner.scan(&mut content);
+        assert_eq!(matches.len(), 1);
     }
 
     #[test]
@@ -1376,7 +1416,7 @@ mod test {
 
             fn calculate_indices<'a>(
                 _content: &str,
-                match_visitor: impl Iterator<Item=crate::EncodeIndices<'a, Self>>,
+                match_visitor: impl Iterator<Item = crate::EncodeIndices<'a, Self>>,
             ) {
                 let mut prev_start = 0;
                 for indices in match_visitor {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -201,13 +201,19 @@ pub struct Scanner {
 
 impl Scanner {
     pub fn new<C: RuleConfigTrait>(rules: &[C]) -> Result<Self, CreateScannerError> {
-        Scanner::new_with_labels(rules, Labels::empty(), true)
+        Scanner::new_with_labels(
+            rules,
+            Labels::empty(),
+            ScannerFeatures {
+                should_keywords_match_event_paths: true,
+            },
+        )
     }
 
     pub fn new_with_labels<C: RuleConfigTrait>(
         rules: &[C],
         scanner_labels: Labels,
-        should_keywords_match_event_paths: bool,
+        feature_set: ScannerFeatures,
     ) -> Result<Self, CreateScannerError> {
         let mut cache_pool_builder = CachePoolBuilder::new();
         let compiled_rules = rules
@@ -233,9 +239,7 @@ impl Scanner {
             rules: compiled_rules,
             scoped_ruleset,
             cache_pool: cache_pool_builder.build(),
-            feature_set: ScannerFeatures {
-                should_keywords_match_event_paths,
-            },
+            feature_set,
         })
     }
 
@@ -547,7 +551,7 @@ fn is_false_positive_match(
 #[cfg(test)]
 mod test {
     use super::cache_pool::{CachePoolBuilder, CachePoolGuard};
-    use super::{MatchEmitter, StringMatch};
+    use super::{MatchEmitter, ScannerFeatures, StringMatch};
     use crate::match_action::{MatchAction, MatchActionValidationError};
     use crate::observability::labels::Labels;
     use crate::rule::{
@@ -676,7 +680,9 @@ mod test {
                 })
                 .build()],
             Labels::new(&[("key".to_string(), "value".to_string())]),
-            true,
+            ScannerFeatures {
+                should_keywords_match_event_paths: true,
+            },
         )
         .unwrap();
 

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -45,6 +45,7 @@ where
 pub trait CompiledRuleTrait: Send + Sync {
     fn get_match_action(&self) -> &MatchAction;
     fn get_scope(&self) -> &Scope;
+    #[allow(clippy::too_many_arguments)]
     fn get_string_matches(
         &self,
         content: &str,
@@ -197,7 +198,7 @@ impl RuleConfigTrait for RegexRuleConfig {
 }
 
 pub struct ScannerFeatures {
-    should_keywords_match_event_paths: bool,
+    pub should_keywords_match_event_paths: bool,
 }
 
 pub struct Scanner {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -188,7 +188,7 @@ impl RuleConfigTrait for RegexRuleConfig {
     }
 }
 
-struct ScannerFeatures {
+pub struct ScannerFeatures {
     should_keywords_match_event_paths: bool,
 }
 

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -466,9 +466,7 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
                     });
                 };
 
-                let mut should_keywords_match_event_paths =
-                    self.scanner.feature_set.should_keywords_match_event_paths;
-                let sanitized_path = if should_keywords_match_event_paths {
+                let sanitized_path = if self.scanner.feature_set.should_keywords_match_event_paths {
                     path.sanitize()
                 } else {
                     "".to_string()

--- a/sds/tools/fuzz/src/main.rs
+++ b/sds/tools/fuzz/src/main.rs
@@ -2,7 +2,9 @@
 #![allow(warnings)]
 
 use afl::fuzz;
-use dd_sds::{MatchAction, PartialRedactDirection, RegexRuleConfig, Scanner, Scope};
+use dd_sds::{
+    MatchAction, PartialRedactDirection, RegexRuleConfig, Scanner, ScannerFeatures, Scope,
+};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 #[cfg(not(feature = "manual_test"))]
@@ -85,9 +87,14 @@ fn run_fuzz(pattern: &str, input: &str, mut rng: StdRng) {
         println!("Match action: {:?}", match_action);
     }
 
-    let scanner_result = Scanner::new(&[RegexRuleConfig::builder(pattern.to_string())
-        .match_action(match_action)
-        .build()]);
+    let scanner_result = Scanner::new(
+        &[RegexRuleConfig::builder(pattern.to_string())
+            .match_action(match_action)
+            .build()],
+        ScannerFeatures {
+            should_keywords_match_event_paths: true,
+        },
+    );
 
     if let Ok(scanner) = scanner_result {
         let mut mutated_input = input.to_string();


### PR DESCRIPTION
- Add a `sanitize` method on the Path struct, that uses the same algorithm that is done for the proximity keywords and sanitize the path to a string
- Add a false positive method that validates keywords using the path of the match on structured events.
- Add a `ScannerFeature` struct that controls whether or not we will use that new false positive method
- Add unit tests to cover the feature