### PR TITLE
Move the embedded structure back in

### DIFF
--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -41,10 +41,6 @@ type ScanResult struct {
 	// If `Mutated` is false:
 	//   * it contains the original event, unchanged.
 	Event []byte
-	scanResult
-}
-
-type scanResult struct {
 	// Mutated indicates if the processed event has been
 	// mutated or not (e.g. redacted).
 	Mutated bool

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -253,10 +253,10 @@ func TestScanStringWithHash(t *testing.T) {
 	if !result.Mutated {
 		t.Fatal("Failed to scan the event: not mutated")
 	}
-	if len(result.scanResult.Matches) != 1 {
+	if len(result.Matches) != 1 {
 		t.Fatal("Failed to scan the event: not the good amount of rules returned")
 	}
-	if result.scanResult.Matches[0].ReplacementType != ReplacementTypeHash {
+	if result.Matches[0].ReplacementType != ReplacementTypeHash {
 		t.Fatal("Failed to scan the event: not hashed")
 	}
 


### PR DESCRIPTION
This PR moves the embedded non exported scanResult structure back into the main structure. This will allow an user of the library to more easily tests a potentially non Mutated result in their own tests.