### PR TITLE
Implement Event trait for an Hashmap<String, Value> type (for serde_json)

### DIFF
--- a/sds/src/event.rs
+++ b/sds/src/event.rs
@@ -1,7 +1,3 @@
-use core::panic;
-use std::collections::HashMap;
-use std::hash::RandomState;
-
 use crate::encoding::{Encoding, Utf8Encoding};
 use crate::path::Path;
 use crate::PathSegment;
@@ -47,90 +43,8 @@ impl Event for String {
     }
 }
 
-impl Event for serde_json::Value {
-    type Encoding = Utf8Encoding;
-
-    fn visit_event<'a>(&'a mut self, visitor: &mut impl EventVisitor<'a>) {
-        match self {
-            serde_json::Value::Null => {}
-            serde_json::Value::Bool(value) => {
-                let _result = visitor.visit_string(value.to_string().as_str());
-            }
-            serde_json::Value::Number(number) => {
-                let _result = visitor.visit_string(number.to_string().as_str());
-            }
-            serde_json::Value::String(s) => {
-                let _result = visitor.visit_string(s);
-            }
-            serde_json::Value::Object(map) => {
-                for (k, child) in map.iter_mut() {
-                    visitor.push_segment(k.as_str().into());
-                    child.visit_event(visitor);
-                    visitor.pop_segment();
-                }
-            }
-            serde_json::Value::Array(values) => {
-                for (i, value) in values.iter_mut().enumerate() {
-                    visitor.push_segment(PathSegment::Index(i));
-                    value.visit_event(visitor);
-                    visitor.pop_segment();
-                }
-            }
-        }
-    }
-
-    fn visit_string_mut(&mut self, path: &Path, mut visit: impl FnMut(&mut String) -> bool) {
-        let mut value = self;
-        for segment in &path.segments {
-            match segment {
-                PathSegment::Field(key) => {
-                    value = value
-                        .as_object_mut()
-                        .unwrap()
-                        .get_mut(key.as_ref())
-                        .unwrap();
-                }
-                PathSegment::Index(i) => {
-                    value = value.as_array_mut().unwrap().get_mut(*i).unwrap();
-                }
-            }
-        }
-        match value {
-            serde_json::Value::String(s) => {
-                (visit)(s);
-            }
-            _ => panic!("unknown value"),
-        };
-    }
-}
-
-impl Event for HashMap<String, serde_json::Value, RandomState> {
-    type Encoding = Utf8Encoding;
-
-    fn visit_event<'a>(&'a mut self, visitor: &mut impl EventVisitor<'a>) {
-        for (k, v) in self.iter_mut() {
-            visitor.push_segment(PathSegment::Field(k.as_str().into()));
-            v.visit_event(visitor);
-            visitor.pop_segment();
-        }
-    }
-
-    fn visit_string_mut(&mut self, path: &Path, mut visit: impl FnMut(&mut String) -> bool) {
-        let first_segment = path.segments.first().unwrap();
-        let mut remaining_segments = path.segments.clone();
-        remaining_segments.remove(0);
-        if let PathSegment::Field(field) = first_segment {
-            let value = self.get_mut(&field.to_string()).unwrap();
-            value.visit_string_mut(&Path::from(remaining_segments), &mut visit);
-        }
-    }
-}
-
 #[cfg(test)]
 pub(crate) mod test {
-
-    use serde_json::{json, Map, Value};
-
     use crate::simple_event::SimpleEvent;
 
     use super::*;
@@ -217,61 +131,5 @@ pub(crate) mod test {
                 VisitOp::Pop,
             ]
         );
