### PR TITLE
✨ Improve performance of `sanitize_path` and `standardize_path_chars`

### DIFF
--- a/sds/benches/bench.rs
+++ b/sds/benches/bench.rs
@@ -141,8 +141,8 @@ mod benchmarks {
                     excluded_keywords: vec![],
                 })
                 .build()])
-                .build()
-                .unwrap();
+            .build()
+            .unwrap();
 
         let mut message = "a".repeat(1_000_000);
 
@@ -162,16 +162,10 @@ mod benchmarks {
             for j in 0..100 {
                 let is_secret = j % 6 == 0;
                 let key = if is_secret { "secret" } else { "another-key" };
-                nested_event.insert(
-                    key.to_string(),
-                    SimpleEvent::String(format!("value-{}", i)),
-                );
+                nested_event.insert(key.to_string(), SimpleEvent::String(format!("value-{}", i)));
             }
 
-            event_map.insert(
-                format!("key-{}", i),
-                SimpleEvent::Map(nested_event),
-            );
+            event_map.insert(format!("key-{}", i), SimpleEvent::Map(nested_event));
         }
 
         for i in 0..100 {
@@ -190,28 +184,21 @@ mod benchmarks {
                 );
             }
 
-            event_map.insert(
-                format!("ssn-{}", i),
-                SimpleEvent::Map(nested_event),
-            );
+            event_map.insert(format!("ssn-{}", i), SimpleEvent::Map(nested_event));
         }
 
         let mut event = SimpleEvent::Map(event_map);
 
