### PR TITLE
Perf: Remove`scanned_bytes` metric

### DIFF
--- a/sds/src/scanner/metrics.rs
+++ b/sds/src/scanner/metrics.rs
@@ -20,7 +20,6 @@ pub struct ScannerMetrics {
     pub num_scanned_events: Counter,
     pub duration_ns: Counter,
     pub match_count: Counter,
-    pub event_size_bytes: Counter,
 }
 
 impl ScannerMetrics {
@@ -29,7 +28,6 @@ impl ScannerMetrics {
             num_scanned_events: counter!("scanned_events", labels.clone()),
             duration_ns: counter!("scanning.duration", labels.clone()),
             match_count: counter!("scanning.match_count", labels.clone()),
-            event_size_bytes: counter!("scanned_bytes", labels.clone()),
         }
     }
 }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -492,12 +492,6 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
             }
         });
 
-        // Emit metrics for event_size_bytes
-        self.scanner
-            .metrics
-            .event_size_bytes
-            .increment(content.len() as u64);
-
         // calculate_indices requires that matches are sorted by start index
         path_rules_matches.sort_unstable_by_key(|rule_match| rule_match.utf8_start);
 
@@ -1985,19 +1979,6 @@ mod test {
                 DebugValue::Counter(val) => assert!(val > 0),
                 _ => assert!(false),
             }
-
-            let metric_name = "scanned_bytes";
-            let metric_value = snapshot
-                .get(&CompositeKey::new(Counter, Key::from_name(metric_name)))
-                .expect("metric not found");
-            assert_eq!(
-                metric_value,
-                &(
-                    None,
-                    None,
-                    DebugValue::Counter((content_1.len() + content_2.len()) as u64)
-                )
-            );
         }
 
         #[test]


### PR DESCRIPTION
The `scanned_bytes` metric is incremented for every string in every event. Unfortunately the underlying metrics library used here (`metrics-exporter-statsd` / `cadence`) has poor performance and requires re-constructing tags for every increment. This is used in a very hot loop, and can cause a ~50% performance regression (for a `scan()` call) from this single metric.

This is being removed for now to fix the perf regression, but in the future we can consider switching to something like `metrics-exporter-prometheus` instead which should have better performance.