### PR TITLE
🎨 [Included keywords matching path improvement 4/4] When scanning a leaf, retrieve information if the rule was a true positive

### DIFF
--- a/sds/benches/bench.rs
+++ b/sds/benches/bench.rs
@@ -53,6 +53,7 @@ pub fn scoped_ruleset(c: &mut Criterion) {
                     _content: &str,
                     mut rules: RuleIndexVisitor,
                     _check: ExclusionCheck,
+                    _current: &[usize],
                 ) -> bool {
                     rules.visit_rule_indices(|_rule_index| {
                         *self.num_visited += 1;

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -72,7 +72,7 @@ pub trait CompiledRuleDyn: Send + Sync {
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
-        should_keywords_match_event_paths: bool,
+        true_positive_rule_idx: &[usize],
         scanner_labels: &Labels,
     );
 
@@ -117,7 +117,7 @@ impl<T: CompiledRule> CompiledRuleDyn for T {
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
-        should_keywords_match_event_paths: bool,
+        true_positive_rule_idx: &[usize],
         scanner_labels: &Labels,
     ) {
         let group_data_any = group_data
@@ -132,7 +132,7 @@ impl<T: CompiledRule> CompiledRuleDyn for T {
             exclusion_check,
             excluded_matches,
             match_emitter,
-            should_keywords_match_event_paths,
+            true_positive_rule_idx,
         )
     }
 
@@ -176,7 +176,7 @@ pub trait CompiledRule: Send + Sync {
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
-        should_keywords_match_event_paths: bool,
+        true_positive_rule_idx: &[usize],
     );
 
     // Whether a match from this rule should be excluded (marked as a false-positive)
@@ -662,6 +662,7 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
         content: &str,
         mut rule_visitor: crate::scoped_ruleset::RuleIndexVisitor,
         exclusion_check: ExclusionCheck<'b>,
+        true_positive_rule_idx: &[usize],
     ) -> bool {
         // matches for a single path
         let mut path_rules_matches = vec![];
@@ -694,9 +695,7 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
                     &exclusion_check,
                     self.excluded_matches,
                     &mut emitter,
-                    self.scanner
-                        .scanner_features
-                        .should_keywords_match_event_paths,
+                    true_positive_rule_idx,
                     &self.scanner.labels,
                 );
             }
@@ -847,7 +846,7 @@ mod test {
             _exclusion_check: &ExclusionCheck<'_>,
             _excluded_matches: &mut AHashSet<String>,
             match_emitter: &mut dyn MatchEmitter,
-            _should_keywords_match_event_paths: bool,
+            _true_positive_rule_idx: &[usize],
         ) {
             match_emitter.emit(StringMatch { start: 10, end: 16 });
         }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -60,7 +60,9 @@ where
 pub trait CompiledRuleDyn: Send + Sync {
     fn get_match_action(&self) -> &MatchAction;
     fn get_scope(&self) -> &Scope;
-    fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords>;
+    fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
+        None
+    }
 
     #[allow(clippy::too_many_arguments)]
     fn get_string_matches(
@@ -161,7 +163,9 @@ pub trait CompiledRule: Send + Sync {
 
     fn get_match_action(&self) -> &MatchAction;
     fn get_scope(&self) -> &Scope;
-    fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords>;
+    fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
+        None
+    }
 
     #[allow(clippy::too_many_arguments)]
     fn get_string_matches(
@@ -827,10 +831,6 @@ mod test {
         }
 
         fn create_group_data(_: &Labels) {}
-
-        fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
-            None
-        }
 
         fn get_string_matches(
             &self,

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -66,7 +66,6 @@ pub trait CompiledRuleDyn: Send + Sync {
     fn get_string_matches(
         &self,
         content: &str,
-        path: &Path,
         regex_caches: &mut RegexCaches,
         group_data: &mut AHashMap<TypeId, Box<dyn Any>>,
         exclusion_check: &ExclusionCheck<'_>,
@@ -111,7 +110,6 @@ impl<T: CompiledRule> CompiledRuleDyn for T {
     fn get_string_matches(
         &self,
         content: &str,
-        path: &Path,
         regex_caches: &mut RegexCaches,
         group_data: &mut AHashMap<TypeId, Box<dyn Any>>,
         exclusion_check: &ExclusionCheck<'_>,
@@ -126,7 +124,6 @@ impl<T: CompiledRule> CompiledRuleDyn for T {
         let group_data: &mut T::GroupData = group_data_any.downcast_mut().unwrap();
         self.get_string_matches(
             content,
-            path,
             regex_caches,
             group_data,
             exclusion_check,
@@ -170,7 +167,6 @@ pub trait CompiledRule: Send + Sync {
     fn get_string_matches(
         &self,
         content: &str,
-        path: &Path,
         regex_caches: &mut RegexCaches,
         group_data: &mut Self::GroupData,
         exclusion_check: &ExclusionCheck<'_>,
@@ -689,7 +685,6 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
 
                 rule.get_string_matches(
                     content,
-                    path,
                     self.regex_caches,
                     &mut group_data,
                     &exclusion_check,
@@ -840,7 +835,6 @@ mod test {
         fn get_string_matches(
             &self,
             _content: &str,
-            _path: &Path,
             _regex_caches: &mut RegexCaches,
             _group_data: &mut Self::GroupData,
             _exclusion_check: &ExclusionCheck<'_>,

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -9,7 +9,7 @@ use crate::scanner::regex_rule::RegexCaches;
 use crate::scanner::scope::Scope;
 use crate::scanner::{get_next_regex_start, is_false_positive_match};
 use crate::secondary_validation::Validator;
-use crate::{CompiledRule, ExclusionCheck, Labels, MatchAction, MatchEmitter, Path, StringMatch};
+use crate::{CompiledRule, ExclusionCheck, Labels, MatchAction, MatchEmitter, StringMatch};
 use ahash::AHashSet;
 use regex_automata::meta::Cache;
 use regex_automata::Input;
@@ -47,7 +47,6 @@ impl CompiledRule for RegexCompiledRule {
     fn get_string_matches(
         &self,
         content: &str,
-        path: &Path,
         regex_caches: &mut RegexCaches,
         _group_data: &mut (),
         exclusion_check: &ExclusionCheck<'_>,
@@ -59,7 +58,6 @@ impl CompiledRule for RegexCompiledRule {
             Some(ref included_keywords) => {
                 self.get_string_matches_with_included_keywords(
                     content,
-                    path,
                     regex_caches,
                     exclusion_check,
                     excluded_matches,
@@ -112,7 +110,6 @@ impl RegexCompiledRule {
     fn get_string_matches_with_included_keywords(
         &self,
         content: &str,
-        path: &Path,
         regex_caches: &mut RegexCaches,
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -117,7 +117,7 @@ impl RegexCompiledRule {
         true_positive_rule_idx: &[usize],
         included_keywords: &CompiledIncludedProximityKeywords,
     ) {
-        if !true_positive_rule_idx.is_empty() && true_positive_rule_idx.contains(&self.rule_index) {
+        if true_positive_rule_idx.contains(&self.rule_index) {
             // since the path contains a match, we can skip future included keyword checks
             let true_positive_search = self.true_positive_matches(
                 content,

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -122,6 +122,7 @@ pub trait ContentVisitor<'path> {
         content: &str,
         rules: RuleIndexVisitor,
         is_excluded: ExclusionCheck<'content_visitor>,
+        true_positive_rule_idx: &[usize],
     ) -> bool;
 
     fn find_true_positive_rules_from_current_path(
@@ -239,6 +240,7 @@ where
                 }
                 current_sanitized_path.push_str(segment.as_ref());
             }
+
             self.content_visitor
                 .find_true_positive_rules_from_current_path(
                     current_sanitized_path.as_str(),
@@ -283,6 +285,7 @@ where
             ExclusionCheck {
                 tree_nodes: &self.tree_nodes,
             },
+            &self.true_positive_rule_idx,
         );
         if let Some(bool_set) = &mut self.bool_set {
             bool_set.reset();
@@ -421,6 +424,7 @@ mod test {
                 content: &str,
                 mut rule_iter: RuleIndexVisitor,
                 exclusion_check: ExclusionCheck<'content_visitor>,
+                _true_positive_rule_idx: &[usize],
             ) -> bool {
                 let mut rules = vec![];
                 rule_iter.visit_rule_indices(|rule_index| {


### PR DESCRIPTION
## Description

Plan to optimise the included keywords match on events path:

Make a new data structure called NodeCounter that contains the count for the current active_tree_count, and the upcoming true_positive_rule_idx vector that will contain the rule indices that have matched at the current path. (☝️ Previous PR)

Create another vector (that acts as a stack) that contains the list of sanitized segments until that point. The sanitized path would be the concatenation of all the vector, linked using the unified linked char (☝️ previous PRs)
Create a sanitize method on the segment struct  (☝️ previous PRs)

Introduce `find_true_positive_rules_from_current_path` method on ContentVisitor, that pushes rule indices onto the current `true_positive_rule_idx`

⬇️  This PR

**Run the path matching every time we push a segment on all the rules that have not yet matched the path (looking at the true_positive_rule_idx
Store the result in the true_positive_rule_idx
When scanning a leaf, retrieve the information if the rule is a true positive or not, and either include it or exclude it**

