### PR TITLE
Support CustomHttp with several endpoint (eu, us, etc)

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -29,8 +29,8 @@ pub use event::{Event, EventVisitor, VisitStringResult};
 pub use match_action::{MatchAction, PartialRedactDirection};
 
 pub use match_validation::{
-    config::AwsConfig, config::AwsType, config::InternalMatchValidationType,
-    config::MatchValidationType, http_validator::HttpValidatorConfigBuilder,
+    config::AwsConfig, config::AwsType, config::HttpValidatorConfigBuilder,
+    config::InternalMatchValidationType, config::MatchValidationType,
     http_validator::HttpValidatorHelper, match_status::MatchStatus,
 };
 pub use observability::labels::Labels;

--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -207,15 +207,17 @@ impl MatchValidationType {
             }
         }
     }
-    pub fn into_match_validator(&self) -> Box<dyn MatchValidator> {
+    pub fn into_match_validator(&self) -> Result<Box<dyn MatchValidator>, String> {
         match self {
             MatchValidationType::Aws(aws_type) => match aws_type {
-                AwsType::AwsSecret(aws_config) => Box::new(AwsValidator::new(aws_config.clone())),
-                _ => panic!("This aws type shall not be used to create a validator"),
+                AwsType::AwsSecret(aws_config) => {
+                    Ok(Box::new(AwsValidator::new(aws_config.clone())))
+                }
+                _ => Err("This aws type shall not be used to create a validator".to_string()),
             },
-            MatchValidationType::CustomHttp(http_config) => {
-                Box::new(HttpValidator::new_from_config(http_config.clone()))
-            }
+            MatchValidationType::CustomHttp(http_config) => Ok(Box::new(
+                HttpValidator::new_from_config(http_config.clone()),
+            )),
         }
     }
 }

--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -74,7 +74,7 @@ pub struct HttpValidatorConfig {
 }
 
 impl HttpValidatorConfig {
-    pub fn new(endpoint: &str, hosts: Vec<String>) -> Result<Self, String> {
+    fn new(endpoint: &str, hosts: Vec<String>) -> Result<Self, String> {
         // Handle errors cases
         // - endpoint contains $HOST but no hosts are provided
         // - endpoint does not contain $HOST but hosts are provided
@@ -106,6 +106,77 @@ impl HttpValidatorConfig {
                 timeout: Duration::from_secs(DEFAULT_HTTPS_TIMEOUT_SEC),
             },
         })
+    }
+}
+
+pub struct HttpValidatorConfigBuilder {
+    endpoint: String,
+    hosts: Vec<String>,
+    method: HttpMethod,
+    request_header: Vec<RequestHeader>,
+    valid_http_status_code: Vec<Range<u16>>,
+    invalid_http_status_code: Vec<Range<u16>>,
+    options: HttpValidatorOption,
+}
+
+impl HttpValidatorConfigBuilder {
+    pub fn new(endpoint: String) -> Self {
+        HttpValidatorConfigBuilder {
+            endpoint,
+            hosts: vec![],
+            method: HttpMethod::Get,
+            request_header: vec![RequestHeader {
+                key: "Authorization".to_string(),
+                value: "Bearer $MATCH".to_string(),
+            }],
+            #[allow(clippy::single_range_in_vec_init)]
+            valid_http_status_code: vec![200..300],
+            #[allow(clippy::single_range_in_vec_init)]
+            invalid_http_status_code: vec![400..500],
+            options: HttpValidatorOption {
+                timeout: Duration::from_secs(DEFAULT_HTTPS_TIMEOUT_SEC),
+            },
+        }
+    }
+    pub fn set_request_header(&mut self, request_header: Vec<RequestHeader>) -> &mut Self {
+        self.request_header = request_header;
+        self
+    }
+    pub fn set_hosts(&mut self, hosts: Vec<String>) -> &mut Self {
+        self.hosts = hosts;
+        self
+    }
+    pub fn set_method(&mut self, method: HttpMethod) -> &mut Self {
+        self.method = method;
+        self
+    }
+    pub fn set_valid_http_status_code(
+        &mut self,
+        valid_http_status_code: Vec<Range<u16>>,
+    ) -> &mut Self {
+        self.valid_http_status_code = valid_http_status_code;
+        self
+    }
+    pub fn set_invalid_http_status_code(
+        &mut self,
+        invalid_http_status_code: Vec<Range<u16>>,
+    ) -> &mut Self {
+        self.invalid_http_status_code = invalid_http_status_code;
+        self
+    }
+    pub fn set_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.options.timeout = timeout;
+        self
+    }
+    pub fn build(&self) -> Result<HttpValidatorConfig, String> {
+        let mut config = HttpValidatorConfig::new(self.endpoint.as_str(), self.hosts.clone())?;
+        config.invalid_http_status_code = self.invalid_http_status_code.clone();
+        config.method = self.method.clone();
+        config.request_header = self.request_header.clone();
+        config.valid_http_status_code = self.valid_http_status_code.clone();
+        config.options = self.options.clone();
+        config.invalid_http_status_code = self.invalid_http_status_code.clone();
+        Ok(config)
     }
 }
 
