### PR TITLE
Validate GitHub tokens with zero padding checksum

### DIFF
--- a/sds/src/secondary_validation/github_token_checksum.rs
+++ b/sds/src/secondary_validation/github_token_checksum.rs
@@ -20,11 +20,14 @@ impl Validator for GithubTokenChecksum {
             return false;
         }
 
-        // extract the payload (everything except the last 6 chars)
         let computed_checksum = crc32fast::hash(last_part[..last_part.len() - 6].as_bytes());
-        let computed_checksum_b62 = base62::encode(computed_checksum);
-        // check that the crc is the last 6 chars
-        computed_checksum_b62 == last_part[last_part.len() - 6..]
+        let checksum = base62::decode(last_part[last_part.len() - 6..].as_bytes());
+
+        if checksum.is_err() {
+            return false;
+        }
+
+        computed_checksum as u64 == checksum.unwrap() as u64
     }
 }
 

--- a/sds/src/secondary_validation/github_token_checksum.rs
+++ b/sds/src/secondary_validation/github_token_checksum.rs
@@ -41,7 +41,10 @@ mod test {
             "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",
             "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",
             "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",
+            // long prefix
             "nawak_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",
+            // Example with zero padding
+            "b62_QdwULL38u41vs1OcAjhKqcaSZ9W63r0Zu4ln",
         ];
         for id in validids {
             assert!(GithubTokenChecksum.is_valid_match(id));
@@ -58,6 +61,8 @@ mod test {
             "ghp_M7H4jxUDDWHP4kZ6A4dxlQYsQIWJuq11T4V/",
             // No sep
             "ghpM7H4jxUDDWHP4kZ6A4dxlQYsQIWJuq11T4V4",
+            // too short second part
+            "ghp_T4V4",
         ];
         for id in invalid_ids {
             assert!(!GithubTokenChecksum.is_valid_match(id));


### PR DESCRIPTION
Detect valid Github tokens with checksum starting with zeros. Decoding the checksum instead of encoding generated one fixes the padding issue 
Examples in the PR have been generated with [this software](https://github.com/therootcompany/base62-token.js).


https://github.blog/engineering/behind-githubs-new-authentication-token-formats/

> A 32 bit checksum in the last 6 digits of each token strikes the optimal balance between keeping the random token portion at a consistent entropy and enough confidence in the checksum. We start the implementation with a CRC32 algorithm, a standard checksum algorithm. We then encode the result with a Base62 implementation, using leading zeros for padding as needed.

_This is not related to any story in particular._