### PR TITLE
Support "implicit index wildcards" in scopes

### DIFF
--- a/sds-go/rust/src/native/create_scanner.rs
+++ b/sds-go/rust/src/native/create_scanner.rs
@@ -1,7 +1,7 @@
 use std::ffi::{c_char, CStr, CString};
 use std::sync::Arc;
 
-use dd_sds::{RegexRuleConfig, ScannerBuilder, ScannerFeatures};
+use dd_sds::{RegexRuleConfig, Scanner, ScannerBuilder, ScannerFeatures};
 
 use super::convert_panic_to_error;
 
@@ -23,10 +23,8 @@ pub extern "C" fn create_scanner(
         let rules: Vec<RegexRuleConfig> = serde_json::from_str(&val).unwrap();
 
         // create the scanner
-        let scanner = match ScannerBuilder::new(&rules)
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths,
-            })
+        let scanner = match Scanner::builder(&rules)
+            .with_keywords_should_match_event_paths(should_keywords_match_event_paths)
             .build()
         {
             Ok(s) => s,

--- a/sds-go/rust/src/native/create_scanner.rs
+++ b/sds-go/rust/src/native/create_scanner.rs
@@ -1,7 +1,7 @@
 use std::ffi::{c_char, CStr, CString};
 use std::sync::Arc;
 
-use dd_sds::{RegexRuleConfig, Scanner, ScannerBuilder, ScannerFeatures};
+use dd_sds::{RegexRuleConfig, Scanner};
 
 use super::convert_panic_to_error;
 

--- a/sds/benches/bench.rs
+++ b/sds/benches/bench.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main};
 
 mod scope_benchmark {
     use core::num;
-    use criterion::Criterion;
+    use criterion::{black_box, Criterion};
     use dd_sds::SimpleEvent;
     use dd_sds::{
         ContentVisitor, ExclusionCheck, Path, PathSegment, RuleIndexVisitor, Scope, ScopedRuleSet,
@@ -53,7 +53,7 @@ mod scope_benchmark {
                         &mut self,
                         path: &Path<'a>,
                         content: &str,
-                        rules: RuleIndexVisitor,
+                        mut rules: RuleIndexVisitor,
                         _check: ExclusionCheck,
                     ) -> bool {
                         rules.visit_rule_indices(|_rule_index| {
@@ -69,6 +69,7 @@ mod scope_benchmark {
                         num_visited: &mut num_visited,
                     },
                 );
+
                 assert_eq!(num_visited, 20_000);
             })
         });

