### PR TITLE
Revert "Make multi-pass V0 order independent (again) (#79)"

### DIFF
--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -61,17 +61,6 @@ pub trait CompiledRuleTrait: Send + Sync {
         match_emitter: &mut dyn MatchEmitter,
         should_keywords_match_event_paths: bool,
     );
-
-    // Whether a match from this rule should be excluded (marked as a false-positive)
-    // if the content of this match was found in a match from an excluded scope
-    fn should_exclude_multipass_v0(&self) -> bool {
-        // default is to NOT use Multi-pass V0
-        false
-    }
-
-    fn on_excluded_match_multipass_v0(&self) {
-        // default is to do nothing
-    }
 }
 
 impl RuleConfigTrait for Box<dyn RuleConfigTrait> {
@@ -188,20 +177,8 @@ impl Scanner {
         for (path, rule_matches) in &mut rule_matches_list {
             // All rule matches in each inner list are for a single path, so they can be processed independently.
             event.visit_string_mut(path, |content| {
-                // Now that the `excluded_matches` set is fully populated, filter out any matches
-                // that are the same as excluded matches (also known as "Multi-pass V0")
-                rule_matches.retain(|rule_match| {
-                    if self.rules[rule_match.rule_index].should_exclude_multipass_v0() {
-                        let is_false_positive = excluded_matches
-                            .contains(&content[rule_match.utf8_start..rule_match.utf8_end]);
-                        if is_false_positive {
-                            self.rules[rule_match.rule_index].on_excluded_match_multipass_v0();
-                        }
-                        !is_false_positive
-                    } else {
-                        true
-                    }
-                });
+                // Normally matches should be filtered out that match `excluded_matches` here, but it
+                // has temporarily moved for backwards compatibility
 
                 self.sort_and_remove_overlapping_rules::<E::Encoding>(rule_matches);
 
@@ -1525,11 +1502,11 @@ mod test {
 
         // Due to the ordering of the scan (alphabetical in this case), the match from "a-match" is not
         // excluded yet, but "z-match" is, so only 1 match is found.
-
-        // "test" is excluded because it matches the excluded scope.
-        // Both "a-match" and "z-match" are excluded due to having the
-        // same match value as "test" (multi-pass V0)
-        assert_eq!(matches.len(), 0);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(
+            matches[0].path,
+            Path::from(vec![PathSegment::Field("a-match".into())])
+        );
     }
 
     #[test]

--- a/sds/src/scanner/regex_rule.rs
+++ b/sds/src/scanner/regex_rule.rs
@@ -35,15 +35,6 @@ impl CompiledRuleTrait for RegexCompiledRule {
     fn get_scope(&self) -> &Scope {
         &self.scope
     }
-
-    fn should_exclude_multipass_v0(&self) -> bool {
-        true
-    }
-
-    fn on_excluded_match_multipass_v0(&self) {
-        self.metrics.false_positive_excluded_attributes.increment(1);
-    }
-
     fn get_string_matches(
         &self,
         content: &str,
@@ -229,15 +220,27 @@ impl<'a> Iterator for TruePositiveSearch<'a> {
                     self.start = regex_match.end();
 
                     if self.exclusion_check.is_excluded(self.rule.rule_index) {
-                        // Matches from excluded paths are saved and used to treat additional equal matches as false positives.
-                        // Matches are checked against this `excluded_matches` set after all scanning has been done.
+                        // Matches from excluded paths are saved and used to treat additional equal matches as false positives
                         self.excluded_matches
                             .insert(self.content[regex_match.range()].to_string());
                     } else {
-                        return Some(StringMatch {
-                            start: regex_match.start(),
-                            end: regex_match.end(),
-                        });
+                        // If the matched content is in `excluded_matches` it should not count as a match.
+                        // This is temporary to maintain backwards compatibility, but this should eventually happen
+                        // after all scanning is done so `excluded_matches` is fully populated.
+                        if !self
+                            .excluded_matches
+                            .contains(&self.content[regex_match.range()])
+                        {
+                            return Some(StringMatch {
+                                start: regex_match.start(),
+                                end: regex_match.end(),
+                            });
+                        } else {
+                            self.rule
+                                .metrics
+                                .false_positive_excluded_attributes
+                                .increment(1)
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
This reverts commit 9291b47fc34eb3fd97cbb8b939db044d7ad1b6cc.
In case #incident-804 is urgent we need to revert this to make logs-backend tests pass