### PR TITLE
✨ Improve overall included keywords performance

### DIFF
--- a/sds/src/proximity_keywords/included_keywords.rs
+++ b/sds/src/proximity_keywords/included_keywords.rs
@@ -30,19 +30,6 @@ impl<'a> IncludedKeywordSearch<'a> {
         }
     }
 
-    pub fn is_empty(&self, regex_caches: &mut RegexCaches) -> bool {
-        let input = Input::new(self.content).range(self.start..).earliest(true);
-
-        self.keywords
-            .keywords_pattern
-            .content_regex
-            .search_with(
-                regex_caches.get(&self.keywords.keywords_pattern.content_regex),
-                &input,
-            )
-            .is_none()
-    }
-
     pub fn next(&mut self, regex_caches: &mut RegexCaches) -> Option<usize> {
         let input = Input::new(self.content).range(self.start..).earliest(true);
 

--- a/sds/src/proximity_keywords/included_keywords.rs
+++ b/sds/src/proximity_keywords/included_keywords.rs
@@ -30,6 +30,19 @@ impl<'a> IncludedKeywordSearch<'a> {
         }
     }
 
+    pub fn is_empty(&self, regex_caches: &mut RegexCaches) -> bool {
+        let input = Input::new(self.content).range(self.start..).earliest(true);
+
+        self.keywords
+            .keywords_pattern
+            .content_regex
+            .search_with(
+                regex_caches.get(&self.keywords.keywords_pattern.content_regex),
+                &input,
+            )
+            .is_none()
+    }
+
     pub fn next(&mut self, regex_caches: &mut RegexCaches) -> Option<usize> {
         let input = Input::new(self.content).range(self.start..).earliest(true);
 

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -2255,6 +2255,29 @@ mod test {
     }
 
     #[test]
+    fn should_verify_included_keywords_on_path_even_if_included_keywords_are_in_string() {
+        let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("world")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 10,
+                included_keywords: vec!["hello".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build()])
+        .with_keywords_should_match_event_paths(true)
+        .build()
+        .unwrap();
+
+        let mut event = SimpleEvent::Map(BTreeMap::from([(
+            "hello".to_string(),
+            SimpleEvent::String("hello [more than ten characters] world".to_string()),
+        )]));
+
+        // Even though the included keywords are too far from the match in the string
+        // the keyword is present in the path and that should validate the match.
+        assert_eq!(scanner.scan(&mut event, vec![]).len(), 1);
+    }
+
+    #[test]
     fn test_included_and_excluded_keyword() {
         let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("world")
             .proximity_keywords(ProximityKeywordsConfig {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -1936,9 +1936,6 @@ mod test {
         ]));
 
         let matches = scanner.scan(&mut content, vec![]);
-
-        // The match from the "test" field (which is excluded) is the same as the match from "message", so it is
-        // treated as a false positive.
         assert_eq!(matches.len(), 1);
     }
 

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -79,7 +79,6 @@ pub trait CompiledRuleDyn: Send + Sync {
         match_emitter: &mut dyn MatchEmitter,
         true_positive_rule_idx: &[usize],
         scanner_labels: &Labels,
-        path: &Path,
         should_kws_match_event_paths: bool,
     );
 
@@ -133,7 +132,6 @@ impl<T: CompiledRule> CompiledRuleDyn for T {
         match_emitter: &mut dyn MatchEmitter,
         true_positive_rule_idx: &[usize],
         scanner_labels: &Labels,
-        path: &Path,
         should_kws_match_event_paths: bool,
     ) {
         let group_data_any = group_data
@@ -160,7 +158,6 @@ impl<T: CompiledRule> CompiledRuleDyn for T {
             excluded_matches,
             match_emitter,
             true_positive_rule_idx,
-            path,
             should_kws_match_event_paths,
         )
     }
@@ -235,7 +232,6 @@ pub trait CompiledRule: Send + Sync {
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
         true_positive_rule_idx: &[usize],
-        path: &Path,
         should_kws_match_event_paths: bool,
     );
 