--- a/sds/benches/bench.rs
+++ b/sds/benches/bench.rs
@@ -1,8 +1,7 @@
 use criterion::{criterion_group, criterion_main};
 
 mod scope_benchmark {
-    use core::num;
-    use criterion::{black_box, Criterion};
+    use criterion::Criterion;
     use dd_sds::SimpleEvent;
     use dd_sds::{
         ContentVisitor, ExclusionCheck, Path, PathSegment, RuleIndexVisitor, Scope, ScopedRuleSet,
@@ -39,7 +38,7 @@ mod scope_benchmark {
             scopes.push(exclude_scope.clone());
         }
 
-        let fast_rule_set = ScopedRuleSet::new(&scopes).with_implicit_index_wildcards();
+        let fast_rule_set = ScopedRuleSet::new(&scopes).with_implicit_index_wildcards(true);
 
         c.bench_function("scoped_rule_set", |b| {
             b.iter(|| {
@@ -51,8 +50,8 @@ mod scope_benchmark {
                 impl<'a> ContentVisitor<'a> for Counter<'a> {
                     fn visit_content(
                         &mut self,
-                        path: &Path<'a>,
-                        content: &str,
+                        _path: &Path<'a>,
+                        _content: &str,
                         mut rules: RuleIndexVisitor,
                         _check: ExclusionCheck,
                     ) -> bool {
@@ -77,7 +76,7 @@ mod scope_benchmark {
 }
 
 mod luhn_checksum_benchmark {
-    use criterion::{black_box, BenchmarkId, Criterion};
+    use criterion::Criterion;
     use dd_sds::{LuhnChecksum, Validator};
 
     pub fn criterion_benchmark(c: &mut Criterion) {

--- a/sds/benches/bench.rs
+++ b/sds/benches/bench.rs
@@ -39,7 +39,7 @@ mod scope_benchmark {
             scopes.push(exclude_scope.clone());
         }
 
-        let fast_rule_set = ScopedRuleSet::new(&scopes);
+        let fast_rule_set = ScopedRuleSet::new(&scopes).with_implicit_index_wildcards();
 
         c.bench_function("scoped_rule_set", |b| {
             b.iter(|| {

--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -34,7 +34,7 @@ pub use rule_match::{ReplacementType, RuleMatch};
 pub use scanner::cache_pool::{CachePool, CachePoolBuilder, CachePoolGuard};
 pub use scanner::{
     error::CreateScannerError, CompiledRuleTrait, MatchEmitter, Scanner, ScannerBuilder,
-    ScannerFeatures, StringMatch,
+    StringMatch,
 };
 pub use scoped_ruleset::ExclusionCheck;
 pub use validation::{

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -76,6 +76,10 @@ impl<'a> PathSegment<'a> {
             PathSegment::Index(i) => PathSegment::Index(*i),
         }
     }
+
+    pub fn is_index(&self) -> bool {
+        matches!(self, PathSegment::Index(_))
+    }
 }
 
 impl<'a> Debug for Path<'a> {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -16,6 +16,7 @@ use self::cache_pool::{CachePool, CachePoolBuilder, CachePoolGuard};
 use self::metrics::Metrics;
 use ahash::AHashSet;
 use regex_automata::{Input, Match};
+use serde::{Deserialize, Serialize};
 
 pub(crate) mod cache_pool;
 pub mod error;
@@ -195,7 +196,7 @@ impl RuleConfigTrait for RegexRuleConfig {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ScannerFeatures {
     pub should_keywords_match_event_paths: bool,
 }
@@ -1784,6 +1785,7 @@ mod test {
         use metrics_util::debugging::DebuggingRecorder;
         use metrics_util::CompositeKey;
         use metrics_util::MetricKind::Counter;
+        use serde_test::{assert_tokens, Token};
         use std::collections::BTreeMap;
 
         #[test]
@@ -1917,6 +1919,25 @@ mod test {
                 .expect("metric not found");
 
             assert_eq!(metric_value, &(None, None, DebugValue::Counter(1)));
+        }
+
+        #[test]
+        fn test_serde() {
+            let scanner_features = ScannerFeatures {
+                should_keywords_match_event_paths: true,
+            };
+            assert_tokens(
+                &scanner_features,
+                &[
+                    Token::Struct {
+                        name: "ScannerFeatures",
+                        len: 1,
+                    },
+                    Token::String("should_keywords_match_event_paths"),
+                    Token::Bool(true),
+                    Token::StructEnd,
+                ],
+            )
         }
     }
 }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -477,7 +477,7 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
         &'b mut self,
         path: &crate::Path<'a>,
         content: &str,
-        rule_visitor: crate::scoped_ruleset::RuleIndexVisitor,
+        mut rule_visitor: crate::scoped_ruleset::RuleIndexVisitor,
         exclusion_check: ExclusionCheck<'b>,
     ) -> bool {
         // matches for a single path
@@ -1014,6 +1014,7 @@ mod test {
         assert_eq!(matches.len(), 0);
     }
 
+    #[test]
     fn test_included_keywords_path_with_uncaught_separator_symbol() {
         let scanner = build_test_scanner(true);
 
@@ -1026,6 +1027,7 @@ mod test {
         assert_eq!(matches.len(), 0);
     }
 
+    #[test]
     fn test_included_keywords_path_deep() {
         let scanner = build_test_scanner(true);
 
@@ -1778,7 +1780,7 @@ mod test {
         use crate::scanner::ScannerBuilder;
         use crate::{
             simple_event::SimpleEvent, Path, PathSegment, ProximityKeywordsConfig, RegexRuleConfig,
-            RuleMatch, ScannerFeatures, Scope,
+            ScannerFeatures, Scope,
         };
         use metrics::{Key, Label};
         use metrics_util::debugging::DebugValue;

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -16,7 +16,6 @@ use self::cache_pool::{CachePool, CachePoolBuilder, CachePoolGuard};
 use self::metrics::Metrics;
 use ahash::AHashSet;
 use regex_automata::{Input, Match};
-use serde::{Deserialize, Serialize};
 
 pub(crate) mod cache_pool;
 pub mod error;
@@ -460,7 +459,8 @@ impl<C: RuleConfigTrait> ScannerBuilder<'_, C> {
                 .iter()
                 .map(|rule| rule.get_scope().clone())
                 .collect::<Vec<_>>(),
-        );
+        )
+        .with_implicit_index_wildcards(self.scanner_features.add_implicit_index_wildcards);
 
         Ok(Scanner {
             rules: compiled_rules,

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -196,9 +196,10 @@ impl RuleConfigTrait for RegexRuleConfig {
     }
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq)]
-pub struct ScannerFeatures {
+#[derive(Default, Debug, PartialEq)]
+struct ScannerFeatures {
     pub should_keywords_match_event_paths: bool,
+    pub add_implicit_index_wildcards: bool,
 }
 
 pub struct Scanner {
@@ -209,8 +210,8 @@ pub struct Scanner {
 }
 
 impl Scanner {
-    pub fn builder<C: RuleConfigTrait + Default>() -> ScannerBuilder<'static, C> {
-        ScannerBuilder::default()
+    pub fn builder<C: RuleConfigTrait>(rules: &[C]) -> ScannerBuilder<C> {
+        ScannerBuilder::new(rules)
     }
 
     pub fn scan<E: Event>(&self, event: &mut E) -> Vec<RuleMatch> {
@@ -416,7 +417,7 @@ pub struct ScannerBuilder<'a, C: RuleConfigTrait> {
 }
 
 impl<C: RuleConfigTrait> ScannerBuilder<'_, C> {
-    pub fn new(rules: &'_ [C]) -> ScannerBuilder<'_, C> {
+    pub fn new(rules: &[C]) -> ScannerBuilder<C> {
         ScannerBuilder {
             rules,
             labels: Labels::empty(),
@@ -429,8 +430,13 @@ impl<C: RuleConfigTrait> ScannerBuilder<'_, C> {
         self
     }
 
-    pub fn scanner_features(mut self, features: ScannerFeatures) -> Self {
-        self.scanner_features = features;
+    pub fn with_keywords_should_match_event_paths(mut self, value: bool) -> Self {
+        self.scanner_features.should_keywords_match_event_paths = value;
+        self
+    }
+
+    pub fn with_implicit_wildcard_indexes_for_scopes(mut self, value: bool) -> Self {
+        self.scanner_features.add_implicit_index_wildcards = value;
         self
     }
 
@@ -643,9 +649,7 @@ mod test {
     #[test]
     fn dumb_custom_rule() {
         let scanner = ScannerBuilder::new(&[DumbRuleConfig {}])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
 
@@ -669,9 +673,7 @@ mod test {
                     .build(),
             ) as Box<dyn RuleConfigTrait>,
         ])
-        .scanner_features(ScannerFeatures {
-            should_keywords_match_event_paths: true,
-        })
+        .with_keywords_should_match_event_paths(true)
         .build()
         .unwrap();
 
@@ -693,9 +695,7 @@ mod test {
                 replacement: "[REDACTED]".to_string(),
             })
             .build()])
-        .scanner_features(ScannerFeatures {
-            should_keywords_match_event_paths: true,
-        })
+        .with_keywords_should_match_event_paths(true)
         .build()
         .unwrap();
 
@@ -715,9 +715,7 @@ mod test {
             })
             .build()])
         .labels(Labels::new(&[("key".to_string(), "value".to_string())]))
-        .scanner_features(ScannerFeatures {
-            should_keywords_match_event_paths: true,
-        })
+        .with_keywords_should_match_event_paths(true)
         .build()
         .unwrap();
 
@@ -733,9 +731,7 @@ mod test {
     fn should_fail_on_compilation_error() {
         let scanner_result =
             ScannerBuilder::new(&[RegexRuleConfig::builder("\\u".to_owned()).build()])
-                .scanner_features(ScannerFeatures {
-                    should_keywords_match_event_paths: true,
-                })
+                .with_keywords_should_match_event_paths(true)
                 .build();
         assert!(scanner_result.is_err());
         assert_eq!(
@@ -752,9 +748,7 @@ mod test {
                 character_count: 0,
             })
             .build()])
-        .scanner_features(ScannerFeatures {
-            should_keywords_match_event_paths: true,
-        })
+        .with_keywords_should_match_event_paths(true)
         .build();
 
         assert!(scanner_result.is_err());
@@ -773,9 +767,7 @@ mod test {
                 replacement: "[REDACTED]".to_string(),
             })
             .build()])
-        .scanner_features(ScannerFeatures {
-            should_keywords_match_event_paths: true,
-        })
+        .with_keywords_should_match_event_paths(true)
         .build()
         .unwrap();
 
@@ -793,9 +785,7 @@ mod test {
             RegexRuleConfig::builder("a".to_owned()).build(),
             RegexRuleConfig::builder("b".to_owned()).build(),
         ])
-        .scanner_features(ScannerFeatures {
-            should_keywords_match_event_paths: true,
-        })
+        .with_keywords_should_match_event_paths(true)
         .build()
         .unwrap();
 
@@ -867,9 +857,7 @@ mod test {
 
         for (rule_config, input, expected_indices) in test_cases {
             let scanner = ScannerBuilder::new(rule_config.leak())
-                .scanner_features(ScannerFeatures {
-                    should_keywords_match_event_paths: true,
-                })
+                .with_keywords_should_match_event_paths(true)
                 .build()
                 .unwrap();
             let mut input = input.to_string();
@@ -903,9 +891,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[redact_test_rule])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "hello world".to_string();
@@ -936,10 +922,8 @@ mod test {
             })
             .build();
 
-        return ScannerBuilder::new(&[redact_test_rule])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths,
-            })
+        return Scanner::builder(&[redact_test_rule])
+            .with_keywords_should_match_event_paths(should_keywords_match_event_paths)
             .build()
             .unwrap();
     }
@@ -1072,9 +1056,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[redact_test_rule])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "hello world".to_string();
@@ -1101,9 +1083,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "4556997807150071 4111 1111 1111 1111".to_string();
@@ -1112,9 +1092,7 @@ mod test {
         assert_eq!(content, "[credit card] [credit card]");
 
         let scanner = ScannerBuilder::new(&[rule_with_checksum])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "4556997807150071 4111 1111 1111 1111".to_string();
@@ -1137,9 +1115,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "513231200012121657 513231200012121651".to_string();
@@ -1148,9 +1124,7 @@ mod test {
         assert_eq!(content, "[IDCARD] [IDCARD]");
 
         let scanner = ScannerBuilder::new(&[rule_with_checksum])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "513231200012121657 513231200012121651".to_string();
@@ -1173,9 +1147,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content =
@@ -1186,9 +1158,7 @@ mod test {
         assert_eq!(content, "[GITHUB] [GITHUB]");
 
         let scanner = ScannerBuilder::new(&[rule_with_checksum])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content =
@@ -1211,9 +1181,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule.clone(), rule])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "hello world".to_string();
@@ -1234,9 +1202,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule.clone(), rule])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "hello world".to_string();
@@ -1303,9 +1269,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0, rule_1])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "hello world".to_string();
@@ -1367,9 +1331,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0, rule_1])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "abcdef".to_string();
@@ -1405,9 +1367,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0, rule_1])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "abcdef".to_string();
@@ -1443,9 +1403,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0, rule_1])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "abcdef".to_string();
@@ -1481,9 +1439,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0, rule_1])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
         let mut content = "abcdef".to_string();
