### PR TITLE
Match Validation: Extract AWS Secret access key from the match to support current and future aws rule

### DIFF
--- a/sds/src/match_validation/aws_validator.rs
+++ b/sds/src/match_validation/aws_validator.rs
@@ -16,6 +16,9 @@ use super::{
 
 lazy_static! {
     static ref AWS_CLIENT: Client = Client::new();
+    // Right now the regex matched the secret key with extra characters, this regex aims to extract the secret key only
+    static ref AWS_SECRET_REGEX: regex::Regex =
+        regex::Regex::new(r"([A-Za-z0-9\/+]{40})\b").unwrap();
 }
 
 pub struct AwsValidator {
@@ -26,6 +29,14 @@ impl AwsValidator {
     pub fn new(config: AwsConfig) -> Self {
         AwsValidator { config }
     }
+}
+
+fn extract_aws_secret_from_match(match_value: &str) -> String {
+    let caps = AWS_SECRET_REGEX.captures(match_value);
+    if let Some(caps) = caps {
+        return caps[1].to_string();
+    }
+    return "".to_string();
 }
 
 #[async_trait]
@@ -70,9 +81,22 @@ impl MatchValidator for AwsValidator {
         // Let's try all combination of aws_id and aws_secret
         let futures = match_status_per_pairs_of_matches_idx.iter_mut().map(
             |((id_index, secret_index), match_status)| {
-                let match_id = &matches[*id_index];
-                let match_secret = &matches[*secret_index];
+                let match_id = &matches[*id_index].match_value;
+                let match_secret = &matches[*secret_index].match_value;
                 async move {
+                    if match_secret.is_none() {
+                        *match_status =
+                            MatchStatus::Error(format!("Missing match value for aws_secret"));
+                        return;
+                    }
+                    if match_id.is_none() {
+                        *match_status =
+                            MatchStatus::Error(format!("Missing match value for aws_id"));
+                        return;
+                    }
+                    let match_secret =
+                        extract_aws_secret_from_match(match_secret.as_ref().unwrap());
+                    let match_id = match_id.as_ref().unwrap();
                     // Let's reqwest the HTTP API endpoint to validate the matches
                     let mut datetime = chrono::Utc::now();
                     if self.config.forced_datetime_utc.is_some() {
@@ -81,8 +105,8 @@ impl MatchValidator for AwsValidator {
                     let (body, headers) = generate_aws_headers_and_body(
                         &datetime,
                         &self.config.aws_sts_endpoint,
-                        match_id.match_value.as_ref().unwrap(),
-                        match_secret.match_value.as_ref().unwrap(),
+                        match_id,
+                        &match_secret,
                     );
                     let res = AWS_CLIENT
                         .post(self.config.aws_sts_endpoint.as_str())
@@ -140,5 +164,30 @@ impl MatchValidator for AwsValidator {
                     .merge(match_status.clone());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_aws_secret_from_match() {
+        assert_eq!(
+            extract_aws_secret_from_match(
+                "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            ),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        );
+        assert_eq!(
+            extract_aws_secret_from_match(
+                "aws_secret_access_key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            ),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        );
+        assert_eq!(
+            extract_aws_secret_from_match("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        );
     }
 }

--- a/sds/src/match_validation/aws_validator.rs
+++ b/sds/src/match_validation/aws_validator.rs
@@ -36,7 +36,7 @@ fn extract_aws_secret_from_match(match_value: &str) -> String {
     if let Some(caps) = caps {
         return caps[1].to_string();
     }
-    return "".to_string();
+    "".to_string()
 }
 
 #[async_trait]
@@ -86,12 +86,12 @@ impl MatchValidator for AwsValidator {
                 async move {
                     if match_secret.is_none() {
                         *match_status =
-                            MatchStatus::Error(format!("Missing match value for aws_secret"));
+                            MatchStatus::Error("Missing match value for aws_secret".to_string());
                         return;
                     }
                     if match_id.is_none() {
                         *match_status =
-                            MatchStatus::Error(format!("Missing match value for aws_id"));
+                            MatchStatus::Error("Missing match value for aws_id".to_string());
                         return;
                     }
                     let match_secret =


### PR DESCRIPTION
[JIRA](https://datadoghq.atlassian.net/browse/SDS-548)
Current AWS Secret access key standard rule extract more than the secret.
This is done in order to reduce false positive. 

It first detect the presence of a char like this [^A-Za-z0-9/+]

This PR aims to extract the secret only before using it to create AWS signature in the futures.

Ideally this should be fixed in the regex itself using capture groups, but this is not implemented yet. In order to unlock match validation feature I implemented here. 
It should work even when the capture will be implemented