### PR TITLE
Bump go staticcheck the previous version was crashing ...

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test Suite
 on:
   pull_request:
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
   push:
     branches:
       - main
@@ -54,7 +54,7 @@ jobs:
       - name: "Run the Go linter"
         run: |
           cd go
-          go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
+          go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
           export PATH=$PATH:$(go env GOPATH)/bin
           LD_LIBRARY_PATH=../rust/target/release staticcheck ./...
       - name: "Run the Go unit tests"

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@
 
 This is a library of the core SDS (Sensitive Data Scanner) functionality.
 
+


### PR DESCRIPTION
I believe the action we are using has updated its go version and it is no longer compatible with our staticcheck

Added Go 1.23 support 
Staticcheck 2024.1 has full support for iterators / range-over-func. Furthermore, SA1015 will skip any code targeting Go 1.23 or newer, as it is now possible to use time.Tick without leaking memory.