@@ -1520,9 +1476,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
 
@@ -1569,9 +1523,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
 
@@ -1653,9 +1605,7 @@ mod test {
         let rule_1 = RegexRuleConfig::builder("abc".to_owned()).build();
 
         let scanner = ScannerBuilder::new(&[rule_0, rule_1])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
 
@@ -1675,9 +1625,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
 
@@ -1698,9 +1646,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
 
@@ -1724,9 +1670,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
 
@@ -1760,9 +1704,7 @@ mod test {
             .build();
 
         let scanner = ScannerBuilder::new(&[rule_0])
-            .scanner_features(ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            })
+            .with_keywords_should_match_event_paths(true)
             .build()
             .unwrap();
 
@@ -1777,10 +1719,10 @@ mod test {
 
     mod metrics_test {
         use crate::match_action::MatchAction;
-        use crate::scanner::ScannerBuilder;
+        use crate::scanner::{ScannerBuilder, ScannerFeatures};
         use crate::{
             simple_event::SimpleEvent, Path, PathSegment, ProximityKeywordsConfig, RegexRuleConfig,
-            ScannerFeatures, Scope,
+            Scope,
         };
         use metrics::{Key, Label};
         use metrics_util::debugging::DebugValue;
@@ -1804,9 +1746,7 @@ mod test {
                     .build();
 
                 let scanner = ScannerBuilder::new(&[rule_0])
-                    .scanner_features(ScannerFeatures {
-                        should_keywords_match_event_paths: true,
-                    })
+                    .with_keywords_should_match_event_paths(true)
                     .build()
                     .unwrap();
                 let mut content = SimpleEvent::Map(BTreeMap::from([
@@ -1849,9 +1789,7 @@ mod test {
                     .build();
 
                 let scanner = ScannerBuilder::new(&[redact_test_rule])
-                    .scanner_features(ScannerFeatures {
-                        should_keywords_match_event_paths: true,
-                    })
+                    .with_keywords_should_match_event_paths(true)
                     .build()
                     .unwrap();
                 let mut content = SimpleEvent::Map(BTreeMap::from([(
@@ -1895,9 +1833,7 @@ mod test {
                     .build();
 
                 let scanner = ScannerBuilder::new(&[redact_test_rule])
-                    .scanner_features(ScannerFeatures {
-                        should_keywords_match_event_paths: true,
-                    })
+                    .with_keywords_should_match_event_paths(true)
                     .build()
                     .unwrap();
                 let mut content = SimpleEvent::Map(BTreeMap::from([(
@@ -1921,25 +1857,6 @@ mod test {
                 .expect("metric not found");
 
             assert_eq!(metric_value, &(None, None, DebugValue::Counter(1)));
-        }
-
-        #[test]
-        fn test_serde() {
-            let scanner_features = ScannerFeatures {
-                should_keywords_match_event_paths: true,
-            };
-            assert_tokens(
-                &scanner_features,
-                &[
-                    Token::Struct {
-                        name: "ScannerFeatures",
-                        len: 1,
-                    },
-                    Token::String("should_keywords_match_event_paths"),
-                    Token::Bool(true),
-                    Token::StructEnd,
-                ],
-            )
         }
     }
 }

--- a/sds/src/scoped_ruleset/bool_set.rs
+++ b/sds/src/scoped_ruleset/bool_set.rs
@@ -1,0 +1,26 @@
+/// This allows keeping track of multiple (contiguous) boolean flags,
+/// and efficiently resetting all of them.
+
+pub struct BoolSet {
+    rule_used: Vec<bool>,
+}
+
+impl BoolSet {
+    pub fn new(num_rules: usize) -> Self {
+        Self {
+            rule_used: vec![false; num_rules],
+        }
+    }
+
+    pub fn get_and_set(&mut self, index: usize) -> bool {
+        let result = self.rule_used[index];
+        self.rule_used[index] = true;
+        result
+    }
+
+    pub fn reset(&mut self) {
+        // Note: An implementation with "generations" was tried to prevent
+        // having to reset all flags, but surprisingly it was slightly slower in benchmarks.
+        self.rule_used.fill(false);
+    }
+}

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -159,14 +159,6 @@ where
         self.active_tree_count
             .push(self.tree_nodes.len() - tree_nodes_len);
 
-        // if self.path.len() + 1 == self.tree_nodes.len() {
-        //     let last_tree = *self.tree_nodes.last().unwrap();
-        //     if let Some(child) = last_tree.children.get(&segment) {
-        //         // All of the rules from the `child` node should be applied to the current path (and anything below it)
-        //         self.tree_nodes.push(child);
-        //     }
-        // }
-        //
         self.path.segments.push(segment);
     }
 
@@ -217,7 +209,6 @@ impl<'a> RuleIndexVisitor<'a> {
             for change in &include_node.rule_tree.rule_changes {
                 match change {
                     RuleChange::Add(rule_id) => {
-                        // if self.
                         if !self.used_rule_set.get_and_set(*rule_id) {
                             (visit)(*rule_id);
                         }

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -161,15 +161,13 @@ where
                 }
             }
 
-            if self.add_implicit_index_wildcards {
-                if segment.is_index() {
-                    // Optionally skip the index (it acts as a wildcard) by
-                    // pushing the same tree back onto the stack.
-                    self.tree_nodes.push(ActiveRuleTree {
-                        rule_tree: self.tree_nodes[tree_index].rule_tree,
-                        index_wildcard_match: true,
-                    });
-                }
+            if self.add_implicit_index_wildcards && segment.is_index() {
+                // Optionally skip the index (it acts as a wildcard) by
+                // pushing the same tree back onto the stack.
+                self.tree_nodes.push(ActiveRuleTree {
+                    rule_tree: self.tree_nodes[tree_index].rule_tree,
+                    index_wildcard_match: true,
+                });
             }
         }
         // The new number of active trees is the number of new trees pushed

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -46,8 +46,8 @@ impl ScopedRuleSet {
         }
     }
 
-    pub fn with_implicit_index_wildcards(mut self) -> Self {
-        self.add_implicit_index_wildcards = true;
+    pub fn with_implicit_index_wildcards(mut self, value: bool) -> Self {
+        self.add_implicit_index_wildcards = value;
         self
     }
 

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -227,13 +227,13 @@ impl<'a> RuleIndexVisitor<'a> {
             }
             for change in &include_node.rule_tree.rule_changes {
                 match change {
-                    RuleChange::Add(rule_id) => {
+                    RuleChange::Add(rule_index) => {
                         if let Some(used_rule_set) = &mut self.used_rule_set {
-                            if !used_rule_set.get_and_set(*rule_id) {
-                                (visit)(*rule_id);
+                            if !used_rule_set.get_and_set(*rule_index) {
+                                (visit)(*rule_index);
                             }
                         } else {
-                            (visit)(*rule_id);
+                            (visit)(*rule_index);
                         }
                     }
                     RuleChange::Remove(_) => { /* Nothing to do here */ }
@@ -964,7 +964,7 @@ mod test {
             "a".into(),
             "b".into(),
         ])])])
-        .with_implicit_index_wildcards();
+        .with_implicit_index_wildcards(true);
 
         let mut event = SimpleEvent::Map(
             [(
@@ -1004,7 +1004,7 @@ mod test {
             vec![ab_path.clone()],
             vec![ab_path],
         )])
-        .with_implicit_index_wildcards();
+        .with_implicit_index_wildcards(true);
 
         let mut event = SimpleEvent::Map(
             [(
@@ -1041,7 +1041,7 @@ mod test {
         let a_1_d_path = Path::from(vec!["a".into(), 1.into(), "d".into()]);
 
         let ruleset = ScopedRuleSet::new(&[Scope::include(vec![a_0_c_path, ab_path, a_1_d_path])])
-            .with_implicit_index_wildcards();
+            .with_implicit_index_wildcards(true);
 
         let mut event = SimpleEvent::Map(
             [(
@@ -1131,7 +1131,7 @@ mod test {
         let a_0_b_path = Path::from(vec!["a".into(), 0.into(), "b".into()]);
 
         let ruleset = ScopedRuleSet::new(&[Scope::include(vec![a_b_path, a_0_b_path])])
-            .with_implicit_index_wildcards();
+            .with_implicit_index_wildcards(true);
 
         let mut event = SimpleEvent::Map(
             [(
@@ -1165,8 +1165,8 @@ mod test {
         // A wildcard index can skip multiple levels of indexing, not just 1
 
         let a_b_path = Path::from(vec!["a".into(), "b".into()]);
-        let ruleset =
-            ScopedRuleSet::new(&[Scope::include(vec![a_b_path])]).with_implicit_index_wildcards();
+        let ruleset = ScopedRuleSet::new(&[Scope::include(vec![a_b_path])])
+            .with_implicit_index_wildcards(true);
 
         let mut event = SimpleEvent::Map(
             [(

--- a/sds/tools/fuzz/src/main.rs
+++ b/sds/tools/fuzz/src/main.rs
@@ -90,9 +90,7 @@ fn run_fuzz(pattern: &str, input: &str, mut rng: StdRng) {
     let scanner_result = ScannerBuilder::new(&[RegexRuleConfig::builder(pattern.to_string())
         .match_action(match_action)
         .build()])
-    .scanner_features(ScannerFeatures {
-        should_keywords_match_event_paths: true,
-    })
+    .with_keywords_should_match_event_paths(true)
     .build();
 
     if let Ok(scanner) = scanner_result {

--- a/sds/tools/fuzz/src/main.rs
+++ b/sds/tools/fuzz/src/main.rs
@@ -2,9 +2,7 @@
 #![allow(warnings)]
 
 use afl::fuzz;
-use dd_sds::{
-    MatchAction, PartialRedactDirection, RegexRuleConfig, ScannerBuilder, ScannerFeatures, Scope,
-};
+use dd_sds::{MatchAction, PartialRedactDirection, RegexRuleConfig, ScannerBuilder, Scope};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 #[cfg(not(feature = "manual_test"))]


### PR DESCRIPTION
[Jira ticket](https://datadoghq.atlassian.net/browse/SDS-217)

All scope paths now have implicit optional index wildcards before each field. For example, a scope with a path of `a.b`, would act as if it is something like `[*]?a.[*]?b` (using an imaginary regex-like syntax).

That means that `a.b` will match an event like this

```json
{
   "a": [
      {
         "b": "This string is included, even though it's in an array"
      }
   ]
}
```


## Implementation Details

Previously, the `ScopedRuleset` would have a single active node in the tree it would follow along with the event to determine which rules are active. Now, there are potentially multiple activate nodes due to the implicit wildcard being optional. Because of this, rules can potentially be duplicated, so there is now an additional check to ensure rules are never duplicated.

There is unfortunately a significant performance impact from this change according to our benchmarks. Overall a `visit_string_rule_combinations` call will take about twice as long as before. Most of the performance regression is from the rule deduplication. I've already optimized this function quite a bit, and I'm not aware of any easy ways to improve this further.

`visit_string_rule_combinations` is still a relatively small cost of overall scanning, so there should only be a small impact on the overall performance.

I did try a different approach here where a single tree is compiled with all the possibilities to prevent having multiple active nodes while scanning, and prevent having to de-duplicate rules. That would likely have better runtime performance, but it's more complex, and most importantly, the memory usage increased exponentially with the length of paths (number of segments). It might be useful to try this approach again in the future if performance is a large concern here.