### PR TITLE
Add global stats

### DIFF
--- a/sds-bindings-utils/Cargo.lock
+++ b/sds-bindings-utils/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "crc32fast",
  "farmhash",
  "iban_validate",
+ "lazy_static",
  "metrics",
  "metrics-util",
  "nom",
@@ -331,6 +332,12 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/sds-go/rust/Cargo.lock
+++ b/sds-go/rust/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "crc32fast",
  "farmhash",
  "iban_validate",
+ "lazy_static",
  "metrics",
  "metrics-util",
  "nom",
@@ -341,6 +342,12 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/sds/Cargo.lock
+++ b/sds/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
  "farmhash",
  "hyperscan",
  "iban_validate",
+ "lazy_static",
  "luhn",
  "metrics",
  "metrics-util",
@@ -664,6 +665,12 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -36,6 +36,7 @@ iban_validate = "4"
 
 # This is deprecated and may switch to `serde_yml` in the future. Waiting for it to mature a bit first.
 serde_yaml = "0.9.34"
+lazy_static = "1.5.0"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -14,6 +14,7 @@ mod rule_match;
 mod scanner;
 mod scoped_ruleset;
 mod secondary_validation;
+mod stats;
 mod validation;
 
 #[cfg(any(test, feature = "testing", feature = "bench"))]

--- a/sds/src/stats.rs
+++ b/sds/src/stats.rs
@@ -1,0 +1,31 @@
+use lazy_static::lazy_static;
+use metrics::{counter, gauge, histogram, Counter, Gauge, Histogram};
+
+lazy_static! {
+    pub static ref GLOBAL_STATS: Stats = Stats::new();
+}
+
+pub struct Stats {
+    pub scanner_creations: Counter,
+    pub scanner_deletions: Counter,
+
+    pub total_scanners: Gauge,
+
+    // The total number of rules in a scanner
+    pub number_of_rules_per_scanner: Histogram,
+
+    // The total amount of memory used for a single set of regex caches for a single scanner
+    pub regex_cache_per_scanner: Histogram,
+}
+
+impl Stats {
+    pub fn new() -> Self {
+        Self {
+            scanner_creations: counter!("scanner.creations"),
+            scanner_deletions: counter!("scanner.deletions"),
+            total_scanners: gauge!("scanner.total_count"),
+            number_of_rules_per_scanner: histogram!("scanner.num_rules"),
+            regex_cache_per_scanner: histogram!("scanner.regex_cache_size"),
+        }
+    }
+}


### PR DESCRIPTION
[jira ticket](https://datadoghq.atlassian.net/browse/SDS-460)

This adds global metrics, mostly around scanner creation / rules to better understand memory usage of scanners.
These metrics are no-op unless a recorder is explicitly set for the `metrics` crate.

There are 2 additional metrics that would be useful, but were not implemented due to complexity / cost.

- Regex size. This is very expensive to calculate since it's not directly accessible. It tends to be significantly lower than the cache size used for the regex, so it's not as important. This memory usage also isn't multiplied by the parallelism like the regex cache is.
- Actual parallelism per scanner/rule. This is very complicated to calculate without impacting performance. It can be roughly estimated by comparing the total memory usage by the number of scanners * avg cache size of scanners, which is probably enough to have a good understanding of this. Some new changes are coming soon to consolidate rules across Scanners which would significantly change how this is implemented anyway and this can be revisited then.