### PR TITLE
Add support for a group_config object that is created a scanner build time and provided to each get_string_matches 

### DIFF
--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -32,6 +32,7 @@ pub struct RegexCompiledRule {
 impl CompiledRule for RegexCompiledRule {
     // no special data
     type GroupData = ();
+    type GroupConfig = ();
 
     fn get_match_action(&self) -> &MatchAction {
         &self.match_action
@@ -40,6 +41,7 @@ impl CompiledRule for RegexCompiledRule {
         &self.scope
     }
     fn create_group_data(_: &Labels) {}
+    fn create_group_config() {}
     fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
         self.included_keywords.as_ref()
     }
@@ -49,6 +51,7 @@ impl CompiledRule for RegexCompiledRule {
         content: &str,
         regex_caches: &mut RegexCaches,
         _group_data: &mut (),
+        _group_config: &(),
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
@@ -102,6 +105,9 @@ impl CompiledRule for RegexCompiledRule {
             Some(internal_match_validation_type) => Some(internal_match_validation_type),
             None => None,
         }
+    }
+    fn process_scanner_config(&self, _: &mut Self::GroupConfig) {
+        // no special processing
     }
 }
 


### PR DESCRIPTION
This is largely inspired from the group_data implementation.

The basic idea is that we create the group_config in the `CompiledRuleDyn.process_scanner_config` that is done during scanner build time, so each rule can define their own group and store group specific configuration data 

This group_config is then pass down to the get_string_matches of each CompiledRule so they can have access to it if it exists (there is no GroupConfig for CompiledRegexRule as this is intended for MLRules (they will register in it which feature they need to compute)

[JIRA](https://datadoghq.atlassian.net/browse/SDS-602)