@@ -774,7 +770,6 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
                     &mut emitter,
                     true_positive_rule_idx,
                     &self.scanner.labels,
-                    path,
                     self.scanner
                         .scanner_features
                         .should_keywords_match_event_paths,
@@ -931,7 +926,6 @@ mod test {
             _excluded_matches: &mut AHashSet<String>,
             match_emitter: &mut dyn MatchEmitter,
             _true_positive_rule_idx: &[usize],
-            _path: &Path,
             _should_kws_match_event_paths: bool,
         ) {
             match_emitter.emit(StringMatch { start: 10, end: 16 });

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -76,6 +76,8 @@ pub trait CompiledRuleDyn: Send + Sync {
         match_emitter: &mut dyn MatchEmitter,
         true_positive_rule_idx: &[usize],
         scanner_labels: &Labels,
+        path: &Path,
+        should_kws_match_event_paths: bool,
     );
 
     // Whether a match from this rule should be excluded (marked as a false-positive)
@@ -120,6 +122,8 @@ impl<T: CompiledRule> CompiledRuleDyn for T {
         match_emitter: &mut dyn MatchEmitter,
         true_positive_rule_idx: &[usize],
         scanner_labels: &Labels,
+        path: &Path,
+        should_kws_match_event_paths: bool,
     ) {
         let group_data_any = group_data
             .entry(TypeId::of::<T::GroupData>())
@@ -133,6 +137,8 @@ impl<T: CompiledRule> CompiledRuleDyn for T {
             excluded_matches,
             match_emitter,
             true_positive_rule_idx,
+            path,
+            should_kws_match_event_paths,
         )
     }
 
@@ -178,6 +184,8 @@ pub trait CompiledRule: Send + Sync {
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
         true_positive_rule_idx: &[usize],
+        path: &Path,
+        should_kws_match_event_paths: bool,
     );
 
     // Whether a match from this rule should be excluded (marked as a false-positive)
@@ -699,6 +707,10 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
                     &mut emitter,
                     true_positive_rule_idx,
                     &self.scanner.labels,
+                    path,
+                    self.scanner
+                        .scanner_features
+                        .should_keywords_match_event_paths,
                 );
             }
         });
