### PR TITLE
Add Rule Scan cache that can be reused during a scan by each rule

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -20,8 +20,9 @@ mod secondary_validation;
 mod stats;
 mod validation;
 
-#[cfg(any(test, feature = "testing", feature = "bench"))]
 mod simple_event;
+
+pub use simple_event::SimpleEvent;
 
 // This is the public API of the SDS core library
 pub use encoding::{EncodeIndices, Encoding, Utf8Encoding};
@@ -56,5 +57,4 @@ pub use validation::{
 pub use crate::{
     scoped_ruleset::{ContentVisitor, RuleIndexVisitor, ScopedRuleSet},
     secondary_validation::{LuhnChecksum, Validator},
-    simple_event::SimpleEvent,
 };

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -9,7 +9,7 @@ use crate::scanner::regex_rule::RegexCaches;
 use crate::scanner::scope::Scope;
 use crate::scanner::{get_next_regex_start, is_false_positive_match};
 use crate::secondary_validation::Validator;
-use crate::{CompiledRule, ExclusionCheck, Labels, MatchAction, MatchEmitter, StringMatch};
+use crate::{CompiledRule, ExclusionCheck, Labels, MatchAction, MatchEmitter, Path, StringMatch};
 use ahash::AHashSet;
 use regex_automata::meta::Cache;
 use regex_automata::Input;
@@ -33,6 +33,7 @@ impl CompiledRule for RegexCompiledRule {
     // no special data
     type GroupData = ();
     type GroupConfig = ();
+    type RuleScanCache = ();
 
     fn get_match_action(&self) -> &MatchAction {
         &self.match_action
@@ -42,6 +43,7 @@ impl CompiledRule for RegexCompiledRule {
     }
     fn create_group_data(_: &Labels) {}
     fn create_group_config() {}
+    fn create_rule_scan_cache() {}
     fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
         self.included_keywords.as_ref()
     }
@@ -49,9 +51,11 @@ impl CompiledRule for RegexCompiledRule {
     fn get_string_matches(
         &self,
         content: &str,
+        _path: &Path,
         regex_caches: &mut RegexCaches,
         _group_data: &mut (),
         _group_config: &(),
+        _rule_scan_cache: &mut (),
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -32,6 +32,7 @@ pub struct RegexCompiledRule {
 impl CompiledRule for RegexCompiledRule {
     // no special data
     type GroupData = ();
+    type GroupConfig = ();
 
     fn get_match_action(&self) -> &MatchAction {
         &self.match_action
@@ -40,6 +41,7 @@ impl CompiledRule for RegexCompiledRule {
         &self.scope
     }
     fn create_group_data(_: &Labels) {}
+    fn create_group_config() {}
     fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
         self.included_keywords.as_ref()
     }
@@ -49,6 +51,7 @@ impl CompiledRule for RegexCompiledRule {
         content: &str,
         regex_caches: &mut RegexCaches,
         _group_data: &mut (),
+        _group_config: &(),
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
@@ -102,6 +105,9 @@ impl CompiledRule for RegexCompiledRule {
             Some(internal_match_validation_type) => Some(internal_match_validation_type),
             None => None,
         }
+    }
+    fn process_scanner_config(&self, _: &mut Self::GroupConfig) {
+        // no special processing
     }
 }
 


### PR DESCRIPTION
This introduces the notion of scan_rule_cache, that is allocated once per scan and shared between rules
Same logic that for group_config and group_cache

[JIRA_TICKET](https://datadoghq.atlassian.net/browse/SDS-335)