### PR TITLE
🐛 Remove feature bench for event_json

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -7,7 +7,6 @@ mod encoding;
 mod event;
 mod match_action;
 
-#[cfg(any(test, feature = "testing", feature = "bench"))]
 mod event_json;
 mod match_validation;
 mod normalization;


### PR DESCRIPTION
This is not needed, and it breaks the benchmarks in the sds-shared-library