### PR TITLE
🎨 [Included keywords matching path improvement 3/N] Sanitize segment and push it to a new list when pushing a new segment

### DIFF
--- a/sds/benches/bench.rs
+++ b/sds/benches/bench.rs
@@ -59,6 +59,14 @@ pub fn scoped_ruleset(c: &mut Criterion) {
                     });
                     false
                 }
+
+                fn find_true_positive_rules_from_current_path(
+                    &self,
+                    sanitized_path: &str,
+                    current_true_positive_rule_idx: &mut Vec<usize>,
+                ) -> usize {
+                    0
+                }
             }
 
             fast_rule_set.visit_string_rule_combinations(

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -37,6 +37,7 @@ pub struct ProximityKeywordsRegex {
 pub const MULTI_WORD_KEYWORDS_LINK_CHARS: &[char] = &['-', '_', '.', ' ', '/'];
 
 pub const UNIFIED_LINK_CHAR: char = '.';
+#[allow(dead_code)]
 pub const UNIFIED_LINK_STR: &str = ".";
 
 pub fn compile_keywords_proximity_config(

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -37,7 +37,6 @@ pub struct ProximityKeywordsRegex {
 pub const MULTI_WORD_KEYWORDS_LINK_CHARS: &[char] = &['-', '_', '.', ' ', '/'];
 
 pub const UNIFIED_LINK_CHAR: char = '.';
-#[allow(dead_code)]
 pub const UNIFIED_LINK_STR: &str = ".";
 
 pub fn compile_keywords_proximity_config(

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -738,7 +738,7 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
         for (idx, rule) in self.scanner.rules.iter().enumerate() {
             if !current_true_positive_rule_idx.contains(&idx) {
                 if let Some(keywords) = rule.get_included_keywords() {
-                    if contains_keyword_in_path(&sanitized_path, &keywords.keywords_pattern) {
+                    if contains_keyword_in_path(sanitized_path, &keywords.keywords_pattern) {
                         // The rule is found has a true positive for this path, push it
                         current_true_positive_rule_idx.push(idx);
                         times_pushed += 1

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -731,6 +731,27 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
 
         has_match
     }
+
+    fn find_true_positive_rules_from_current_path(
+        &self,
+        sanitized_segments: &[Cow<str>],
+        current_true_positive_rule_idx: &mut Vec<usize>,
+    ) -> usize {
+        let mut times_pushed = 0;
+        for (idx, rule) in self.scanner.rules.iter().enumerate() {
+            if !current_true_positive_rule_idx.contains(&idx) {
+                if let Some(keywords) = rule.get_included_keywords() {
+                    let sanitized_path = sanitized_segments.join(UNIFIED_LINK_STR);
+                    if contains_keyword_in_path(&sanitized_path, &keywords.keywords_pattern) {
+                        // The rule is found has a true positive for this path, push it
+                        current_true_positive_rule_idx.push(idx);
+                        times_pushed += 1
+                    }
+                }
+            }
+        }
+        times_pushed
+    }
 }
 
 // Calculates the next starting position for a regex match if a the previous match is a false positive

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -17,9 +17,7 @@ use std::any::{Any, TypeId};
 use std::sync::Arc;
 
 use self::metrics::ScannerMetrics;
-use crate::proximity_keywords::{
-    contains_keyword_in_path, CompiledIncludedProximityKeywords,
-};
+use crate::proximity_keywords::{contains_keyword_in_path, CompiledIncludedProximityKeywords};
 use crate::scanner::config::RuleConfig;
 use crate::scanner::regex_rule::compiled::RegexCompiledRule;
 use crate::scanner::regex_rule::{access_regex_caches, RegexCaches};

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -14,12 +14,11 @@ use crate::scoped_ruleset::{ContentVisitor, ExclusionCheck, ScopedRuleSet};
 pub use crate::secondary_validation::Validator;
 use crate::{CreateScannerError, EncodeIndices, MatchAction, Path};
 use std::any::{Any, TypeId};
-use std::borrow::Cow;
 use std::sync::Arc;
 
 use self::metrics::ScannerMetrics;
 use crate::proximity_keywords::{
-    contains_keyword_in_path, CompiledIncludedProximityKeywords, UNIFIED_LINK_STR,
+    contains_keyword_in_path, CompiledIncludedProximityKeywords,
 };
 use crate::scanner::config::RuleConfig;
 use crate::scanner::regex_rule::compiled::RegexCompiledRule;

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -734,14 +734,13 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
 
     fn find_true_positive_rules_from_current_path(
         &self,
-        sanitized_segments: &[Cow<str>],
+        sanitized_path: &str,
         current_true_positive_rule_idx: &mut Vec<usize>,
     ) -> usize {
         let mut times_pushed = 0;
         for (idx, rule) in self.scanner.rules.iter().enumerate() {
             if !current_true_positive_rule_idx.contains(&idx) {
                 if let Some(keywords) = rule.get_included_keywords() {
-                    let sanitized_path = sanitized_segments.join(UNIFIED_LINK_STR);
                     if contains_keyword_in_path(&sanitized_path, &keywords.keywords_pattern) {
                         // The rule is found has a true positive for this path, push it
                         current_true_positive_rule_idx.push(idx);

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -625,7 +625,10 @@ impl ScannerBuilder<'_> {
                 .map(|rule| rule.get_scope().clone())
                 .collect::<Vec<_>>(),
         )
-        .with_implicit_index_wildcards(self.scanner_features.add_implicit_index_wildcards);
+        .with_implicit_index_wildcards(self.scanner_features.add_implicit_index_wildcards)
+        .with_keywords_should_match_event_paths(
+            self.scanner_features.should_keywords_match_event_paths,
+        );
 
         {
             let stats = &*GLOBAL_STATS;

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -40,6 +40,10 @@ impl CompiledRule for RegexCompiledRule {
         &self.scope
     }
     fn create_group_data(_: &Labels) {}
+    fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
+        self.included_keywords.as_ref()
+    }
+
     fn get_string_matches(
         &self,
         content: &str,

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -122,6 +122,12 @@ pub trait ContentVisitor<'path> {
         rules: RuleIndexVisitor,
         is_excluded: ExclusionCheck<'content_visitor>,
     ) -> bool;
+
+    fn find_true_positive_rules_from_current_path(
+        &self,
+        sanitized_segments: &[Cow<str>],
+        current_true_positive_rule_idx: &mut Vec<usize>,
+    ) -> usize;
 }
 
 // This is just a reference to a RuleTree with some additional information
@@ -391,6 +397,14 @@ mod test {
                     rules,
                 });
                 true
+            }
+
+            fn find_true_positive_rules_from_current_path(
+                &self,
+                sanitized_segments: &[Cow<str>],
+                current_true_positive_rule_idx: &mut Vec<usize>,
+            ) -> usize {
+                0
             }
         }
 

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -261,7 +261,8 @@ where
             // The true positive rule indices from the last node are no longer active, remove them.
             let _popped = self.true_positive_rule_idx.pop();
         }
-
+        // Pop the sanitized segment
+        self.sanitized_segments_until_node.pop();
         self.path.segments.pop();
     }
 

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -164,6 +164,7 @@ struct ScopedRuledSetEventVisitor<'a, C> {
     true_positive_rule_idx: Vec<usize>,
 
     // This is a list of sanitized segments until the current node.
+    // It contains Options because the segments can be Indexes, not Fields. Fields have a path, Index don't and will result in None instead.
     sanitized_segments_until_node: Vec<Option<Cow<'a, str>>>,
 
     // This is a counter that helps keep track of how many elements we have pushed
@@ -212,7 +213,7 @@ where
             }
         }
 
-        // Sanitize the segment and push it
+        // Sanitize the segment and push it. If the segment is an Index, it will push None.
         self.sanitized_segments_until_node.push(segment.sanitize());
 
         let true_positive_rules_count = if self.should_keywords_match_event_paths {

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -432,8 +432,8 @@ mod test {
 
             fn find_true_positive_rules_from_current_path(
                 &self,
-                sanitized_path: &str,
-                current_true_positive_rule_idx: &mut Vec<usize>,
+                _sanitized_path: &str,
+                _current_true_positive_rule_idx: &mut Vec<usize>,
             ) -> usize {
                 0
             }

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -6,7 +6,6 @@ use crate::scanner::scope::Scope;
 use crate::scoped_ruleset::bool_set::BoolSet;
 use crate::{Event, Path, PathSegment};
 use ahash::AHashMap;
-use serde::Serialize;
 use std::borrow::Cow;
 
 /// A `ScopedRuleSet` determines which rules will be used to scan each field of an event, and which

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -15,6 +15,7 @@ pub struct ScopedRuleSet {
     // The number of rules stored in this set
     num_rules: usize,
     add_implicit_index_wildcards: bool,
+    should_keywords_match_event_paths: bool,
 }
 
 impl ScopedRuleSet {
@@ -45,11 +46,17 @@ impl ScopedRuleSet {
             tree,
             num_rules: rules_scopes.len(),
             add_implicit_index_wildcards: false,
+            should_keywords_match_event_paths: false,
         }
     }
 
     pub fn with_implicit_index_wildcards(mut self, value: bool) -> Self {
         self.add_implicit_index_wildcards = value;
+        self
+    }
+
+    pub fn with_keywords_should_match_event_paths(mut self, value: bool) -> Self {
+        self.should_keywords_match_event_paths = value;
         self
     }
 
@@ -78,6 +85,7 @@ impl ScopedRuleSet {
             path: Path::root(),
             bool_set,
             add_implicit_index_wildcards: self.add_implicit_index_wildcards,
+            should_keywords_match_event_paths: self.should_keywords_match_event_paths,
         };
 
         event.visit_event(&mut visitor)
@@ -162,6 +170,7 @@ struct ScopedRuledSetEventVisitor<'a, C> {
     bool_set: Option<BoolSet>,
 
     add_implicit_index_wildcards: bool,
+    should_keywords_match_event_paths: bool,
 }
 
 impl<'path, C> EventVisitor<'path> for ScopedRuledSetEventVisitor<'path, C>

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -220,13 +220,14 @@ where
                 .sanitized_segments_until_node
                 .iter()
                 .filter_map(|sanitized_segment| {
-                    sanitized_segment
-                        .as_ref()
-                        .map_or(None::<Cow<str>>, |x| Some(x.clone()))
+                    sanitized_segment.as_ref().map(|seg| Some(seg.clone()))
                 })
                 .fold(String::new(), |mut a, b| {
-                    a.reserve(b.len() + 1);
-                    a.push_str(&*b);
+                    let b_str = b.expect(
+                        "In the filter_map above, we make sure to filter out the None variants",
+                    );
+                    a.reserve(b_str.len() + 1);
+                    a.push_str(&b_str);
                     a.push(UNIFIED_LINK_CHAR);
                     a
                 });

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -223,16 +223,14 @@ where
                 .flatten()
                 .map(|x| x.len() + 1)
                 .sum();
-            if total_len > 0 {
-                // subtract the len of the last link char that isn't needed
-                total_len -= 1;
-            }
+
+            // This will remove 1 to the total_len only if the result is >= 0
+            total_len = total_len.saturating_sub(1);
 
             let mut current_sanitized_path = String::with_capacity(total_len);
             for (i, segment) in self
                 .sanitized_segments_until_node
                 .iter()
-                .cloned()
                 .flatten()
                 .enumerate()
             {


### PR DESCRIPTION
## Description

Plan to optimise the included keywords match on events path:

Make a new data structure called NodeCounter that contains the count for the current active_tree_count, and the upcoming true_positive_rule_idx vector that will contain the rule indices that have matched at the current path. (☝️ Previous PR)

Create another vector (that acts as a stack) that contains the list of sanitized segments until that point. The sanitized path would be the concatenation of all the vector, linked using the unified linked char (☝️ previous PRs)
Create a sanitize method on the segment struct  (☝️ previous PRs)

**Introduce `find_true_positive_rules_from_current_path` method on ContentVisitor, that pushes rule indices onto the current `true_positive_rule_idx`** (👈 this PR)

(Next PRs 👇)

Run the path matching every time we push a segment on all the rules that have not yet matched the path (looking at the true_positive_rule_idx
Store the result in the true_positive_rule_idx
When scanning a leaf, retrieve the information if the rule is a true positive or not, and either include it or exclude it