### PR TITLE
Fix gauge metrics

### DIFF
--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -436,7 +436,7 @@ impl Drop for Scanner {
     fn drop(&mut self) {
         let stats = &*GLOBAL_STATS;
         stats.scanner_deletions.increment(1);
-        stats.total_scanners.decrement(1);
+        stats.decrement_total_scanners();
     }
 }
 
@@ -515,7 +515,7 @@ impl ScannerBuilder<'_> {
                 .sum();
 
             stats.scanner_creations.increment(1);
-            stats.total_scanners.increment(1);
+            stats.increment_total_scanners();
             stats
                 .regex_cache_per_scanner
                 .record(total_cache_size as f64);

--- a/sds/src/stats.rs
+++ b/sds/src/stats.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use metrics::{counter, gauge, histogram, Counter, Gauge, Histogram};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
 lazy_static! {
     pub static ref GLOBAL_STATS: Stats = Stats::new();
@@ -9,7 +10,10 @@ pub struct Stats {
     pub scanner_creations: Counter,
     pub scanner_deletions: Counter,
 
-    pub total_scanners: Gauge,
+    // Count of total scanners. The actual count is calculated with an atomic
+    // since some metrics exporters don't supporting incrementing gauges (e.g. statsd)
+    total_scanners_count: AtomicI64,
+    total_scanners: Gauge,
 
     // The total number of rules in a scanner
     pub number_of_rules_per_scanner: Histogram,
@@ -23,9 +27,23 @@ impl Stats {
         Self {
             scanner_creations: counter!("scanner.creations"),
             scanner_deletions: counter!("scanner.deletions"),
+            total_scanners_count: AtomicI64::new(0),
             total_scanners: gauge!("scanner.total_count"),
             number_of_rules_per_scanner: histogram!("scanner.num_rules"),
             regex_cache_per_scanner: histogram!("scanner.regex_cache_size"),
         }
+    }
+
+    pub fn increment_total_scanners(&self) {
+        self.update_total_scanners(1);
+    }
+
+    pub fn decrement_total_scanners(&self) {
+        self.update_total_scanners(-1);
+    }
+
+    fn update_total_scanners(&self, delta: i64) {
+        let prev_value = self.total_scanners_count.fetch_add(delta, Ordering::SeqCst);
+        self.total_scanners.set((prev_value + delta) as f64);
     }
 }


### PR DESCRIPTION
Some metrics exporters (e.g. statsd) don't support directly incrementing / decrementing gauges. Instead, an atomic is used to calculate the value and the gauge is directly set to the current value.