### PR TITLE
Reverting cache hashmap as it is too costly. Will be reintroduced by CacheGroupScan

### DIFF
--- a/sds/src/scanner/regex_rule.rs
+++ b/sds/src/scanner/regex_rule.rs
@@ -40,7 +40,6 @@ impl CompiledRuleTrait for RegexCompiledRule {
         content: &str,
         path: &Path,
         caches: &mut CachePoolGuard<'_>,
-        _cached_string_matches_per_rule: &mut AHashSet<String>,
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,


### PR DESCRIPTION
HashMap insertion accounts for 10% of sds cpu time in event processing
[https://app.datadoghq.com/profiling/explorer?query=service%3Aevent-processing%20logs_[…]lame_graph&start=1721390705492&end=1721394305492&paused=true](https://app.datadoghq.com/profiling/explorer?query=service%3Aevent-processing%20logs_cell_name%3Aspans-datadog%20&agg_m=count&agg_m_source=base&agg_t=count&compareValuesMode=absolute&fromUser=true&my_code=disabled&op_filter=focus_on%28method%3A%22ScrubbingProcessor.applyProcessor%28PipelineDatum%2C%20PipelineContext%29%22%29%20focus_on%28method%3A%22SynchronousProcessor.applyStage%28PipelineDatum%2C%20PipelineContext%2C%20CompletableStageResultFactory%29%22%29%20method%3A%22Java_dd_sds_Native_scan%28%29%22%20show_from%28method%3A%22Java_dd_sds_Native_scan%28%29%22%29%20method%3A%22core%3A%3Ahash%3A%3ABuildHasher%3A%3Ahash_one%28%29%22&viz=flame_graph&start=1721390705492&end=1721394305492&paused=true)