### PR TITLE
make Labels::new more generic

### DIFF
--- a/sds/src/observability/labels.rs
+++ b/sds/src/observability/labels.rs
@@ -1,4 +1,4 @@
-use metrics::{IntoLabels, Label, SharedString};
+use metrics::{IntoLabels, Label};
 use std::fmt;
 
 use serde::de::{Deserializer, Error, SeqAccess, Visitor};
@@ -17,13 +17,11 @@ impl Labels {
         Labels(tags)
     }
 
-    pub fn new(
-        labels: &[(
-            impl Into<SharedString> + Clone,
-            impl Into<SharedString> + Clone,
-        )],
-    ) -> Self {
-        Labels(labels.iter().map(Label::from).collect())
+    pub fn new<T>(labels: &[T]) -> Self
+    where
+        Label: for<'a> From<&'a T>,
+    {
+        Labels(labels.into_iter().map(Label::from).collect())
     }
 
     pub const fn empty() -> Self {

--- a/sds/src/observability/labels.rs
+++ b/sds/src/observability/labels.rs
@@ -17,11 +17,11 @@ impl Labels {
         Labels(tags)
     }
 
-    pub fn new<T>(labels: &[T]) -> Self
+    pub fn new<'a, T: 'a>(labels: impl IntoIterator<Item = &'a T>) -> Self
     where
-        Label: for<'a> From<&'a T>,
+        Label: From<&'a T>,
     {
-        Labels(labels.iter().map(Label::from).collect())
+        Labels(labels.into_iter().map(Label::from).collect())
     }
 
     pub const fn empty() -> Self {

--- a/sds/src/observability/labels.rs
+++ b/sds/src/observability/labels.rs
@@ -21,7 +21,7 @@ impl Labels {
     where
         Label: for<'a> From<&'a T>,
     {
-        Labels(labels.into_iter().map(Label::from).collect())
+        Labels(labels.iter().map(Label::from).collect())
     }
 
     pub const fn empty() -> Self {


### PR DESCRIPTION
This allows creating labels from anything that can be converted to a label, rather than 1 specific form