### PR TITLE
Fix farmhash override

### DIFF
--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -17,7 +17,8 @@ bench = []
 
 [dependencies]
 ahash = "0.8.7"
-farmhash = "1.1.5"
+# Overriding with fix repo due to: https://github.com/seiflotfy/rust-farmhash/pull/16
+farmhash = { git = "https://github.com/fuchsnj/rust-farmhash", rev = "82d80b689d65fbd378b13deff10cdd07794df64e" }
 nom = "7.1.3"
 regex = "1.9.5"
 regex-automata = "0.4.4"
@@ -49,6 +50,4 @@ name = "bench"
 harness = false
 
 
-[patch.crates-io]
-# https://github.com/seiflotfy/rust-farmhash/pull/16
-farmhash = { git = "https://github.com/fuchsnj/rust-farmhash", rev="82d80b689d65fbd378b13deff10cdd07794df64e"}
+


### PR DESCRIPTION
`[patch]` sections are ignored when used as a dependency, so the fix was only used locally for tests, and didn't actually fix the issue.

Previous hash mismatches that were fixed were likely due to different underlying data that was hashed (other mismatch fixes), and not the hash function itself.