### PR TITLE
Add regex complexity function

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -41,7 +41,9 @@ pub use standard_rules::{
     get_simple_standard_rule_configs, parse_standard_rules, serialize_standard_rules_list,
     test_framework as standard_rule_test, StandardRule,
 };
-pub use validation::{validate_regex, RegexValidationError};
+pub use validation::{
+    get_regex_complexity_estimate_very_slow, validate_regex, RegexValidationError,
+};
 
 #[cfg(feature = "bench")]
 pub use crate::{

--- a/sds/src/validation.rs
+++ b/sds/src/validation.rs
@@ -1,6 +1,6 @@
 use crate::normalization::rust_regex_adapter::{convert_to_rust_regex, QUANTIFIER_LIMIT};
 use crate::parser::error::ParseError;
-use regex_automata::meta::{self, Regex};
+use regex_automata::meta::{self};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -88,7 +88,7 @@ fn build_regex(
     converted_pattern: &str,
     complexity_limit: usize,
 ) -> Result<meta::Regex, RegexValidationError> {
-    Ok(meta::Builder::new()
+    meta::Builder::new()
         .configure(
             meta::Config::new()
                 .nfa_size_limit(Some(complexity_limit))
@@ -100,7 +100,7 @@ fn build_regex(
                 .dot_matches_new_line(false)
                 .unicode(true),
         )
-        .build(&converted_pattern)
+        .build(converted_pattern)
         .map_err(|regex_err| {
             if regex_err.size_limit().is_some() {
                 RegexValidationError::TooComplex
@@ -108,7 +108,7 @@ fn build_regex(
                 // Internally the `regex` crate does this conversion, so we do it too
                 RegexValidationError::InvalidSyntax
             }
-        })?)
+        })
 }
 
 #[cfg(test)]

--- a/sds/src/validation.rs
+++ b/sds/src/validation.rs
@@ -1,6 +1,6 @@
 use crate::normalization::rust_regex_adapter::{convert_to_rust_regex, QUANTIFIER_LIMIT};
 use crate::parser::error::ParseError;
-use regex_automata::meta::{self};
+use regex_automata::meta::{self, Regex};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -40,14 +40,58 @@ pub fn validate_regex(input: &str) -> Result<(), RegexValidationError> {
     validate_and_create_regex(input).map(|_| ())
 }
 
+pub fn get_regex_complexity_estimate_very_slow(input: &str) -> Result<usize, RegexValidationError> {
+    // The regex crate doesn't directly give you access to the "complexity", but it does
+    // reject if it's too large, so we can binary search to find the limit.
+
+    let converted_pattern = convert_to_rust_regex(input)?;
+
+    let mut low = 1;
+    // Allow it to go a bit higher than the normal limit, since this can be used for debugging
+    // how complex a regex is.
+    let mut high = 10 * REGEX_COMPLEXITY_LIMIT;
+    while low < high {
+        let mid = low + (high - low) / 2;
+        if is_regex_within_complexity_limit(&converted_pattern, mid)? {
+            high = mid;
+        } else {
+            low = mid + 1;
+        }
+    }
+    Ok(low)
+}
+
 pub fn validate_and_create_regex(input: &str) -> Result<meta::Regex, RegexValidationError> {
     // This validates that the syntax is valid and normalizes behavior.
     let converted_pattern = convert_to_rust_regex(input)?;
+    let regex = build_regex(&converted_pattern, REGEX_COMPLEXITY_LIMIT)?;
+    if regex.is_match("") {
+        return Err(RegexValidationError::MatchesEmptyString);
+    }
+    Ok(regex)
+}
 
-    let regex = meta::Builder::new()
+fn is_regex_within_complexity_limit(
+    converted_pattern: &str,
+    complexity_limit: usize,
+) -> Result<bool, RegexValidationError> {
+    match build_regex(converted_pattern, complexity_limit) {
+        Ok(_) => Ok(true),
+        Err(err) => match err {
+            RegexValidationError::TooComplex => Ok(false),
+            _ => Err(err),
+        },
+    }
+}
+
+fn build_regex(
+    converted_pattern: &str,
+    complexity_limit: usize,
+) -> Result<meta::Regex, RegexValidationError> {
+    Ok(meta::Builder::new()
         .configure(
             meta::Config::new()
-                .nfa_size_limit(Some(REGEX_COMPLEXITY_LIMIT))
+                .nfa_size_limit(Some(complexity_limit))
                 // This is purely a performance setting. This is the default, but it might be worth testing this in benchmarks for a better number
                 .hybrid_cache_capacity(2 * (1 << 20)),
         )
@@ -64,18 +108,15 @@ pub fn validate_and_create_regex(input: &str) -> Result<meta::Regex, RegexValida
                 // Internally the `regex` crate does this conversion, so we do it too
                 RegexValidationError::InvalidSyntax
             }
-        })?;
-
-    if regex.is_match("") {
-        return Err(RegexValidationError::MatchesEmptyString);
-    }
-
-    Ok(regex)
+        })?)
 }
 
 #[cfg(test)]
 mod test {
-    use crate::validation::{validate_and_create_regex, validate_regex, RegexValidationError};
+    use crate::validation::{
+        get_regex_complexity_estimate_very_slow, validate_and_create_regex, validate_regex,
+        RegexValidationError,
+    };
 
     #[test]
     fn pattern_matching_empty_string_is_invalid() {
@@ -122,5 +163,24 @@ mod test {
     fn dot_new_line() {
         let regex = validate_and_create_regex(".").unwrap();
         assert_eq!(regex.is_match("\n"), false);
+    }
+
+    #[test]
+    fn test_complexity() {
+        // These values may change slightly when the `regex` crate is updated. As long as they
+        // are close, the test should be updated, otherwise the complexity limit may need to
+        // be adjusted.
+
+        assert_eq!(get_regex_complexity_estimate_very_slow("x"), Ok(1));
+        assert_eq!(get_regex_complexity_estimate_very_slow("x{1,10}"), Ok(920));
+        assert_eq!(get_regex_complexity_estimate_very_slow("."), Ok(1144));
+        assert_eq!(
+            get_regex_complexity_estimate_very_slow(".{1,10}"),
+            Ok(10536)
+        );
+        assert_eq!(
+            get_regex_complexity_estimate_very_slow(".{1,1000}"),
+            Ok(1_040_136)
+        );
     }
 }


### PR DESCRIPTION
This adds a function that can calculate the "complexity" of a regex function. It's mostly useful for debugging.