### PR TITLE
Add option to disable multipass v0

### DIFF
--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -51,6 +51,3 @@ hyperscan = { version = "0.3.2", features = ["static"] }
 [[bench]]
 name = "bench"
 harness = false
-
-
-


### PR DESCRIPTION
An option is added to the scanner builder to disable "Multipass V0". Previously this was always on, and now it defaults to on, but can be disabled for the entire scanner.