-    }
-    #[test]
-    pub fn test_hashmap_event() {
-        let mut map = Map::new();
-        map.insert(
-            "key-a-1".to_string(),
-            Value::String("value-a-1".to_string()),
-        );
-        map.insert(
-            "key-a-2".to_string(),
-            Value::String("value-b-1".to_string()),
-        );
-        map.insert("key-a-3".to_string(), json!(["an", "array"]));
-        let mut event = HashMap::from([("key-a".to_string(), Value::Object(map))]);
-
-        let mut visitor = Visitor {
-            ops: vec![],
-            path: Path::root(),
-        };
-        event.visit_event(&mut visitor);
-
-        assert_eq!(
-            visitor.ops,
-            vec![
-                VisitOp::Push(PathSegment::Field("key-a".into())),
-                VisitOp::Push(PathSegment::Field("key-a-1".into())),
-                VisitOp::Visit("value-a-1".into()),
-                VisitOp::Pop,
-                VisitOp::Push(PathSegment::Field("key-a-2".into())),
-                VisitOp::Visit("value-b-1".into()),
-                VisitOp::Pop,
-                VisitOp::Push(PathSegment::Field("key-a-3".into())),
-                VisitOp::Push(PathSegment::Index(0)),
-                VisitOp::Visit("an".into()),
-                VisitOp::Pop,
-                VisitOp::Push(PathSegment::Index(1)),
-                VisitOp::Visit("array".into()),
-                VisitOp::Pop,
-                VisitOp::Pop,
-                VisitOp::Pop,
-            ]
-        );
-
-        let mut leaf = String::new();
-        event.visit_string_mut(
-            &Path::from(vec![
-                PathSegment::Field("key-a".into()),
-                PathSegment::Field("key-a-3".into()),
-                PathSegment::Index(1),
-            ]),
-            |s| {
-                leaf = s.clone();
-                true
-            },
-        );
-        assert_eq!(leaf, "array".to_string())
     }
 }

--- a/sds/src/event.rs
+++ b/sds/src/event.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::hash::RandomState;
+
 use crate::encoding::{Encoding, Utf8Encoding};
 use crate::path::Path;
 use crate::PathSegment;
@@ -41,6 +44,14 @@ impl Event for String {
     fn visit_string_mut(&mut self, _path: &Path, mut visit: impl FnMut(&mut String) -> bool) {
         (visit)(self);
     }
+}
+
+impl<K, V> Event for HashMap<K, V, RandomState> {
+    type Encoding = Utf8Encoding;
+
+    fn visit_event<'a>(&'a mut self, visitor: &mut impl EventVisitor<'a>) {}
+
+    fn visit_string_mut(&mut self, path: &Path, visit: impl FnMut(&mut String) -> bool) {}
 }
 
 #[cfg(test)]

--- a/sds/src/event.rs
+++ b/sds/src/event.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use std::collections::HashMap;
 use std::hash::RandomState;
 
@@ -46,16 +47,90 @@ impl Event for String {
     }
 }
 
