### PR TITLE
🎨 [Included keywords matching path improvement 1/N] Make active_tree_count a struct called NodeCounter

### DIFF
--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -128,6 +128,7 @@ struct NodeCounter {
     // list is the current number of active trees (n), which is the last
     // n trees in `tree_nodes`.
     active_tree_count: usize,
+    #[allow(dead_code)]
     // This counts how many rule indices we have pushed at the given node.
     // This helps remove the right number of elements when popping the segment.
     true_positive_rules_count: usize,
@@ -141,6 +142,7 @@ struct ScopedRuledSetEventVisitor<'a, C> {
     // If an "Add" exists for a rule in this list, it will be scanned. If a single "Remove" exists, it will cause the `ExclusionCheck` to return true.
     tree_nodes: Vec<ActiveRuleTree<'a>>,
 
+    #[allow(dead_code)]
     // This is a list of rule indices that have been detected as true positives for the current path.
     true_positive_rule_idx: Vec<usize>,
 

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -147,7 +147,7 @@ struct ScopedRuledSetEventVisitor<'a, C> {
     true_positive_rule_idx: Vec<usize>,
 
     // This is a counter that helps keep track of how many elements we have pushed
-    // In the tree_nodes list and in the rule_in
+    // In the tree_nodes list and in the true_positive_rule_idx list
     active_node_counter: Vec<NodeCounter>,
 
     // The current path being visited


### PR DESCRIPTION
## Description

Plan to optimise the included keywords match on events path:

- Make a new data structure called `NodeCounter` that contains the count for the current `active_tree_count`, and the upcoming `true_positive_rule_idx` vector that will contain the rule indices that have matched at the current path. (👈  This PR)

(Next PRs 👇)
- Create another vector (that acts as a stack) that contains the list of sanitized segments until that point. The sanitized path would be the concatenation of all the vector, linked using the unified linked char
- Create a sanitize method on the segment struct
- Run the path matching every time we push a segment on all the rules that have not yet matched the path (looking at the `true_positive_rule_idx`
- Store the result in the `true_positive_rule_idx`
- When scanning a leaf, retrieve the information if the rule is a true positive or not, and either include it or exclude it