### PR TITLE
Add redactionType to sds-go bindings after scanned event

### DIFF
--- a/sds-go/go/rule.go
+++ b/sds-go/go/rule.go
@@ -5,12 +5,19 @@ import (
 )
 
 type MatchActionType string
+type ReplacementType string
 
 const (
 	MatchActionNone          = MatchActionType("None")
 	MatchActionRedact        = MatchActionType("Redact")
 	MatchActionHash          = MatchActionType("Hash")
 	MatchActionPartialRedact = MatchActionType("PartialRedact")
+
+	ReplacementTypeNone         = ReplacementType("none")
+	ReplacementTypePlaceholder  = ReplacementType("placeholder")
+	ReplacementTypeHash         = ReplacementType("hash")
+	ReplacementTypePartialStart = ReplacementType("partial_beginning")
+	ReplacementTypePartialEnd   = ReplacementType("partial_end")
 )
 
 type SecondaryValidator string
@@ -67,10 +74,9 @@ type ProximityKeywordsConfig struct {
 
 // RuleMatch stores the matches reported by the core library.
 type RuleMatch struct {
-	RuleIdx uint32
-	Path    string
-	// TODO(https://datadoghq.atlassian.net/browse/SDS-301): implement replacement type
-	ReplacementType   MatchAction
+	RuleIdx           uint32
+	Path              string
+	ReplacementType   ReplacementType
 	StartIndex        uint32
 	EndIndexExclusive uint32
 	ShiftOffset       int32

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -265,6 +265,7 @@ func TestScanStringEvent(t *testing.T) {
 			str:     "this is a hello event",
 			rules: []RuleMatch{{
 				RuleIdx:           0,
+				ReplacementType:   ReplacementTypeNone,
 				StartIndex:        10,
 				EndIndexExclusive: 15,
 				ShiftOffset:       0,
@@ -276,16 +277,19 @@ func TestScanStringEvent(t *testing.T) {
 			str:     "this is a hello event, even a hello world!",
 			rules: []RuleMatch{{
 				RuleIdx:           0,
+				ReplacementType:   ReplacementTypeNone,
 				StartIndex:        10,
 				EndIndexExclusive: 15,
 				ShiftOffset:       0,
 			}, {
 				RuleIdx:           0,
+				ReplacementType:   ReplacementTypeNone,
 				StartIndex:        30,
 				EndIndexExclusive: 35,
 				ShiftOffset:       0,
 			}, {
 				RuleIdx:           1,
+				ReplacementType:   ReplacementTypeNone,
 				StartIndex:        36,
 				EndIndexExclusive: 41,
 				ShiftOffset:       0,
@@ -297,11 +301,13 @@ func TestScanStringEvent(t *testing.T) {
 			str:     "this is a hello event, and containing a [REDACTED] here!",
 			rules: []RuleMatch{{
 				RuleIdx:           0,
+				ReplacementType:   ReplacementTypeNone,
 				StartIndex:        10,
 				EndIndexExclusive: 10 + uint32(len("hello")),
 				ShiftOffset:       0,
 			}, {
 				RuleIdx:           2,
+				ReplacementType:   ReplacementTypePlaceholder,
 				StartIndex:        40,
 				EndIndexExclusive: 40 + uint32(len("[REDACTED]")),
 				ShiftOffset:       4,

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -237,6 +237,35 @@ func TestScanMapEvent(t *testing.T) {
 	runTestMap(t, scanner, testData)
 }
 
+func TestScanStringWithHash(t *testing.T) {
+	var extraConfig ExtraConfig
+
+	rules := []Rule{
+		NewHashRule("rule_secret", "se..et", extraConfig),
+	}
+
+	scanner, err := CreateScanner(rules)
+	if err != nil {
+		t.Fatal("failed to create the scanner:", err.Error())
+	}
+	defer scanner.Delete()
+	event := "this is a hello event, and containing a secret here!"
+	result, err := scanner.Scan([]byte(event))
+	if err != nil {
+		t.Fatal("failed to scan the event:", err.Error())
+	}
+	if !result.Mutated {
+		t.Fatal("Failed to scan the event: not mutated")
+	}
+	if len(result.scanResult.Matches) != 1 {
+		t.Fatal("Failed to scan the event: not the good amount of rules returned")
+	}
+	if result.scanResult.Matches[0].ReplacementType != ReplacementTypeHash {
+		t.Fatal("Failed to scan the event: not hashed")
+	}
+
+}
+
 func TestScanStringEvent(t *testing.T) {
 	var extraConfig ExtraConfig
 


### PR DESCRIPTION
[PR](https://datadoghq.atlassian.net/browse/SDS-301)
Parse redactionType coming from the rust scan and exposes it in sds-go binding