@@ -181,6 +252,25 @@ mod tests {
         assert_eq!(
             config,
             "Endpoint does not contain $HOST but hosts are provided".to_string()
+        );
+    }
+    #[test]
+    fn test_http_validator_builder_config_no_hosts() {
+        let config = HttpValidatorConfigBuilder::new("http://localhost/test".to_string())
+            .build()
+            .unwrap();
+        assert_eq!(config.endpoints, vec!["http://localhost/test"]);
+    }
+
+    #[test]
+    fn test_http_validator_builder_config_with_hosts() {
+        let config = HttpValidatorConfigBuilder::new("http://localhost/$HOST".to_string())
+            .set_hosts(vec!["us".to_string(), "eu".to_string()])
+            .build()
+            .unwrap();
+        assert_eq!(
+            config.endpoints,
+            vec!["http://localhost/us", "http://localhost/eu"]
         );
     }
 }

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -170,8 +170,7 @@ impl MatchValidator for HttpValidator {
             |((match_idx, endpoint), match_status)| {
                 let match_value = matches[*match_idx].match_value.as_ref().unwrap();
                 async move {
-                    let mut request_builder: reqwest::RequestBuilder;
-                    request_builder = match self.config.method {
+                    let mut request_builder = match self.config.method {
                         HttpMethod::Get => HTTP_CLIENT.get(*endpoint),
                         HttpMethod::Post => HTTP_CLIENT.post(*endpoint),
                         HttpMethod::Put => HTTP_CLIENT.put(*endpoint),

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -184,7 +184,6 @@ impl MatchValidator for HttpValidator {
                             request_builder = HTTP_CLIENT.patch(*endpoint);
                         }
                     }
-                    // Set timeout
                     request_builder = request_builder.timeout(self.config.options.timeout);
 
                     // Add headers

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -229,7 +229,7 @@ impl MatchValidator for HttpValidator {
         // Wait for all result to complete
         let _ = join_all(futures).await;
 
-        // Update the match status
+        // Update the match status with this highest priority returned
         for ((match_idx, _), status) in match_status_per_endpoint_and_match {
             matches[match_idx].match_status.merge(status.clone());
         }

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -152,7 +152,7 @@ impl HttpValidatorHelper {
 #[async_trait]
 impl MatchValidator for HttpValidator {
     async fn validate(&self, matches: &mut Vec<RuleMatch>, _: &[Box<dyn CompiledRuleDyn>]) {
-        // let's build a map of match status per endpoint and per match_idx
+        // build a map of match status per endpoint and per match_idx
         let mut match_status_per_endpoint_and_match = AHashMap::new();
         for (idx, _) in matches.iter().enumerate() {
             for endpoint in &self.config.endpoints {

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -19,10 +19,8 @@ pub struct HttpValidator {
 }
 
 impl HttpValidator {
-    pub fn new_clone_config(config: &HttpValidatorConfig) -> Self {
-        HttpValidator {
-            config: config.clone(),
-        }
+    pub fn new_from_config(config: HttpValidatorConfig) -> Self {
+        HttpValidator { config }
     }
 }
 

--- a/sds/src/match_validation/validator_utils.rs
+++ b/sds/src/match_validation/validator_utils.rs
@@ -14,7 +14,7 @@ pub fn new_match_validator_from_type(config: &MatchValidationType) -> Box<dyn Ma
             _ => panic!("This aws type shall not be used to create a validator"),
         },
         MatchValidationType::CustomHttp(http_config) => {
-            Box::new(HttpValidator::new(http_config.clone()))
+            Box::new(HttpValidator::new_clone_config(http_config))
         }
     }
 }

--- a/sds/src/match_validation/validator_utils.rs
+++ b/sds/src/match_validation/validator_utils.rs
@@ -1,24 +1,5 @@
 use chrono::{DateTime, Utc};
 
-use crate::AwsType;
-
-use super::{
-    aws_validator::AwsValidator, config::MatchValidationType, http_validator::HttpValidator,
-    match_validator::MatchValidator,
-};
-
-pub fn new_match_validator_from_type(config: &MatchValidationType) -> Box<dyn MatchValidator> {
-    match config {
-        MatchValidationType::Aws(aws_config) => match aws_config {
-            AwsType::AwsSecret(aws_config) => Box::new(AwsValidator::new(aws_config.clone())),
-            _ => panic!("This aws type shall not be used to create a validator"),
-        },
-        MatchValidationType::CustomHttp(http_config) => {
-            Box::new(HttpValidator::new_clone_config(http_config))
-        }
-    }
-}
-
 pub fn generate_aws_headers_and_body(
     datetime: &DateTime<Utc>,
     endpoint: &str,

--- a/sds/src/scanner/error.rs
+++ b/sds/src/scanner/error.rs
@@ -12,8 +12,15 @@ impl From<CreateScannerError> for i64 {
             CreateScannerError::InvalidRegex(_) => -2,
             CreateScannerError::InvalidKeywords(_) => -3,
             CreateScannerError::InvalidMatchAction(_) => -4,
+            CreateScannerError::InvalidMatchValidator(_) => -5,
         }
     }
+}
+
+#[derive(Debug, PartialEq, Eq, Error)]
+pub enum MatchValidatorCreationError {
+    #[error("Internal error while creating the match validator")]
+    InternalError,
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -27,6 +34,9 @@ pub enum CreateScannerError {
     /// Invalid configuration of a match action
     #[error(transparent)]
     InvalidMatchAction(#[from] MatchActionValidationError),
+    /// The match validator cannot be created
+    #[error(transparent)]
+    InvalidMatchValidator(#[from] MatchValidatorCreationError),
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -2286,7 +2286,7 @@ mod test {
 
     #[test]
     fn test_should_allocate_match_validator_depending_on_match_type() {
-        use crate::match_validation::config::{AwsConfig, HttpValidatorConfig};
+        use crate::match_validation::config::AwsConfig;
 
         let rule_aws_id = RegexRuleConfig::new("aws-id")
             .match_action(MatchAction::Redact {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -790,7 +790,7 @@ mod test {
 
     use crate::match_validation::config::{AwsConfig, AwsType, MatchValidationType};
 
-    use crate::match_validation::http_validator::HttpValidatorConfigBuilder;
+    use crate::match_validation::config::HttpValidatorConfigBuilder;
     use crate::match_validation::validator_utils::generate_aws_headers_and_body;
     use crate::observability::labels::Labels;
     use crate::scanner::regex_rule::config::{

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -3,7 +3,7 @@ use crate::event::Event;
 
 use crate::match_validation::{
     config::InternalMatchValidationType, config::MatchValidationType, match_status::MatchStatus,
-    match_validator::MatchValidator, validator_utils::new_match_validator_from_type,
+    match_validator::MatchValidator,
 };
 
 use error::MatchValidationError;
@@ -596,10 +596,8 @@ impl ScannerBuilder<'_> {
                 if match_validation_type.can_create_match_validator() {
                     let internal_type = match_validation_type.get_internal_match_validation_type();
                     if !match_validators_per_type.contains_key(&internal_type) {
-                        match_validators_per_type.insert(
-                            internal_type,
-                            new_match_validator_from_type(match_validation_type),
-                        );
+                        match_validators_per_type
+                            .insert(internal_type, match_validation_type.into_match_validator());
                         // Let's add return_matches to the scanner features
                         scanner_features.return_matches = true;
                     }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -2244,16 +2244,15 @@ mod test {
 
     #[test]
     fn test_should_return_match_with_match_validation() {
-        use crate::match_validation::config::HttpValidatorConfig;
-
         let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("world")
             .match_action(MatchAction::Redact {
                 replacement: "[REDACTED]".to_string(),
             })
-            .match_validation_type(MatchValidationType::CustomHttp(HttpValidatorConfig::new(
-                "http://localhost:8080",
-                vec![],
-            )))
+            .match_validation_type(MatchValidationType::CustomHttp(
+                HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
+                    .build()
+                    .unwrap(),
+            ))
             .build()])
         .build()
         .unwrap();
@@ -2308,30 +2307,33 @@ mod test {
             .match_action(MatchAction::Redact {
                 replacement: "[CUSTOM HTTP1]".to_string(),
             })
-            .match_validation_type(MatchValidationType::CustomHttp(HttpValidatorConfig::new(
-                "http://localhost:8080",
-                vec![],
-            )))
+            .match_validation_type(MatchValidationType::CustomHttp(
+                HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
+                    .build()
+                    .unwrap(),
+            ))
             .build();
 
         let rule_custom_http_2_domain_1 = RegexRuleConfig::new("custom-http2")
             .match_action(MatchAction::Redact {
                 replacement: "[CUSTOM HTTP2]".to_string(),
             })
-            .match_validation_type(MatchValidationType::CustomHttp(HttpValidatorConfig::new(
-                "http://localhost:8080",
-                vec![],
-            )))
+            .match_validation_type(MatchValidationType::CustomHttp(
+                HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
+                    .build()
+                    .unwrap(),
+            ))
             .build();
 
         let rule_custom_http_domain_2 = RegexRuleConfig::new("custom-http3")
             .match_action(MatchAction::Redact {
                 replacement: "[CUSTOM HTTP2]".to_string(),
             })
-            .match_validation_type(MatchValidationType::CustomHttp(HttpValidatorConfig::new(
-                "http://localhost:8081",
-                vec![],
-            )))
+            .match_validation_type(MatchValidationType::CustomHttp(
+                HttpValidatorConfigBuilder::new("http://localhost:8081".to_string())
+                    .build()
+                    .unwrap(),
+            ))
             .build();
 
         let scanner = ScannerBuilder::new(&[
@@ -2422,7 +2424,9 @@ mod test {
                 replacement: "[VALID]".to_string(),
             })
             .match_validation_type(MatchValidationType::CustomHttp(
-                HttpValidatorConfigBuilder::new(server.url("/").to_string()).build(),
+                HttpValidatorConfigBuilder::new(server.url("/").to_string())
+                    .build()
+                    .unwrap(),
             ))
             .build();
 
@@ -2431,7 +2435,9 @@ mod test {
                 replacement: "[INVALID]".to_string(),
             })
             .match_validation_type(MatchValidationType::CustomHttp(
-                HttpValidatorConfigBuilder::new(server.url("/").to_string()).build(),
+                HttpValidatorConfigBuilder::new(server.url("/").to_string())
+                    .build()
+                    .unwrap(),
             ))
             .build();
 
@@ -2440,7 +2446,9 @@ mod test {
                 replacement: "[ERROR]".to_string(),
             })
             .match_validation_type(MatchValidationType::CustomHttp(
-                HttpValidatorConfigBuilder::new(server.url("/").to_string()).build(),
+                HttpValidatorConfigBuilder::new(server.url("/").to_string())
+                    .build()
+                    .unwrap(),
             ))
             .build();
         let scanner =
@@ -2484,7 +2492,8 @@ mod test {
             .match_validation_type(MatchValidationType::CustomHttp(
                 HttpValidatorConfigBuilder::new(server.url("/").to_string())
                     .set_timeout(Duration::from_micros(0))
-                    .build(),
+                    .build()
+                    .unwrap(),
             ))
             .build();
 
@@ -2522,7 +2531,9 @@ mod test {
                 replacement: "[VALID]".to_string(),
             })
             .match_validation_type(MatchValidationType::CustomHttp(
-                HttpValidatorConfigBuilder::new(server.url("/http-service").to_string()).build(),
+                HttpValidatorConfigBuilder::new(server.url("/http-service").to_string())
+                    .build()
+                    .unwrap(),
             ))
             .build();
 
@@ -2581,9 +2592,10 @@ mod test {
                 replacement: "[VALID]".to_string(),
             })
             .match_validation_type(MatchValidationType::CustomHttp(
-                HttpValidatorConfigBuilder::new(server.url("/$HOSTS-service").to_string())
+                HttpValidatorConfigBuilder::new(server.url("/$HOST-service").to_string())
                     .set_hosts(vec!["us".to_string(), "eu".to_string()])
-                    .build(),
+                    .build()
+                    .unwrap(),
             ))
             .build();
 


### PR DESCRIPTION
[JIRA](https://datadoghq.atlassian.net/browse/SDS-382)

This PR comes from a comment made by @vinckama about how we would support CustomHttp with multiple domain such   as datadog with api1, eu1, us1, us3, us5 etc ....
The basic idea here is that we would add a pattern in the endpoint **$HOST** that would be replaced by all the hosts in the hosts items
i.e. If we had
endpoint: https://$HOST/api/v1/validate
hosts:
  - api.datadoghq.com
  - api.datadoghq.eu
  
We would try the match on https://api.datadoghq.com and https://api.datadoghq.eu