### PR TITLE
Add validation by checksum for Brazilian CNPJ

### DIFF
--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -157,6 +157,7 @@ pub enum SecondaryValidator {
     IbanChecker,
     NirChecksum,
     JwtExpirationChecker,
+    BrazilianCpfChecksum,
 }
 
 #[cfg(test)]

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -150,14 +150,15 @@ pub struct ProximityKeywordsConfig {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "type")]
 pub enum SecondaryValidator {
-    LuhnChecksum,
+    BrazilianCpfChecksum,
+    BrazilianCnpjChecksum,
     ChineseIdChecksum,
     GithubTokenChecksum,
-    NhsCheckDigit,
     IbanChecker,
-    NirChecksum,
     JwtExpirationChecker,
-    BrazilianCpfChecksum,
+    LuhnChecksum,
+    NhsCheckDigit,
+    NirChecksum,
 }
 
 #[cfg(test)]

--- a/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
@@ -1,0 +1,84 @@
+use crate::secondary_validation::Validator;
+
+pub struct BrazilianCnpjChecksum;
+
+const BRAZILIAN_CNPJ_LENGTH: usize = 18;
+// XX.XXX.XXX/YYYY-ZZ
+const BRAZILIAN_CNPJ_SEPARATOR_INDICES: &'static [usize] = &[2, 6, 10, 15];
+
+impl Validator for BrazilianCnpjChecksum {
+    // https://pt.wikipedia.org/wiki/Cadastro_Nacional_da_Pessoa_Jur%C3%ADdica
+    fn is_valid_match(&self, regex_match: &str) -> bool {
+        // Check if the length of the ID is correct
+        if regex_match.len() != BRAZILIAN_CNPJ_LENGTH {
+            return false;
+        }
+
+        // Collect digits from match
+        let mut digits: Vec<u32> = Vec::with_capacity(10);
+        for (idx, c) in regex_match[..BRAZILIAN_CNPJ_LENGTH].chars().enumerate() {
+            if BRAZILIAN_CNPJ_SEPARATOR_INDICES.contains(&idx) {
+                // Skip the separator
+                continue;
+            }
+            if let Some(x) = c.to_digit(10) {
+                digits.push(x);
+            } else {
+                // Non-digit char in a position that should be a digit
+                return false;
+            }
+        }
+
+        // Compute the checksum
+        let mut v1;
+        let mut v2;
+        v1 = 5 * digits[0] + 4 * digits[1] + 3 * digits[2] + 2 * digits[3];
+        v1 += 9 * digits[4] + 8 * digits[5] + 7 * digits[6] + 6 * digits[7];
+        v1 += 5 * digits[8] + 4 * digits[9] + 3 * digits[10] + 2 * digits[11];
+        v1 = 11 - v1 % 11;
+        if v1 >= 10 {
+            v1 = 0;
+        }
+        v2 = 6 * digits[0] + 5 * digits[1] + 4 * digits[2] + 3 * digits[3];
+        v2 += 2 * digits[4] + 9 * digits[5] + 8 * digits[6] + 7 * digits[7];
+        v2 += 6 * digits[8] + 5 * digits[9] + 4 * digits[10] + 3 * digits[11];
+        v2 += 2 * digits[12];
+        v2 = 11 - v2 % 11;
+        if v2 >= 10 {
+            v2 = 0;
+        }
+
+        // Compare the computed checksum with the provided one
+        v1 == digits[12] && v2 == digits[13]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::secondary_validation::*;
+    #[test]
+    fn test_valid_brazilian_cnpj_ids() {
+        let valid_ids = vec!["00.623.904/0001-73", "00.623.904/0001-73"];
+        for id in valid_ids {
+            assert!(BrazilianCnpjChecksum.is_valid_match(id));
+        }
+    }
+
+    #[test]
+    fn test_invalid_brazilian_cnpj_ids() {
+        let invalid_ids = vec![
+            // valid cpf
+            "012.345.678-90",
+            // wrong checksum
+            "00.623.904/0001-71",
+            "00.623.904/0001-53",
+            // Non utf-8 characters 18 bytes
+            "567.456.234-90ñô",
+            // wrong length
+            "00.623.904/0131001-53",
+        ];
+        for id in invalid_ids {
+            assert!(!BrazilianCnpjChecksum.is_valid_match(id));
+        }
+    }
+}

--- a/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
@@ -4,8 +4,6 @@ use super::get_next_digit;
 
 pub struct BrazilianCnpjChecksum;
 
-const BRAZILIAN_CNPJ_DIGIT_COUNT: usize = 14;
-
 const BRAZILIAN_CNPJ_V1_MULTIPLIERS: &[u32] = &[5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
 const BRAZILIAN_CNPJ_V2_MULTIPLIERS: &[u32] = &[6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3];
 
@@ -18,42 +16,35 @@ impl Validator for BrazilianCnpjChecksum {
         let mut content_to_scan = regex_match.chars();
         let mut digit_idx = 0;
         let mut prev_digit = 0;
-        loop {
-            if let Some(x) = get_next_digit(&mut content_to_scan) {
-                match digit_idx {
-                    idx if idx < 12 => {
-                        v1 += BRAZILIAN_CNPJ_V1_MULTIPLIERS[idx] * x;
-                        v2 += BRAZILIAN_CNPJ_V2_MULTIPLIERS[idx] * x;
+        while let Some(x) = get_next_digit(&mut content_to_scan) {
+            match digit_idx {
+                idx if idx < 12 => {
+                    v1 += BRAZILIAN_CNPJ_V1_MULTIPLIERS[idx] * x;
+                    v2 += BRAZILIAN_CNPJ_V2_MULTIPLIERS[idx] * x;
+                }
+                12 => {
+                    v1 = 11 - v1 % 11;
+                    if v1 >= 10 {
+                        v1 = 0;
                     }
-                    idx if idx == 12 => {
-                        v1 = 11 - v1 % 11;
-                        if v1 >= 10 {
-                            v1 = 0;
-                        }
-                        v2 += 2 * x;
-                        v2 = 11 - v2 % 11;
-                        if v2 >= 10 {
-                            v2 = 0;
-                        }
-                    }
-                    idx if idx == 13 => {
-                        // Compare the computed checksum with the provided one
-                        return v1 == prev_digit && v2 == x;
-                    }
-                    _ => {
-                        return false;
+                    v2 += 2 * x;
+                    v2 = 11 - v2 % 11;
+                    if v2 >= 10 {
+                        v2 = 0;
                     }
                 }
-                digit_idx += 1;
-                prev_digit = x;
-            } else {
-                // Non-digit char in a position that should be a digit as we expect
-                // to find all 9 digits (11 - 2 check digits)
-                if (digit_idx as usize) != BRAZILIAN_CNPJ_DIGIT_COUNT {
+                13 => {
+                    // Compare the computed checksum with the provided one
+                    return v1 == prev_digit && v2 == x;
+                }
+                _ => {
                     return false;
                 }
             }
+            digit_idx += 1;
+            prev_digit = x;
         }
+        false
     }
 }
 

--- a/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
@@ -53,7 +53,12 @@ mod test {
     use crate::secondary_validation::*;
     #[test]
     fn test_valid_brazilian_cnpj_ids() {
-        let valid_ids = vec!["00.623.904/0001-73", "00.623.904/0001-73"];
+        let valid_ids = vec![
+            "00.623.904/0001-73",
+            "00.623.904/0001-73",
+            "00....623.904////0001-/-73",
+            "00623904000173",
+        ];
         for id in valid_ids {
             assert!(BrazilianCnpjChecksum.is_valid_match(id));
         }

--- a/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
@@ -4,7 +4,7 @@ pub struct BrazilianCnpjChecksum;
 
 const BRAZILIAN_CNPJ_LENGTH: usize = 18;
 // XX.XXX.XXX/YYYY-ZZ
-const BRAZILIAN_CNPJ_SEPARATOR_INDICES: &'static [usize] = &[2, 6, 10, 15];
+const BRAZILIAN_CNPJ_SEPARATOR_INDICES: &[usize] = &[2, 6, 10, 15];
 
 impl Validator for BrazilianCnpjChecksum {
     // https://pt.wikipedia.org/wiki/Cadastro_Nacional_da_Pessoa_Jur%C3%ADdica

--- a/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cnpj_checksum.rs
@@ -1,5 +1,3 @@
-use std::{default, f32::DIGITS};
-
 use crate::secondary_validation::Validator;
 
 use super::get_next_digit;

--- a/sds/src/secondary_validation/brazilian_cpf_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cpf_checksum.rs
@@ -1,0 +1,92 @@
+use crate::secondary_validation::Validator;
+
+pub struct BrazilianCpfChecksum;
+
+const BRAZILIAN_CPF_LENGTH: usize = 14;
+
+impl Validator for BrazilianCpfChecksum {
+    // https://pt.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas#C%C3%A1lculo_do_d%C3%ADgito_verificador
+    fn is_valid_match(&self, regex_match: &str) -> bool {
+        // Check if the length of the ID is correct
+        if regex_match.len() != BRAZILIAN_CPF_LENGTH {
+            println!("wrong length: {}", regex_match.len());
+            return false;
+        }
+
+        // Check if all characters are digits except the last one
+        // Compute the sum to compute checksum later on
+        let mut digit_idx = 0;
+        let mut v1: u32 = 0;
+        let mut v2: u32 = 0;
+        for (idx, c) in regex_match[..BRAZILIAN_CPF_LENGTH - 2]
+            .chars()
+            .rev()
+            .enumerate()
+        {
+            if idx % 4 == 0 {
+                // Skip the separator
+                continue;
+            }
+            if let Some(x) = c.to_digit(10) {
+                v1 += x * (9 - (digit_idx % 10));
+                println!("v1 -> {} * (9 - ({} % 10)) -> {}", x, digit_idx, v1);
+                v2 += x * (9 - ((digit_idx + 1) % 10));
+                // println!("char: {}, idx: {}, digit_idx: {}", c, idx, digit_idx);
+                digit_idx += 1;
+            } else {
+                println!("non digit char: {}", c);
+                return false;
+            }
+        }
+        v1 = (v1 % 11) % 10;
+        v2 += v1 * 9;
+        v2 = (v2 % 11) % 10;
+
+        for (idx, c) in regex_match.chars().enumerate() {
+            println!("idx: {}, c: {}", idx, c);
+        }
+
+        let actual_v1 = regex_match.chars().nth(12).unwrap().to_digit(10).unwrap();
+        let actual_v2 = regex_match.chars().nth(13).unwrap().to_digit(10).unwrap();
+        if v1 != actual_v1 || v2 != actual_v2 {
+            println!(
+                "v1: {}, v2: {}, actual_v1: {}, actual_v2: {}",
+                v1, v2, actual_v1, actual_v2
+            );
+            return false;
+        }
+        return true;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::secondary_validation::*;
+    #[test]
+    fn test_valid_brazilian_ids() {
+        let valid_ids = vec!["012.345.678-90", "083.358.948-25"];
+        for id in valid_ids {
+            assert!(BrazilianCpfChecksum.is_valid_match(id));
+        }
+    }
+
+    #[test]
+    fn test_invalid_brazilian_ids() {
+        let invalid_ids = vec![
+            // wrong checksum
+            "345.675.677-78",
+            "123.567.234-67",
+            "678.534.123-98",
+            "234.546.324-97",
+            "567.456.234-90",
+            "345.678.342-76",
+            // Non utf-8 characters 18 bytes
+            "567.456.234-90ñô",
+            // wrong length
+            "345.678.3428723-76",
+        ];
+        for id in invalid_ids {
+            assert!(!BrazilianCpfChecksum.is_valid_match(id));
+        }
+    }
+}

--- a/sds/src/secondary_validation/brazilian_cpf_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cpf_checksum.rs
@@ -10,9 +10,6 @@ impl Validator for BrazilianCpfChecksum {
     // https://pt.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas#C%C3%A1lculo_do_d%C3%ADgito_verificador
     fn is_valid_match(&self, regex_match: &str) -> bool {
         // Check if the length of the ID is correct
-        if regex_match.len() != BRAZILIAN_CPF_LENGTH {
-            return false;
-        }
 
         let mut digit_idx = 0;
         let mut v1: u32 = 0;

--- a/sds/src/secondary_validation/brazilian_cpf_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cpf_checksum.rs
@@ -3,8 +3,7 @@ use crate::secondary_validation::Validator;
 
 pub struct BrazilianCpfChecksum;
 
-const BRAZILIAN_CPF_LENGTH: usize = 14;
-const BRAZILIAN_CPF_DIGIT_COUNT: usize = 11;
+const BRAZILIAN_CPF_DIGIT_COUNT: u32 = 11;
 
 impl Validator for BrazilianCpfChecksum {
     // https://pt.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas#C%C3%A1lculo_do_d%C3%ADgito_verificador
@@ -24,19 +23,15 @@ impl Validator for BrazilianCpfChecksum {
             Some(x) => x,
             None => return false,
         };
-        loop {
-            if let Some(x) = get_previous_digit(&mut content_to_scan) {
-                v1 += x * (9 - (digit_idx % 10));
-                v2 += x * (9 - ((digit_idx + 1) % 10));
-                digit_idx += 1;
-            } else {
-                // Non-digit char in a position that should be a digit as we expect
-                // to find all 9 digits (11 - 2 check digits)
-                if (digit_idx as usize) != BRAZILIAN_CPF_DIGIT_COUNT - 2 {
-                    return false;
-                }
-                break;
-            }
+        while let Some(x) = get_previous_digit(&mut content_to_scan) {
+            v1 += x * (9 - (digit_idx % 10));
+            v2 += x * (9 - ((digit_idx + 1) % 10));
+            digit_idx += 1;
+        }
+        // Non-digit char in a position that should be a digit as we expect
+        // to find all 9 digits (11 - 2 check digits)
+        if digit_idx != BRAZILIAN_CPF_DIGIT_COUNT - 2 {
+            return false;
         }
         v1 = (v1 % 11) % 10;
         v2 += v1 * 9;

--- a/sds/src/secondary_validation/brazilian_cpf_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cpf_checksum.rs
@@ -43,7 +43,7 @@ impl Validator for BrazilianCpfChecksum {
             // Checksum failed
             return false;
         }
-        return true;
+        true
     }
 }
 

--- a/sds/src/secondary_validation/brazilian_cpf_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cpf_checksum.rs
@@ -51,7 +51,7 @@ impl Validator for BrazilianCpfChecksum {
 mod test {
     use crate::secondary_validation::*;
     #[test]
-    fn test_valid_brazilian_ids() {
+    fn test_valid_brazilian_cpf_ids() {
         let valid_ids = vec!["012.345.678-90", "083.358.948-25"];
         for id in valid_ids {
             assert!(BrazilianCpfChecksum.is_valid_match(id));
@@ -59,7 +59,7 @@ mod test {
     }
 
     #[test]
-    fn test_invalid_brazilian_ids() {
+    fn test_invalid_brazilian_cpf_ids() {
         let invalid_ids = vec![
             // wrong checksum
             "345.675.677-78",

--- a/sds/src/secondary_validation/brazilian_cpf_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cpf_checksum.rs
@@ -50,7 +50,12 @@ mod test {
     use crate::secondary_validation::*;
     #[test]
     fn test_valid_brazilian_cpf_ids() {
-        let valid_ids = vec!["012.345.678-90", "083.358.948-25"];
+        let valid_ids = vec![
+            "012.345.678-90",
+            "083.358.948-25",
+            "083---358___948_____25",
+            "08335894825",
+        ];
         for id in valid_ids {
             assert!(BrazilianCpfChecksum.is_valid_match(id));
         }

--- a/sds/src/secondary_validation/brazilian_cpf_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cpf_checksum.rs
@@ -13,8 +13,6 @@ impl Validator for BrazilianCpfChecksum {
             return false;
         }
 
-        // Check if all characters are digits except the last one
-        // Compute the sum to compute checksum later on
         let mut digit_idx = 0;
         let mut v1: u32 = 0;
         let mut v2: u32 = 0;
@@ -29,12 +27,10 @@ impl Validator for BrazilianCpfChecksum {
             }
             if let Some(x) = c.to_digit(10) {
                 v1 += x * (9 - (digit_idx % 10));
-                println!("v1 -> {} * (9 - ({} % 10)) -> {}", x, digit_idx, v1);
                 v2 += x * (9 - ((digit_idx + 1) % 10));
-                // println!("char: {}, idx: {}, digit_idx: {}", c, idx, digit_idx);
                 digit_idx += 1;
             } else {
-                println!("non digit char: {}", c);
+                // Non-digit char in a position that should be a digit
                 return false;
             }
         }
@@ -42,17 +38,10 @@ impl Validator for BrazilianCpfChecksum {
         v2 += v1 * 9;
         v2 = (v2 % 11) % 10;
 
-        for (idx, c) in regex_match.chars().enumerate() {
-            println!("idx: {}, c: {}", idx, c);
-        }
-
         let actual_v1 = regex_match.chars().nth(12).unwrap().to_digit(10).unwrap();
         let actual_v2 = regex_match.chars().nth(13).unwrap().to_digit(10).unwrap();
         if v1 != actual_v1 || v2 != actual_v2 {
-            println!(
-                "v1: {}, v2: {}, actual_v1: {}, actual_v2: {}",
-                v1, v2, actual_v1, actual_v2
-            );
+            // Checksum failed
             return false;
         }
         return true;

--- a/sds/src/secondary_validation/brazilian_cpf_checksum.rs
+++ b/sds/src/secondary_validation/brazilian_cpf_checksum.rs
@@ -9,7 +9,6 @@ impl Validator for BrazilianCpfChecksum {
     fn is_valid_match(&self, regex_match: &str) -> bool {
         // Check if the length of the ID is correct
         if regex_match.len() != BRAZILIAN_CPF_LENGTH {
-            println!("wrong length: {}", regex_match.len());
             return false;
         }
 

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -1,3 +1,4 @@
+mod brazilian_cpf_checksum;
 mod chinese_id_checksum;
 mod github_token_checksum;
 mod iban_checker;
@@ -10,6 +11,7 @@ mod nir_checksum;
 pub use jwt_expiration_checker::generate_jwt;
 
 use crate::scanner::regex_rule::config::SecondaryValidator;
+pub use crate::secondary_validation::brazilian_cpf_checksum::BrazilianCpfChecksum;
 pub use crate::secondary_validation::chinese_id_checksum::ChineseIdChecksum;
 pub use crate::secondary_validation::github_token_checksum::GithubTokenChecksum;
 pub use crate::secondary_validation::iban_checker::IbanChecker;
@@ -53,7 +55,8 @@ impl Validator for SecondaryValidator {
             SecondaryValidator::NirChecksum => NirChecksum.is_valid_match(regex_match),
             SecondaryValidator::JwtExpirationChecker => {
                 JwtExpirationChecker.is_valid_match(regex_match)
-            }
+            },
+            SecondaryValidator::BrazilianCpfChecksum => BrazilianCpfChecksum.is_valid_match(regex_match),
         }
     }
 }

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -55,8 +55,10 @@ impl Validator for SecondaryValidator {
             SecondaryValidator::NirChecksum => NirChecksum.is_valid_match(regex_match),
             SecondaryValidator::JwtExpirationChecker => {
                 JwtExpirationChecker.is_valid_match(regex_match)
-            },
-            SecondaryValidator::BrazilianCpfChecksum => BrazilianCpfChecksum.is_valid_match(regex_match),
+            }
+            SecondaryValidator::BrazilianCpfChecksum => {
+                BrazilianCpfChecksum.is_valid_match(regex_match)
+            }
         }
     }
 }

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -1,3 +1,4 @@
+mod brazilian_cnpj_checksum;
 mod brazilian_cpf_checksum;
 mod chinese_id_checksum;
 mod github_token_checksum;
@@ -11,6 +12,7 @@ mod nir_checksum;
 pub use jwt_expiration_checker::generate_jwt;
 
 use crate::scanner::regex_rule::config::SecondaryValidator;
+pub use crate::secondary_validation::brazilian_cnpj_checksum::BrazilianCnpjChecksum;
 pub use crate::secondary_validation::brazilian_cpf_checksum::BrazilianCpfChecksum;
 pub use crate::secondary_validation::chinese_id_checksum::ChineseIdChecksum;
 pub use crate::secondary_validation::github_token_checksum::GithubTokenChecksum;
@@ -58,6 +60,9 @@ impl Validator for SecondaryValidator {
             }
             SecondaryValidator::BrazilianCpfChecksum => {
                 BrazilianCpfChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::BrazilianCnpjChecksum => {
+                BrazilianCnpjChecksum.is_valid_match(regex_match)
             }
         }
     }


### PR DESCRIPTION
Introduce secondary validation by checksum for Brazilian national ID (CNPJ number).

This was implemented based on the description of the checksum algorithm on the [CNPJ wikipedia page](https://pt.wikipedia.org/wiki/Cadastro_Nacional_da_Pessoa_Jur%C3%ADdica).