### PR TITLE
Add `gofmt` & `go mod tidy` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,9 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
           export PATH=$PATH:$(go env GOPATH)/bin
           LD_LIBRARY_PATH=../rust/target/release staticcheck ./...
+          gofmt -s -w . && git diff --exit-code
+          # Replace the gofmt command above by `gofmt -s -d .` when the following is resolved https://github.com/golang/go/issues/46289
+          go mod tidy -diff
       - name: "Run the Go unit tests"
         run: |
           cd go

--- a/sds-go/go/regex_rule.go
+++ b/sds-go/go/regex_rule.go
@@ -8,8 +8,8 @@ import "C"
 
 import (
 	"encoding/json"
-	"unsafe"
 	"fmt"
+	"unsafe"
 )
 
 type RegexRuleConfig struct {


### PR DESCRIPTION
Add `gofmt` and `go mod tidy` in the CI to make sure go files are always formatted. Before fixing formatting, the [CI failed](https://github.com/DataDog/dd-sensitive-data-scanner/actions/runs/11818928119/job/32927650824), it demonstrates that the formatter works as expected:

<img width="1090" alt="Screenshot 2024-11-13 at 15 08 56" src="https://github.com/user-attachments/assets/830a06fc-9f30-40d5-b6ef-fd366c4b5676">