-impl<K, V> Event for HashMap<K, V, RandomState> {
+impl Event for serde_json::Value {
     type Encoding = Utf8Encoding;
 
-    fn visit_event<'a>(&'a mut self, visitor: &mut impl EventVisitor<'a>) {}
+    fn visit_event<'a>(&'a mut self, visitor: &mut impl EventVisitor<'a>) {
+        match self {
+            serde_json::Value::Null => {}
+            serde_json::Value::Bool(value) => {
+                let _result = visitor.visit_string(value.to_string().as_str());
+            }
+            serde_json::Value::Number(number) => {
+                let _result = visitor.visit_string(number.to_string().as_str());
+            }
+            serde_json::Value::String(s) => {
+                let _result = visitor.visit_string(&s);
+            }
+            serde_json::Value::Object(map) => {
+                for (k, child) in map.iter_mut() {
+                    visitor.push_segment(k.as_str().into());
+                    child.visit_event(visitor);
+                    visitor.pop_segment();
+                }
+            }
+            serde_json::Value::Array(values) => {
+                for (i, value) in values.into_iter().enumerate() {
+                    visitor.push_segment(PathSegment::Index(i));
+                    value.visit_event(visitor);
+                    visitor.pop_segment();
+                }
+            }
+        }
+    }
 
-    fn visit_string_mut(&mut self, path: &Path, visit: impl FnMut(&mut String) -> bool) {}
+    fn visit_string_mut(&mut self, path: &Path, mut visit: impl FnMut(&mut String) -> bool) {
+        let mut value = self;
+        for segment in &path.segments {
+            match segment {
+                PathSegment::Field(key) => {
+                    value = value
+                        .as_object_mut()
+                        .unwrap()
+                        .get_mut(key.as_ref())
+                        .unwrap();
+                }
+                PathSegment::Index(i) => {
+                    value = value.as_array_mut().unwrap().get_mut(*i).unwrap();
+                }
+            }
+        }
+        match value {
+            serde_json::Value::String(s) => {
+                (visit)(s);
+            }
+            _ => panic!("unknown value"),
+        };
+    }
+}
+
+impl Event for HashMap<String, serde_json::Value, RandomState> {
+    type Encoding = Utf8Encoding;
+
+    fn visit_event<'a>(&'a mut self, visitor: &mut impl EventVisitor<'a>) {
+        for (k, v) in self.iter_mut() {
+            visitor.push_segment(PathSegment::Field(k.as_str().into()));
+            v.visit_event(visitor);
+            visitor.pop_segment();
+        }
+    }
+
+    fn visit_string_mut(&mut self, path: &Path, mut visit: impl FnMut(&mut String) -> bool) {
+        let first_segment = path.segments.first().unwrap();
+        match first_segment {
+            PathSegment::Field(field) => {
+                let value = self.get_mut(&field.to_string()).unwrap();
+                value.visit_string_mut(path, &mut visit);
+            }
+            _ => {}
+        }
+    }
 }
 
 #[cfg(test)]
 pub(crate) mod test {
+
+    use serde_json::{Map, Value};
 
     use crate::simple_event::SimpleEvent;
 
@@ -137,6 +212,39 @@ pub(crate) mod test {
                 VisitOp::Visit("value-a".into()),
                 VisitOp::Pop,
                 VisitOp::Push(PathSegment::Field("key-b".into())),
+                VisitOp::Push(PathSegment::Field("key-b-1".into())),
+                VisitOp::Visit("value-b-1".into()),
+                VisitOp::Pop,
+                VisitOp::Pop,
+            ]
+        );
+    }
+    #[test]
+    pub fn test_hashmap_event() {
+        let mut map = Map::new();
+        map.insert(
+            "key-a-1".to_string(),
+            Value::String("value-a-1".to_string()),
+        );
+        map.insert(
+            "key-b-1".to_string(),
+            Value::String("value-b-1".to_string()),
+        );
+        let mut event = HashMap::from([("key-a".to_string(), Value::Object(map))]);
+
+        let mut visitor = Visitor {
+            ops: vec![],
+            path: Path::root(),
+        };
+        event.visit_event(&mut visitor);
+
+        assert_eq!(
+            visitor.ops,
+            vec![
+                VisitOp::Push(PathSegment::Field("key-a".into())),
+                VisitOp::Push(PathSegment::Field("key-a-1".into())),
+                VisitOp::Visit("value-a-1".into()),
+                VisitOp::Pop,
                 VisitOp::Push(PathSegment::Field("key-b-1".into())),
                 VisitOp::Visit("value-b-1".into()),
                 VisitOp::Pop,

--- a/sds/src/event.rs
+++ b/sds/src/event.rs
@@ -60,7 +60,7 @@ impl Event for serde_json::Value {
                 let _result = visitor.visit_string(number.to_string().as_str());
             }
             serde_json::Value::String(s) => {
-                let _result = visitor.visit_string(&s);
+                let _result = visitor.visit_string(s);
             }
             serde_json::Value::Object(map) => {
                 for (k, child) in map.iter_mut() {
@@ -70,7 +70,7 @@ impl Event for serde_json::Value {
                 }
             }
             serde_json::Value::Array(values) => {
-                for (i, value) in values.into_iter().enumerate() {
+                for (i, value) in values.iter_mut().enumerate() {
                     visitor.push_segment(PathSegment::Index(i));
                     value.visit_event(visitor);
                     visitor.pop_segment();
@@ -119,12 +119,9 @@ impl Event for HashMap<String, serde_json::Value, RandomState> {
         let first_segment = path.segments.first().unwrap();
         let mut remaining_segments = path.segments.clone();
         remaining_segments.remove(0);
-        match first_segment {
-            PathSegment::Field(field) => {
-                let value = self.get_mut(&field.to_string()).unwrap();
-                value.visit_string_mut(&Path::from(remaining_segments), &mut visit);
-            }
-            _ => {}
+        if let PathSegment::Field(field) = first_segment {
+            let value = self.get_mut(&field.to_string()).unwrap();
+            value.visit_string_mut(&Path::from(remaining_segments), &mut visit);
         }
     }
 }

--- a/sds/src/event_json.rs
+++ b/sds/src/event_json.rs
@@ -177,6 +177,9 @@ mod test {
                 true
             },
         );
+        // We're going to the "key-a.key-a-3.1" path
+        // This corresponds to the leaf "array" in the test event I created.
+        // Because "array" is the second element of the array, located at "key-a.key-a-3"
         assert_eq!(leaf, "array".to_string())
     }
 }

--- a/sds/src/event_json.rs
+++ b/sds/src/event_json.rs
@@ -1,0 +1,182 @@
+use core::panic;
+use std::collections::HashMap;
+use std::hash::RandomState;
+
+use crate::{Event, EventVisitor, Path, PathSegment, Utf8Encoding};
+
+impl Event for serde_json::Value {
+    type Encoding = Utf8Encoding;
+
+    fn visit_event<'a>(&'a mut self, visitor: &mut impl EventVisitor<'a>) {
+        match self {
+            serde_json::Value::Null => {}
+            serde_json::Value::Bool(value) => {
+                let _result = visitor.visit_string(value.to_string().as_str());
+            }
+            serde_json::Value::Number(number) => {
+                let _result = visitor.visit_string(number.to_string().as_str());
+            }
+            serde_json::Value::String(s) => {
+                let _result = visitor.visit_string(s);
+            }
+            serde_json::Value::Object(map) => {
+                for (k, child) in map.iter_mut() {
+                    visitor.push_segment(k.as_str().into());
+                    child.visit_event(visitor);
+                    visitor.pop_segment();
+                }
+            }
+            serde_json::Value::Array(values) => {
+                for (i, value) in values.iter_mut().enumerate() {
+                    visitor.push_segment(PathSegment::Index(i));
+                    value.visit_event(visitor);
+                    visitor.pop_segment();
+                }
+            }
+        }
+    }
+
+    fn visit_string_mut(&mut self, path: &Path, mut visit: impl FnMut(&mut String) -> bool) {
+        let mut value = self;
+        for segment in &path.segments {
+            match segment {
+                PathSegment::Field(key) => {
+                    value = value
+                        .as_object_mut()
+                        .unwrap()
+                        .get_mut(key.as_ref())
+                        .unwrap();
+                }
+                PathSegment::Index(i) => {
+                    value = value.as_array_mut().unwrap().get_mut(*i).unwrap();
+                }
+            }
+        }
+        match value {
+            serde_json::Value::String(s) => {
+                (visit)(s);
+            }
+            _ => panic!("unknown value"),
+        };
+    }
+}
+
+impl Event for HashMap<String, serde_json::Value, RandomState> {
+    type Encoding = Utf8Encoding;
+
+    fn visit_event<'a>(&'a mut self, visitor: &mut impl EventVisitor<'a>) {
+        for (k, v) in self.iter_mut() {
+            visitor.push_segment(PathSegment::Field(k.as_str().into()));
+            v.visit_event(visitor);
+            visitor.pop_segment();
+        }
+    }
+
+    fn visit_string_mut(&mut self, path: &Path, mut visit: impl FnMut(&mut String) -> bool) {
+        let first_segment = path.segments.first().unwrap();
+        let mut remaining_segments = path.segments.clone();
+        remaining_segments.remove(0);
+        if let PathSegment::Field(field) = first_segment {
+            let value = self.get_mut(&field.to_string()).unwrap();
+            value.visit_string_mut(&Path::from(remaining_segments), &mut visit);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use serde_json::{json, Map, Value};
+
+    use crate::VisitStringResult;
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum VisitOp {
+        Push(PathSegment<'static>),
+        Pop,
+        Visit(String),
+    }
+
+    struct Visitor {
+        path: Path<'static>,
+        ops: Vec<VisitOp>,
+    }
+
+    impl<'path> EventVisitor<'path> for Visitor {
+        fn push_segment(&mut self, segment: PathSegment<'path>) {
+            self.ops.push(VisitOp::Push(segment.into_static()));
+        }
+
+        fn pop_segment(&mut self) {
+            self.ops.push(VisitOp::Pop);
+        }
+
+        fn visit_string<'s>(&'s mut self, value: &str) -> VisitStringResult<'s, 'path> {
+            self.ops.push(VisitOp::Visit(value.to_string()));
+            VisitStringResult {
+                might_mutate: true,
+                path: &self.path,
+            }
+        }
+    }
+
+    #[test]
+    pub fn test_hashmap_event() {
+        let mut map = Map::new();
+        map.insert(
+            "key-a-1".to_string(),
+            Value::String("value-a-1".to_string()),
+        );
+        map.insert(
+            "key-a-2".to_string(),
+            Value::String("value-b-1".to_string()),
+        );
+        map.insert("key-a-3".to_string(), json!(["an", "array"]));
+        let mut event = HashMap::from([("key-a".to_string(), Value::Object(map))]);
+
+        let mut visitor = Visitor {
+            ops: vec![],
+            path: Path::root(),
+        };
+        event.visit_event(&mut visitor);
+
+        assert_eq!(
+            visitor.ops,
+            vec![
+                VisitOp::Push(PathSegment::Field("key-a".into())),
+                VisitOp::Push(PathSegment::Field("key-a-1".into())),
+                VisitOp::Visit("value-a-1".into()),
+                VisitOp::Pop,
+                VisitOp::Push(PathSegment::Field("key-a-2".into())),
+                VisitOp::Visit("value-b-1".into()),
+                VisitOp::Pop,
+                VisitOp::Push(PathSegment::Field("key-a-3".into())),
+                VisitOp::Push(PathSegment::Index(0)),
+                VisitOp::Visit("an".into()),
+                VisitOp::Pop,
+                VisitOp::Push(PathSegment::Index(1)),
+                VisitOp::Visit("array".into()),
+                VisitOp::Pop,
+                VisitOp::Pop,
+                VisitOp::Pop,
+            ]
+        );
+
+        let mut leaf = String::new();
+        event.visit_string_mut(
+            &Path::from(vec![
+                PathSegment::Field("key-a".into()),
+                PathSegment::Field("key-a-3".into()),
+                PathSegment::Index(1),
+            ]),
+            |s| {
+                leaf = s.clone();
+                true
+            },
+        );
+        assert_eq!(leaf, "array".to_string())
+    }
+}

--- a/sds/src/event_json.rs
+++ b/sds/src/event_json.rs
@@ -165,6 +165,7 @@ mod test {
             ]
         );
 
+        // I'm testing here that when I visit a string, giving the path will actually visit the right leaf of the tree.
         let mut leaf = String::new();
         event.visit_string_mut(
             &Path::from(vec![

--- a/sds/src/event_json.rs
+++ b/sds/src/event_json.rs
@@ -137,6 +137,16 @@ mod test {
         map.insert("key-a-3".to_string(), json!(["an", "array"]));
         let mut event = HashMap::from([("key-a".to_string(), Value::Object(map))]);
 
+        /*
+           event = {
+               "key-a": {
+                   "key-a-1": "value-a-1",
+                   "key-a-2": "value-a-2",
+                   "key-a-3": ["an", "array"]
+               }
+           }
+        */
+
         let mut visitor = Visitor {
             ops: vec![],
             path: Path::root(),

--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -7,6 +7,8 @@ mod encoding;
 mod event;
 mod match_action;
 
+#[cfg(any(test, feature = "testing", feature = "bench"))]
+mod event_json;
 mod match_validation;
 mod normalization;
 mod observability;
@@ -17,11 +19,10 @@ mod rule_match;
 mod scanner;
 mod scoped_ruleset;
 mod secondary_validation;
-mod stats;
-mod validation;
-
 #[cfg(any(test, feature = "testing", feature = "bench"))]
 mod simple_event;
+mod stats;
+mod validation;
 
 // This is the public API of the SDS core library
 pub use encoding::{EncodeIndices, Encoding, Utf8Encoding};


### PR DESCRIPTION
## Description

When you take any event (json), and you deserialize it with serde_json, without knowing the shape upfront, then you end up with an `Hashmap<String, serde_json::Value>`.

I would like to be able to scan this data so I've implemented the Event trait for Hashmap<String, Value>

I use this directly in this other PR: https://github.com/DataDog/sds-shared-library/pull/412