### PR TITLE
🎨 [Included keywords matching path improvement 2/N] Sanitize segment and push it to a new list when pushing a new segment

### DIFF
--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -109,7 +109,7 @@ impl<'a> PathSegment<'a> {
         }
     }
 
-    pub fn sanitize(&self) -> String {
+    pub fn sanitize(&self) -> Cow<'a, str> {
         let mut sanitized_segment = String::with_capacity(self.length() + 1);
         if let PathSegment::Field(field) = self {
             if should_bypass_standardize_path(field) {
@@ -120,7 +120,7 @@ impl<'a> PathSegment<'a> {
                 });
             }
         }
-        sanitized_segment
+        Cow::Owned(sanitized_segment)
     }
 }
 

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -1,4 +1,3 @@
-use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -76,9 +76,7 @@ impl<'a> Path<'a> {
                     sanitized_path.push(UNIFIED_LINK_CHAR);
                 }
 
-                if should_bypass_standardize_path(field)
-                    != BypassStandardizePathResult::NoBypass
-                {
+                if should_bypass_standardize_path(field) != BypassStandardizePathResult::NoBypass {
                     sanitized_path.push_str(field.to_ascii_lowercase().as_str())
                 } else {
                     standardize_path_chars(field, |c| {

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -77,7 +77,7 @@ impl<'a> Path<'a> {
                 }
 
                 if should_bypass_standardize_path(field)
-                    != BypassStandardizePathResult::ShouldNotBypass
+                    != BypassStandardizePathResult::NoBypass
                 {
                     sanitized_path.push_str(field.to_ascii_lowercase().as_str())
                 } else {
@@ -114,14 +114,14 @@ impl<'a> PathSegment<'a> {
 
     pub fn sanitize(&self) -> Cow<'a, str> {
         if let PathSegment::Field(field) = self {
-            match should_bypass_standardize_path(&field) {
-                BypassStandardizePathResult::ShouldBypassAndAllLowercase => field.clone(),
-                BypassStandardizePathResult::ShouldBypassAndAllUppercase => {
+            match should_bypass_standardize_path(field) {
+                BypassStandardizePathResult::BypassAndAllLowercase => field.clone(),
+                BypassStandardizePathResult::BypassAndAllUppercase => {
                     Cow::Owned(field.to_ascii_lowercase())
                 }
-                BypassStandardizePathResult::ShouldNotBypass => {
+                BypassStandardizePathResult::NoBypass => {
                     let mut sanitized_segment = String::with_capacity(self.length() + 1);
-                    standardize_path_chars(&field, |c| {
+                    standardize_path_chars(field, |c| {
                         sanitized_segment.push(c.to_ascii_lowercase());
                     });
                     Cow::Owned(sanitized_segment)

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 
-use crate::proximity_keywords::{BypassStandardizePathResult, should_bypass_standardize_path, standardize_path_chars, UNIFIED_LINK_CHAR};
+use crate::proximity_keywords::{
+    should_bypass_standardize_path, standardize_path_chars, BypassStandardizePathResult,
+    UNIFIED_LINK_CHAR,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -73,7 +76,9 @@ impl<'a> Path<'a> {
                     sanitized_path.push(UNIFIED_LINK_CHAR);
                 }
 
-                if should_bypass_standardize_path(field) != BypassStandardizePathResult::ShouldNotBypass {
+                if should_bypass_standardize_path(field)
+                    != BypassStandardizePathResult::ShouldNotBypass
+                {
                     sanitized_path.push_str(field.to_ascii_lowercase().as_str())
                 } else {
                     standardize_path_chars(field, |c| {
@@ -111,7 +116,9 @@ impl<'a> PathSegment<'a> {
         if let PathSegment::Field(field) = self {
             match should_bypass_standardize_path(&field) {
                 BypassStandardizePathResult::ShouldBypassAndAllLowercase => field.clone(),
-                BypassStandardizePathResult::ShouldBypassAndAllUppercase => Cow::Owned(field.to_ascii_lowercase()),
+                BypassStandardizePathResult::ShouldBypassAndAllUppercase => {
+                    Cow::Owned(field.to_ascii_lowercase())
+                }
                 BypassStandardizePathResult::ShouldNotBypass => {
                     let mut sanitized_segment = String::with_capacity(self.length() + 1);
                     standardize_path_chars(&field, |c| {

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -110,23 +110,23 @@ impl<'a> PathSegment<'a> {
         }
     }
 
-    pub fn sanitize(&self) -> Cow<'a, str> {
+    pub fn sanitize(&self) -> Option<Cow<'a, str>> {
         if let PathSegment::Field(field) = self {
             match should_bypass_standardize_path(field) {
-                BypassStandardizePathResult::BypassAndAllLowercase => field.clone(),
+                BypassStandardizePathResult::BypassAndAllLowercase => Some(field.clone()),
                 BypassStandardizePathResult::BypassAndAllUppercase => {
-                    Cow::Owned(field.to_ascii_lowercase())
+                    Some(Cow::Owned(field.to_ascii_lowercase()))
                 }
                 BypassStandardizePathResult::NoBypass => {
                     let mut sanitized_segment = String::with_capacity(self.length() + 1);
                     standardize_path_chars(field, |c| {
                         sanitized_segment.push(c.to_ascii_lowercase());
                     });
-                    Cow::Owned(sanitized_segment)
+                    Some(Cow::Owned(sanitized_segment))
                 }
             }
         } else {
-            Cow::Owned(String::new())
+            None
         }
     }
 }
@@ -179,6 +179,7 @@ impl From<usize> for PathSegment<'static> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::proximity_keywords::UNIFIED_LINK_STR;
 
     #[test]
     fn test_starts_with() {
@@ -191,6 +192,52 @@ mod test {
         assert!(foo.starts_with(&foo));
         assert!(!foo.starts_with(&array_foo));
         assert!(!array_foo.starts_with(&foo));
+    }
+
+    #[test]
+    fn test_sanitize_segments() {
+        assert_eq!(
+            Path::from(vec!["hello".into(), 0.into(), "world".into()])
+                .segments
+                .iter()
+                .filter_map(|segment| { segment.sanitize() })
+                .collect::<Vec<_>>()
+                .join(UNIFIED_LINK_STR),
+            "hello.world"
+        );
+        assert_eq!(
+            Path::from(vec!["hello".into(), 1.into(), "CHICKEN".into(), 2.into()])
+                .segments
+                .iter()
+                .filter_map(|segment| { segment.sanitize() })
+                .collect::<Vec<_>>()
+                .join(UNIFIED_LINK_STR),
+            "hello.chicken"
+        );
+        assert_eq!(
+            Path::from(vec![
+                "hello_world-of".into(),
+                1.into(),
+                "CHICKEN".into(),
+                2.into(),
+            ])
+            .segments
+            .iter()
+            .filter_map(|segment| { segment.sanitize() })
+            .collect::<Vec<_>>()
+            .join(UNIFIED_LINK_STR),
+            "hello.world.of.chicken"
+        );
+
+        assert_eq!(
+            Path::from(vec!["hello_world-of-".into(), "/chickens_/".into()])
+                .segments
+                .iter()
+                .filter_map(|segment| { segment.sanitize() })
+                .collect::<Vec<_>>()
+                .join(UNIFIED_LINK_STR),
+            "hello.world.of-./chickens./"
+        );
     }
 
     #[test]

--- a/sds/src/path.rs
+++ b/sds/src/path.rs
@@ -100,6 +100,28 @@ impl<'a> PathSegment<'a> {
     pub fn is_index(&self) -> bool {
         matches!(self, PathSegment::Index(_))
     }
+
+    pub fn length(&self) -> usize {
+        if let PathSegment::Field(field) = self {
+            field.len()
+        } else {
+            0
+        }
+    }
+
+    pub fn sanitize(&self) -> String {
+        let mut sanitized_segment = String::with_capacity(self.length() + 1);
+        if let PathSegment::Field(field) = self {
+            if should_bypass_standardize_path(field) {
+                sanitized_segment.push_str(field.to_ascii_lowercase().as_str())
+            } else {
+                standardize_path_chars(field, |c| {
+                    sanitized_segment.push(c.to_ascii_lowercase());
+                });
+            }
+        }
+        sanitized_segment
+    }
 }
 
 impl<'a> Debug for Path<'a> {

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -36,6 +36,7 @@ pub struct ProximityKeywordsRegex {
 pub const MULTI_WORD_KEYWORDS_LINK_CHARS: &[char] = &['-', '_', '.', ' ', '/'];
 
 pub const UNIFIED_LINK_CHAR: char = '.';
+pub const UNIFIED_LINK_STR: &str = ".";
 
 pub fn compile_keywords_proximity_config(
     config: &ProximityKeywordsConfig,

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -448,8 +448,10 @@ pub enum ProximityKeywordsValidationError {
 
 #[cfg(test)]
 mod test {
+    use crate::proximity_keywords::BypassStandardizePathResult::{
+        BypassAndAllLowercase, BypassAndAllUppercase, NoBypass,
+    };
     use crate::proximity_keywords::*;
-    use crate::proximity_keywords::BypassStandardizePathResult::{BypassAndAllLowercase, BypassAndAllUppercase, NoBypass};
 
     fn try_new_compiled_proximity_keyword(
         look_ahead_character_count: usize,
@@ -881,18 +883,9 @@ mod test {
 
     #[test]
     fn test_should_bypass_standardize() {
-        assert_eq!(
-            should_bypass_standardize_path("hello world"),
-            NoBypass
-        );
-        assert_eq!(
-            should_bypass_standardize_path("helloWorld"),
-            NoBypass
-        );
-        assert_eq!(
-            should_bypass_standardize_path("hello-world"),
-            NoBypass
-        );
+        assert_eq!(should_bypass_standardize_path("hello world"), NoBypass);
+        assert_eq!(should_bypass_standardize_path("helloWorld"), NoBypass);
+        assert_eq!(should_bypass_standardize_path("hello-world"), NoBypass);
         assert_eq!(
             should_bypass_standardize_path("helloworld"),
             BypassAndAllLowercase

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -4,6 +4,9 @@ mod included_keywords;
 pub use crate::proximity_keywords::excluded_keywords::CompiledExcludedProximityKeywords;
 pub use crate::proximity_keywords::included_keywords::*;
 
+use crate::proximity_keywords::BypassStandardizePathResult::{
+    ShouldBypassAndAllLowercase, ShouldBypassAndAllUppercase, ShouldNotBypass,
+};
 use crate::proximity_keywords::ProximityKeywordsValidationError::{
     EmptyKeyword, InvalidLookAheadCharacterCount, KeywordTooLong, TooManyKeywords,
 };
@@ -15,7 +18,6 @@ use regex_syntax::ast::{
     Group, GroupKind, Literal, LiteralKind, Position, Span,
 };
 use thiserror::Error;
-use crate::proximity_keywords::BypassStandardizePathResult::{ShouldBypassAndAllLowercase, ShouldBypassAndAllUppercase, ShouldNotBypass};
 
 const MAX_KEYWORD_COUNT: usize = 50;
 pub const MAX_LOOK_AHEAD_CHARACTER_COUNT: usize = 50;
@@ -881,11 +883,26 @@ mod test {
 
     #[test]
     fn test_should_bypass_standardize() {
-        assert_eq!(should_bypass_standardize_path("hello world"), ShouldNotBypass);
-        assert_eq!(should_bypass_standardize_path("helloWorld"), ShouldNotBypass);
-        assert_eq!(should_bypass_standardize_path("hello-world"), ShouldNotBypass);
-        assert_eq!(should_bypass_standardize_path("helloworld"), ShouldBypassAndAllLowercase);
-        assert_eq!(should_bypass_standardize_path("HELLOWORLD"), ShouldBypassAndAllUppercase);
+        assert_eq!(
+            should_bypass_standardize_path("hello world"),
+            ShouldNotBypass
+        );
+        assert_eq!(
+            should_bypass_standardize_path("helloWorld"),
+            ShouldNotBypass
+        );
+        assert_eq!(
+            should_bypass_standardize_path("hello-world"),
+            ShouldNotBypass
+        );
+        assert_eq!(
+            should_bypass_standardize_path("helloworld"),
+            ShouldBypassAndAllLowercase
+        );
+        assert_eq!(
+            should_bypass_standardize_path("HELLOWORLD"),
+            ShouldBypassAndAllUppercase
+        );
     }
 
     #[test]

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -36,6 +36,7 @@ pub struct ProximityKeywordsRegex {
 pub const MULTI_WORD_KEYWORDS_LINK_CHARS: &[char] = &['-', '_', '.', ' ', '/'];
 
 pub const UNIFIED_LINK_CHAR: char = '.';
+#[allow(dead_code)]
 pub const UNIFIED_LINK_STR: &str = ".";
 
 pub fn compile_keywords_proximity_config(

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -291,19 +291,19 @@ pub fn should_bypass_standardize_path(characters: &str) -> BypassStandardizePath
     for char in characters.chars() {
         let is_upper = char.is_ascii_uppercase();
         let is_lower = char.is_ascii_lowercase();
-        // If it's neither an uppercase character nor a lowercase character, return false
+        // If it's neither an uppercase character nor a lowercase character, return NoBypass
         if !is_lower && !is_upper {
             return BypassStandardizePathResult::NoBypass;
         }
         all_lower = all_lower && is_lower;
         all_upper = all_upper && is_upper;
-        // If we realise that we don't have all uppercase nor all lowercase, return false
+        // If we realise that we don't have all uppercase nor all lowercase, return NoBypass
         if !all_lower && !all_upper {
             return BypassStandardizePathResult::NoBypass;
         }
     }
 
-    // The characters contain only uppercase characters or only lowercase characters by now
+    // The characters contain only uppercase characters or only lowercase characters by now, so we can bypass
     if all_lower {
         BypassStandardizePathResult::BypassAndAllLowercase
     } else {

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -149,7 +149,7 @@ struct ScopedRuledSetEventVisitor<'a, C> {
     true_positive_rule_idx: Vec<usize>,
 
     // This is a list of sanitized segments until the current node.
-    sanitized_segments_until_node: Vec<Cow<'a, str>>,
+    sanitized_segments_until_node: Vec<Option<Cow<'a, str>>>,
 
     // This is a counter that helps keep track of how many elements we have pushed
     // In the tree_nodes list and in the true_positive_rule_idx list

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -1,11 +1,11 @@
 mod bool_set;
 
-use std::borrow::Cow;
 use crate::event::{EventVisitor, VisitStringResult};
 use crate::scanner::scope::Scope;
 use crate::scoped_ruleset::bool_set::BoolSet;
 use crate::{Event, Path, PathSegment};
 use ahash::AHashMap;
+use std::borrow::Cow;
 
 /// A `ScopedRuleSet` determines which rules will be used to scan each field of an event, and which
 /// paths are considered `excluded`.

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -1,5 +1,6 @@
 mod bool_set;
 
+use std::borrow::Cow;
 use crate::event::{EventVisitor, VisitStringResult};
 use crate::scanner::scope::Scope;
 use crate::scoped_ruleset::bool_set::BoolSet;
@@ -148,7 +149,7 @@ struct ScopedRuledSetEventVisitor<'a, C> {
     true_positive_rule_idx: Vec<usize>,
 
     // This is a list of sanitized segments until the current node.
-    sanitized_segments_until_node: Vec<&'a str>,
+    sanitized_segments_until_node: Vec<Cow<'a, str>>,
 
     // This is a counter that helps keep track of how many elements we have pushed
     // In the tree_nodes list and in the true_positive_rule_idx list
@@ -196,7 +197,7 @@ where
         }
 
         // Sanitize the segment and push it
-        self.sanitized_segments_until_node.push(&segment.sanitize());
+        self.sanitized_segments_until_node.push(segment.sanitize());
 
         // The new number of active trees is the number of new trees pushed
         self.active_node_counter.push(NodeCounter {

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -69,6 +69,7 @@ impl ScopedRuleSet {
                 index_wildcard_match: false,
             }],
             true_positive_rule_idx: vec![],
+            sanitized_segments_until_node: vec![],
             active_node_counter: vec![NodeCounter {
                 active_tree_count: 1,
                 true_positive_rules_count: 0,
@@ -146,6 +147,9 @@ struct ScopedRuledSetEventVisitor<'a, C> {
     // This is a list of rule indices that have been detected as true positives for the current path.
     true_positive_rule_idx: Vec<usize>,
 
+    // This is a list of sanitized segments until the current node.
+    sanitized_segments_until_node: Vec<&'a str>,
+
     // This is a counter that helps keep track of how many elements we have pushed
     // In the tree_nodes list and in the true_positive_rule_idx list
     active_node_counter: Vec<NodeCounter>,
@@ -190,6 +194,10 @@ where
                 });
             }
         }
+
+        // Sanitize the segment and push it
+        self.sanitized_segments_until_node.push(&segment.sanitize());
+
         // The new number of active trees is the number of new trees pushed
         self.active_node_counter.push(NodeCounter {
             active_tree_count: self.tree_nodes.len() - tree_nodes_len,

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -214,6 +214,7 @@ where
             // The rules from the last node are no longer active, so remove them.
             let _popped = self.tree_nodes.pop();
         }
+        self.sanitized_segments_until_node.pop();
         self.path.segments.pop();
     }
 


### PR DESCRIPTION
## Description

Plan to optimise the included keywords match on events path:

Make a new data structure called NodeCounter that contains the count for the current active_tree_count, and the upcoming true_positive_rule_idx vector that will contain the rule indices that have matched at the current path. (☝️ Previous PR)

**Create another vector (that acts as a stack) that contains the list of sanitized segments until that point. The sanitized path would be the concatenation of all the vector, linked using the unified linked char (👈  this PR)
Create a sanitize method on the segment struct  (👈 this PR)**

(Next PRs 👇)

Run the path matching every time we push a segment on all the rules that have not yet matched the path (looking at the true_positive_rule_idx
Store the result in the true_positive_rule_idx
When scanning a leaf, retrieve the information if the rule is a true positive or not, and either include it or exclude it