### PR TITLE
Downgrade rayon min version for dd-source compatibility

### DIFF
--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -47,7 +47,7 @@ chrono = { version = "0.4", features = ["serde"] }
 slotmap = "1.0.7"
 base64 = "0.22.1"
 serde_json = "1.0.114"
-rayon = "1.10.0"
+rayon = "1"
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
obs-pipeline in dd-source rely on rayon being max 1.7.0, let's be less rigid on rayon version here