@@ -845,6 +857,8 @@ mod test {
             _excluded_matches: &mut AHashSet<String>,
             match_emitter: &mut dyn MatchEmitter,
             _true_positive_rule_idx: &[usize],
+            _path: &Path,
+            _should_kws_match_event_paths: bool,
         ) {
             match_emitter.emit(StringMatch { start: 10, end: 16 });
         }

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -141,34 +141,7 @@ impl RegexCompiledRule {
 
         let mut included_keyword_matches = included_keywords.keyword_matches(content);
 
-        if included_keyword_matches.is_empty(regex_caches) {
-            if should_kws_match_event_paths {
-                let true_positive_search = self.true_positive_matches(
-                    content,
-                    0,
-                    regex_caches.get(&self.regex),
-                    false,
-                    exclusion_check,
-                    excluded_matches,
-                );
-
-                let mut has_kws_in_path: Option<bool> = None;
-                for string_match in true_positive_search {
-                    // If has_kws_in_path is None, calculate it. We only do it once.
-                    if has_kws_in_path.is_none() {
-                        has_kws_in_path = Some(contains_keyword_in_path(
-                            &path.sanitize(),
-                            &included_keywords.keywords_pattern,
-                        ))
-                    }
-                    // If has_kws_in_path is Some(true), then always emit the match
-                    if has_kws_in_path.is_some_and(|b| b == true) {
-                        match_emitter.emit(string_match);
-                    }
-                }
-            }
-            return;
-        }
+        let mut has_verified_kws_in_path: Option<bool> = None;
 
         'included_keyword_search: while let Some(included_keyword_match_start) =
             included_keyword_matches.next(regex_caches)
@@ -215,6 +188,42 @@ impl RegexCompiledRule {
             // no more "true positive" matches were found in the entire string, so there's no need
             // to continue scanning for included keywords.
             break;
+        }
+
+        if should_kws_match_event_paths && has_verified_kws_in_path.is_none() {
+            let input = Input::new(content);
+
+            {
+                if self
+                    .regex
+                    .search_with(regex_caches.get(&self.regex), &input)
+                    .is_some()
+                {
+                    has_verified_kws_in_path = Some(contains_keyword_in_path(
+                        &path.sanitize(),
+                        &included_keywords.keywords_pattern,
+                    ))
+                }
+            };
+
+            if has_verified_kws_in_path.is_none_or(|x| x == false) {
+                // We don't deal with true positives is in this case, because keywords don't match the path.
+                // Return
+                return;
+            }
+
+            let true_positive_search = self.true_positive_matches(
+                content,
+                0,
+                regex_caches.get(&self.regex),
+                false,
+                exclusion_check,
+                excluded_matches,
+            );
+
+            for string_match in true_positive_search {
+                match_emitter.emit(string_match);
+            }
         }
     }
 

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -51,7 +51,7 @@ impl CompiledRule for RegexCompiledRule {
     fn get_string_matches(
         &self,
         content: &str,
-        _path: &Path,
+        path: &Path,
         regex_caches: &mut RegexCaches,
         _group_data: &mut (),
         _group_config: &(),
@@ -60,20 +60,19 @@ impl CompiledRule for RegexCompiledRule {
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
         true_positive_rule_idx: &[usize],
-        path: &Path,
         should_kws_match_event_paths: bool,
     ) {
         match self.included_keywords {
             Some(ref included_keywords) => {
                 self.get_string_matches_with_included_keywords(
                     content,
+                    path,
                     regex_caches,
                     exclusion_check,
                     excluded_matches,
                     match_emitter,
                     true_positive_rule_idx,
                     included_keywords,
-                    path,
                     should_kws_match_event_paths,
                 );
             }
@@ -124,13 +123,13 @@ impl RegexCompiledRule {
     fn get_string_matches_with_included_keywords(
         &self,
         content: &str,
+        path: &Path,
         regex_caches: &mut RegexCaches,
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
         true_positive_rule_idx: &[usize],
         included_keywords: &CompiledIncludedProximityKeywords,
-        path: &Path,
         should_kws_match_event_paths: bool,
     ) {
         if true_positive_rule_idx.contains(&self.rule_index) {

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -205,7 +205,7 @@ impl RegexCompiledRule {
                 }
             };
 
-            if has_verified_kws_in_path.is_none_or(|x| !x) {
+            if has_verified_kws_in_path.is_none() || has_verified_kws_in_path.is_some_and(|x| !x) {
                 // We don't deal with true positives is in this case, because keywords don't match the path.
                 // Return early.
                 return;

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -141,8 +141,6 @@ impl RegexCompiledRule {
 
         let mut included_keyword_matches = included_keywords.keyword_matches(content);
 
-        let mut has_verified_kws_in_path: Option<bool> = None;
-
         'included_keyword_search: while let Some(included_keyword_match_start) =
             included_keyword_matches.next(regex_caches)
         {
@@ -190,10 +188,11 @@ impl RegexCompiledRule {
             break;
         }
 
-        if should_kws_match_event_paths && has_verified_kws_in_path.is_none() {
-            let input = Input::new(content);
+        if should_kws_match_event_paths {
+            let mut has_verified_kws_in_path: Option<bool> = None;
 
             {
+                let input = Input::new(content);
                 if self
                     .regex
                     .search_with(regex_caches.get(&self.regex), &input)

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -205,7 +205,7 @@ impl RegexCompiledRule {
                 }
             };
 
-            if has_verified_kws_in_path.is_none_or(|x| x == false) {
+            if has_verified_kws_in_path.is_none_or(|x| !x) {
                 // We don't deal with true positives is in this case, because keywords don't match the path.
                 // Return early.
                 return;

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -207,7 +207,7 @@ impl RegexCompiledRule {
 
             if has_verified_kws_in_path.is_none_or(|x| x == false) {
                 // We don't deal with true positives is in this case, because keywords don't match the path.
-                // Return
+                // Return early.
                 return;
             }
 

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -179,7 +179,6 @@ struct ScopedRuledSetEventVisitor<'a, C> {
     bool_set: Option<BoolSet>,
 
     add_implicit_index_wildcards: bool,
-    // should_keywords_match_event_paths: bool,
 }
 
 impl<'path, C> EventVisitor<'path> for ScopedRuledSetEventVisitor<'path, C>

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -215,8 +215,10 @@ where
         }
 
         // Sanitize the segment and push it. If the segment is an Index, it will push None.
-        self.sanitized_segments_until_node.push(segment.sanitize());
+        // I'm testing another way of performing the included keywords on path, so I simply push None here.
+        self.sanitized_segments_until_node.push(None);
 
+        // I'm testing another way of performing the included keywords on path feature, so this will be cleaned soon.
         let true_positive_rules_count = if false {
             let mut total_len: usize = self
                 .sanitized_segments_until_node

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -217,7 +217,7 @@ where
         // Sanitize the segment and push it. If the segment is an Index, it will push None.
         self.sanitized_segments_until_node.push(segment.sanitize());
 
-        let true_positive_rules_count = if self.should_keywords_match_event_paths {
+        let true_positive_rules_count = if false {
             let mut total_len: usize = self
                 .sanitized_segments_until_node
                 .iter()

--- a/sds/src/scoped_ruleset/mod.rs
+++ b/sds/src/scoped_ruleset/mod.rs
@@ -86,7 +86,7 @@ impl ScopedRuleSet {
             path: Path::root(),
             bool_set,
             add_implicit_index_wildcards: self.add_implicit_index_wildcards,
-            should_keywords_match_event_paths: self.should_keywords_match_event_paths,
+            // should_keywords_match_event_paths: self.should_keywords_match_event_paths,
         };
 
         event.visit_event(&mut visitor)
@@ -179,7 +179,7 @@ struct ScopedRuledSetEventVisitor<'a, C> {
     bool_set: Option<BoolSet>,
 
     add_implicit_index_wildcards: bool,
-    should_keywords_match_event_paths: bool,
+    // should_keywords_match_event_paths: bool,
 }
 
 impl<'path, C> EventVisitor<'path> for ScopedRuledSetEventVisitor<'path, C>


### PR DESCRIPTION
## Description

I realised that the approach we took in order to compute included keywords on path was not the right one.

Each time we push a segment (e.g. we go down in the event tree), we would sanitize the segment and try to see if the current path is validated or not for the rules' keywords.

It seems good, but actually it's not that great for two reasons:
- push segment happens a LOT on big events, making the overall performance degrade
- the included keywords are often NOT found in the current path, so we don't often bypass more heavy computations.

Instead:
- Let's move that computation to the very end of the scanning. Once we have emitted our true positives regarding to the included keywords in the string, let's find out if the there's a match in the string, and if so, let's compute the included keywords on path at that point. 

This strategy results in a substantial improvement on real world events! 

## Benchmarks

Main vs This branch

### shared library benchmarks (real world *big* span event ~2MB)

On main:

```
     Running benches/sds.rs (target/release/deps/sds-9a7c6dad4b02cf69)
Gnuplot not found, using plotters backend
big_event_included_keywords_on_path_off
                        time:   [35.939 ms 36.271 ms 36.660 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

Benchmarking big_event_included_keywords_on_path_on: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.1s, or reduce sample count to 40.
big_event_included_keywords_on_path_on
                        time:   [98.189 ms 98.501 ms 98.836 ms]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

On this branch:

```
     Running benches/sds.rs (target/release/deps/sds-b5ace305b04f8d29)
Gnuplot not found, using plotters backend
big_event_included_keywords_on_path_off
                        time:   [36.495 ms 36.657 ms 36.844 ms]
                        change: [-0.1288% +1.0666% +2.1116%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  8 (8.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

big_event_included_keywords_on_path_on
                        time:   [47.636 ms 48.042 ms 48.527 ms]
                        change: [-51.663% -51.227% -50.768%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
```

### Main branch benchmarks on dd-sds

```
included_keywords_on_path_off
                        time:   [60.081 µs 61.026 µs 62.310 µs]
                        change: [-3.2420% -0.5737% +1.6214%] (p = 0.69 > 0.05)
                        No change in performance detected.
Found 24 outliers among 100 measurements (24.00%)
  10 (10.00%) low mild
  2 (2.00%) high mild
  12 (12.00%) high severe

included_keywords_on_path_on
                        time:   [136.46 µs 137.06 µs 137.70 µs]
                        change: [-4.5319% -1.7901% +0.2042%] (p = 0.17 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

### This branch benchmarks on dd-sds

```
scoped_rule_set         time:   [32.149 µs 32.184 µs 32.224 µs]
                        change: [-12.660% -7.0428% -2.1688%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) low mild
  3 (3.00%) high mild
  9 (9.00%) high severe

luhn-checksum           time:   [336.91 ns 337.31 ns 337.68 ns]
                        change: [-3.3543% -1.0816% +0.6513%] (p = 0.37 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

Benchmarking included_keywords_worst_case_scenario: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
included_keywords_worst_case_scenario
                        time:   [1.6874 ms 1.6921 ms 1.6978 ms]
                        change: [-4.7202% -3.0063% -1.4866%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe

included_keywords_on_path_off
                        time:   [57.458 µs 57.523 µs 57.600 µs]
                        change: [-5.6357% -4.8079% -4.1553%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) low severe
  3 (3.00%) high mild
  8 (8.00%) high severe

included_keywords_on_path_on
                        time:   [155.70 µs 156.11 µs 156.56 µs]
                        change: [+13.273% +13.704% +14.183%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  8 (8.00%) high mild
  1 (1.00%) high severe

     Running benches/multithreaded_scanning.rs (target/release/deps/multithreaded_scanning-f0e645bdc7e466e2)
Gnuplot not found, using plotters backend
scan single strings (multi-threaded)
                        time:   [31.072 ms 31.792 ms 32.798 ms]
                        change: [+5.1099% +7.6858% +11.244%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

scan large event (multi-threaded)
                        time:   [24.367 ms 24.517 ms 24.692 ms]
                        change: [-2.4204% +1.4664% +4.7031%] (p = 0.46 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

scan single strings (multi-threaded, with included keywords)
                        time:   [17.072 ms 17.223 ms 17.379 ms]
                        change: [-19.350% -9.5141% -2.0866%] (p = 0.04 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

scan large event (multi-threaded, with included keywords)
                        time:   [12.484 ms 12.565 ms 12.654 ms]
                        change: [-5.6081% -2.2952% +0.2478%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

Benchmarking scan single strings (single-threaded): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 18.2s, or reduce sample count to 20.
scan single strings (single-threaded)
                        time:   [186.41 ms 191.53 ms 197.84 ms]
                        change: [-5.4600% -2.0070% +1.7661%] (p = 0.30 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe

Benchmarking scan large event (single-threaded): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 18.8s, or reduce sample count to 20.
scan large event (single-threaded)
                        time:   [191.91 ms 195.57 ms 200.11 ms]
                        change: [+4.4197% +6.6231% +9.0382%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  9 (9.00%) high severe

Benchmarking scan single strings (single-threaded, with included keywords): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.7s, or reduce sample count to 50.
scan single strings (single-threaded, with included keywords)
                        time:   [86.110 ms 86.867 ms 87.855 ms]
                        change: [-5.6535% -3.6020% -1.5894%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

Benchmarking scan large event (single-threaded, with included keywords): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.3s, or reduce sample count to 50.
scan large event (single-threaded, with included keywords)
                        time:   [89.517 ms 92.684 ms 97.334 ms]
                        change: [-11.004% -5.5524% +0.4003%] (p = 0.07 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```