-        let scanner =
-            Scanner::builder(&[RegexRuleConfig::builder("value".to_string())
-                .proximity_keywords(ProximityKeywordsConfig {
-                    look_ahead_character_count: 30,
-                    included_keywords: vec![
-                        "secret".to_string(),
-                        "ssn".to_string(),
-                    ],
-                    excluded_keywords: vec![],
-                })
-                .build()])
-                .with_keywords_should_match_event_paths(false)
-                .build()
-                .unwrap();
+        let scanner = Scanner::builder(&[RegexRuleConfig::builder("value".to_string())
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["secret".to_string(), "ssn".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build()])
+        .with_keywords_should_match_event_paths(false)
+        .build()
+        .unwrap();
 
         c.bench_function("included_keywords_on_path_off", |b| {
             b.iter(|| {
@@ -220,20 +207,16 @@ mod benchmarks {
             });
         });
 
-        let scanner =
-            Scanner::builder(&[RegexRuleConfig::builder("value".to_string())
-                .proximity_keywords(ProximityKeywordsConfig {
-                    look_ahead_character_count: 30,
-                    included_keywords: vec![
-                        "secret".to_string(),
-                        "ssn".to_string(),
-                    ],
-                    excluded_keywords: vec![],
-                })
-                .build()])
-                .with_keywords_should_match_event_paths(true)
-                .build()
-                .unwrap();
+        let scanner = Scanner::builder(&[RegexRuleConfig::builder("value".to_string())
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["secret".to_string(), "ssn".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build()])
+        .with_keywords_should_match_event_paths(true)
+        .build()
+        .unwrap();
 
         c.bench_function("included_keywords_on_path_on", |b| {
             b.iter(|| {

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -1,7 +1,9 @@
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 
-use crate::proximity_keywords::{should_bypass_standardize_path, standardize_path_chars, UNIFIED_LINK_CHAR};
+use crate::proximity_keywords::{
+    should_bypass_standardize_path, standardize_path_chars, UNIFIED_LINK_CHAR,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -179,7 +181,7 @@ mod test {
                 "CHICKEN".into(),
                 2.into(),
             ])
-                .sanitize(),
+            .sanitize(),
             "hello.world.of.chicken"
         );
 

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -52,7 +52,7 @@ impl<'a> Path<'a> {
         true
     }
 
-    fn size(&self) -> usize {
+    fn size_segments_only(&self) -> usize {
         self.segments
             .iter()
             .map(|segment| {
@@ -65,7 +65,8 @@ impl<'a> Path<'a> {
     }
 
     pub fn sanitize(&self) -> String {
-        let mut sanitized_path = String::with_capacity(self.size() * 2);
+        let size_segments = self.size_segments_only();
+        let mut sanitized_path = String::with_capacity(size_segments + size_segments / 2);
         self.segments.iter().enumerate().for_each(|(i, segment)| {
             if let PathSegment::Field(field) = segment {
                 if i != 0 {
@@ -173,7 +174,7 @@ mod test {
                 "CHICKEN".into(),
                 2.into(),
             ])
-            .sanitize(),
+                .sanitize(),
             "hello.world.of.chicken"
         );
 
@@ -186,11 +187,11 @@ mod test {
     #[test]
     fn test_size() {
         assert_eq!(
-            Path::from(vec!["hello".into(), 0.into(), "world".into()]).size(),
+            Path::from(vec!["hello".into(), 0.into(), "world".into()]).size_segments_only(),
             10
         );
         assert_eq!(
-            Path::from(vec!["".into(), 0.into(), "path✅".into()]).size(),
+            Path::from(vec!["".into(), 0.into(), "path✅".into()]).size_segments_only(),
             7
         );
     }

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 
-use crate::proximity_keywords::{standardize_path_chars, UNIFIED_LINK_CHAR};
+use crate::proximity_keywords::{should_bypass_standardize_path, standardize_path_chars, UNIFIED_LINK_CHAR};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -72,9 +72,14 @@ impl<'a> Path<'a> {
                 if i != 0 {
                     sanitized_path.push(UNIFIED_LINK_CHAR);
                 }
-                standardize_path_chars(field, |c| {
-                    sanitized_path.push(c.to_ascii_lowercase());
-                });
+
+                if should_bypass_standardize_path(field) {
+                    sanitized_path.push_str(field)
+                } else {
+                    standardize_path_chars(field, |c| {
+                        sanitized_path.push(c.to_ascii_lowercase());
+                    });
+                }
             }
         });
 

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -59,7 +59,7 @@ impl<'a> Path<'a> {
                 if let PathSegment::Field(field) = segment {
                     return field.len();
                 }
-                return 0;
+                0
             })
             .sum()
     }

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -52,8 +52,17 @@ impl<'a> Path<'a> {
         true
     }
 
+    fn size(&self) -> usize {
+        self.segments.iter().map(|segment| {
+            if let PathSegment::Field(field) = segment {
+                return field.len();
+            }
+            return 0;
+        }).sum()
+    }
+
     pub fn sanitize(&self) -> String {
-        let mut sanitized_path = "".to_string();
+        let mut sanitized_path = String::with_capacity(self.size() * 2);
         self.segments.iter().enumerate().for_each(|(i, segment)| {
             if let PathSegment::Field(field) = segment {
                 if i != 0 {
@@ -161,13 +170,23 @@ mod test {
                 "CHICKEN".into(),
                 2.into(),
             ])
-            .sanitize(),
+                .sanitize(),
             "hello.world.of.chicken"
         );
 
         assert_eq!(
             Path::from(vec!["hello_world-of-".into(), "/chickens_/".into()]).sanitize(),
             "hello.world.of-./chickens./"
+        );
+    }
+
+    #[test]
+    fn test_size() {
+        assert_eq!(
+            Path::from(vec!["hello".into(), 0.into(), "world".into()]).size(), 10
+        );
+        assert_eq!(
+            Path::from(vec!["".into(), 0.into(), "path✅".into()]).size(), 7
         );
     }
 }

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -76,7 +76,7 @@ impl<'a> Path<'a> {
                 }
 
                 if should_bypass_standardize_path(field) {
-                    sanitized_path.push_str(field)
+                    sanitized_path.push_str(field.to_ascii_lowercase().as_str())
                 } else {
                     standardize_path_chars(field, |c| {
                         sanitized_path.push(c.to_ascii_lowercase());

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -53,12 +53,15 @@ impl<'a> Path<'a> {
     }
 
     fn size(&self) -> usize {
-        self.segments.iter().map(|segment| {
-            if let PathSegment::Field(field) = segment {
-                return field.len();
-            }
-            return 0;
-        }).sum()
+        self.segments
+            .iter()
+            .map(|segment| {
+                if let PathSegment::Field(field) = segment {
+                    return field.len();
+                }
+                return 0;
+            })
+            .sum()
     }
 
     pub fn sanitize(&self) -> String {
@@ -170,7 +173,7 @@ mod test {
                 "CHICKEN".into(),
                 2.into(),
             ])
-                .sanitize(),
+            .sanitize(),
             "hello.world.of.chicken"
         );
 
@@ -183,10 +186,12 @@ mod test {
     #[test]
     fn test_size() {
         assert_eq!(
-            Path::from(vec!["hello".into(), 0.into(), "world".into()]).size(), 10
+            Path::from(vec!["hello".into(), 0.into(), "world".into()]).size(),
+            10
         );
         assert_eq!(
-            Path::from(vec!["".into(), 0.into(), "path✅".into()]).size(), 7
+            Path::from(vec!["".into(), 0.into(), "path✅".into()]).size(),
+            7
         );
     }
 }

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -277,7 +277,7 @@ fn get_char_type(c: &char) -> CharType {
     }
 }
 
-fn should_bypass_standardize_path(characters: &str) -> bool {
+pub fn should_bypass_standardize_path(characters: &str) -> bool {
     let mut all_lower = true;
     let mut all_upper = true;
     for char in characters.chars() {
@@ -307,16 +307,6 @@ where
 {
     let kw_length = characters.len();
     if kw_length == 0 {
-        return;
-    }
-
-    let mut char_iterator = characters.chars();
-    if char_iterator.all(|c| c.is_ascii_lowercase())
-        || char_iterator.all(|c| c.is_ascii_uppercase())
-    {
-        for c in characters.chars() {
-            push_character(&c)
-        }
         return;
     }
 

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -426,7 +426,7 @@ pub enum ProximityKeywordsValidationError {
     KeywordTooLong(usize),
 
     #[error(
-    "Look ahead character count should be bigger than 0 and cannot be longer than {}",
+        "Look ahead character count should be bigger than 0 and cannot be longer than {}",
         MAX_LOOK_AHEAD_CHARACTER_COUNT
     )]
     InvalidLookAheadCharacterCount,
@@ -880,7 +880,7 @@ mod test {
             ],
             vec![],
         )
-            .unwrap();
+        .unwrap();
         let included_keywords = included_keywords.unwrap();
 
         let should_match = vec![

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -296,7 +296,7 @@ pub fn should_bypass_standardize_path(characters: &str) -> bool {
     }
 
     // The characters contain only uppercase characters or only lowercase characters by now
-    return true;
+    true
 }
 
 /// Function that standardizes a list of characters, by pushing characters one by one in a standard way.
@@ -426,7 +426,7 @@ pub enum ProximityKeywordsValidationError {
     KeywordTooLong(usize),
 
     #[error(
-        "Look ahead character count should be bigger than 0 and cannot be longer than {}",
+    "Look ahead character count should be bigger than 0 and cannot be longer than {}",
         MAX_LOOK_AHEAD_CHARACTER_COUNT
     )]
     InvalidLookAheadCharacterCount,
@@ -880,7 +880,7 @@ mod test {
             ],
             vec![],
         )
-        .unwrap();
+            .unwrap();
         let included_keywords = included_keywords.unwrap();
 
         let should_match = vec![

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -279,19 +279,27 @@ fn get_char_type(c: &char) -> CharType {
 
 /// Function that standardizes a list of characters, by pushing characters one by one in a standard way.
 /// Takes a closure that will be called when a character is to be pushed
-pub fn standardize_path_chars<F>(chars: &str, mut push_character: F)
+pub fn standardize_path_chars<F>(characters: &str, mut push_character: F)
 where
     F: FnMut(&char),
 {
-    let kw_length = chars.len();
-
-    if let Some(c) = chars.chars().next() {
-        push_character(&c);
-    } else {
+    let kw_length = characters.len();
+    if kw_length == 0 {
         return;
     }
 
-    for (i, chars) in chars.as_bytes().windows(2).enumerate() {
+    let mut char_iterator = characters.chars();
+    if char_iterator.all(|c| c.is_ascii_lowercase()) || char_iterator.all(|c| c.is_ascii_uppercase()) {
+        for c in characters.chars() {
+            push_character(&c)
+        }
+        return;
+    }
+
+    let character_bytes = characters.as_bytes();
+    push_character(&(character_bytes[0] as char));
+
+    for (i, chars) in character_bytes.windows(2).enumerate() {
         let current = &(chars[1] as char);
         let prev_char = get_char_type(&(chars[0] as char));
         let current_char = get_char_type(current);
@@ -404,7 +412,7 @@ pub enum ProximityKeywordsValidationError {
     KeywordTooLong(usize),
 
     #[error(
-        "Look ahead character count should be bigger than 0 and cannot be longer than {}",
+    "Look ahead character count should be bigger than 0 and cannot be longer than {}",
         MAX_LOOK_AHEAD_CHARACTER_COUNT
     )]
     InvalidLookAheadCharacterCount,
@@ -849,7 +857,7 @@ mod test {
             ],
             vec![],
         )
-        .unwrap();
+            .unwrap();
         let included_keywords = included_keywords.unwrap();
 
         let should_match = vec![

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -289,7 +289,9 @@ where
     }
 
     let mut char_iterator = characters.chars();
-    if char_iterator.all(|c| c.is_ascii_lowercase()) || char_iterator.all(|c| c.is_ascii_uppercase()) {
+    if char_iterator.all(|c| c.is_ascii_lowercase())
+        || char_iterator.all(|c| c.is_ascii_uppercase())
+    {
         for c in characters.chars() {
             push_character(&c)
         }
@@ -412,7 +414,7 @@ pub enum ProximityKeywordsValidationError {
     KeywordTooLong(usize),
 
     #[error(
-    "Look ahead character count should be bigger than 0 and cannot be longer than {}",
+        "Look ahead character count should be bigger than 0 and cannot be longer than {}",
         MAX_LOOK_AHEAD_CHARACTER_COUNT
     )]
     InvalidLookAheadCharacterCount,
@@ -857,7 +859,7 @@ mod test {
             ],
             vec![],
         )
-            .unwrap();
+        .unwrap();
         let included_keywords = included_keywords.unwrap();
 
         let should_match = vec![


### PR DESCRIPTION
Improve perf with two small improvements:

- [Add with_capacity to sanitize_path](https://github.com/DataDog/dd-sensitive-data-scanner/commit/02279cd1328b1867fb6a2d770ef45a9388fb0983) (we know an upper bound of the size of the string in advance)
- [Improve standardize_path_chars by early pushing characters if segment…](https://github.com/DataDog/dd-sensitive-data-scanner/commit/0ea0d9c40d4c56cbbdbffd0f4fb51c14d4abd77e). Push characters early in the method if all are lowercase or all are uppercase