### PR TITLE
Fix panic when included keyword and regex match at the same index

### DIFF
--- a/sds/src/proximity_keywords/included_keywords.rs
+++ b/sds/src/proximity_keywords/included_keywords.rs
@@ -1,6 +1,7 @@
 use crate::proximity_keywords::next_char_index;
 use crate::scanner::regex_rule::RegexCaches;
 use regex_automata::Input;
+use std::ops::Range;
 
 pub struct CompiledIncludedProximityKeywords {
     pub look_ahead_character_count: usize,
@@ -30,7 +31,7 @@ impl IncludedKeywordSearch<'_> {
         }
     }
 
-    pub fn next(&mut self, regex_caches: &mut RegexCaches) -> Option<usize> {
+    pub fn next(&mut self, regex_caches: &mut RegexCaches) -> Option<Range<usize>> {
         let input = Input::new(self.content).range(self.start..).earliest(true);
 
         if let Some(included_keyword_match) =
@@ -43,7 +44,7 @@ impl IncludedKeywordSearch<'_> {
             // multi-word keywords can overlap
             self.start = next_char_index(self.content, included_keyword_match.start())
                 .unwrap_or(included_keyword_match.end());
-            Some(included_keyword_match.start())
+            Some(included_keyword_match.range())
         } else {
             None
         }
@@ -63,7 +64,7 @@ mod test {
         let mut caches = RegexCaches::new();
         let mut output = vec![];
         while let Some(x) = search.next(&mut caches) {
-            output.push(x);
+            output.push(x.start);
         }
         output
     }

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -126,6 +126,10 @@ pub fn is_index_within_prefix(
     target: usize,
     prefix_size: usize,
 ) -> bool {
+    println!("Content: {:?}", content);
+    println!("Prefix start: {:?}", prefix_start);
+    println!("Target: {:?}", target);
+    println!("Prefix size: {:?}", prefix_size);
     debug_assert!(target > prefix_start);
     debug_assert!(content.is_char_boundary(prefix_start));
     debug_assert!(content.is_char_boundary(target));

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -126,10 +126,6 @@ pub fn is_index_within_prefix(
     target: usize,
     prefix_size: usize,
 ) -> bool {
-    println!("Content: {:?}", content);
-    println!("Prefix start: {:?}", prefix_start);
-    println!("Target: {:?}", target);
-    println!("Prefix size: {:?}", prefix_size);
     debug_assert!(target > prefix_start);
     debug_assert!(content.is_char_boundary(prefix_start));
     debug_assert!(content.is_char_boundary(target));

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -3032,7 +3032,7 @@ mod test {
 
         #[test]
         fn test_regex_match_and_included_keyword_same_index() {
-            let email_rule = RegexRuleConfig::new("email.+")
+            let email_rule = RegexRuleConfig::new(".+")
                 .match_action(MatchAction::Redact {
                     replacement: "[REDACTED]".to_string(),
                 })
@@ -3045,6 +3045,7 @@ mod test {
 
             let scanner = ScannerBuilder::new(&[email_rule])
                 .with_keywords_should_match_event_paths(true)
+                .with_return_matches(true)
                 .build()
                 .unwrap();
             let mut content = SimpleEvent::Map(BTreeMap::from([(
@@ -3052,7 +3053,12 @@ mod test {
                 SimpleEvent::String("email=firstname.lastname@acme.com&page2".to_string()),
             )]));
             let matches = scanner.scan(&mut content, vec![]);
-            assert_eq!(matches.len(), 0);
+            assert_eq!(matches.len(), 1);
+
+            assert_eq!(
+                matches[0].match_value,
+                Some("=firstname.lastname@acme.com&page2".to_string())
+            );
         }
     }
 }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -3029,5 +3029,30 @@ mod test {
 
             assert_eq!(metric_value, &(None, None, DebugValue::Counter(1)));
         }
+
+        #[test]
+        fn test_regex_match_and_included_keyword_same_index() {
+            let email_rule = RegexRuleConfig::new("email.+")
+                .match_action(MatchAction::Redact {
+                    replacement: "[REDACTED]".to_string(),
+                })
+                .proximity_keywords(ProximityKeywordsConfig {
+                    look_ahead_character_count: 30,
+                    included_keywords: vec!["email".to_string()],
+                    excluded_keywords: vec![],
+                })
+                .build();
+
+            let scanner = ScannerBuilder::new(&[email_rule])
+                .with_keywords_should_match_event_paths(true)
+                .build()
+                .unwrap();
+            let mut content = SimpleEvent::Map(BTreeMap::from([(
+                "message".to_string(),
+                SimpleEvent::String("email=firstname.lastname@acme.com&page2".to_string()),
+            )]));
+            let matches = scanner.scan(&mut content, vec![]);
+            assert_eq!(matches.len(), 0);
+        }
     }
 }

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -131,12 +131,13 @@ impl RegexCompiledRule {
     ) {
         let mut included_keyword_matches = included_keywords.keyword_matches(content);
 
-        'included_keyword_search: while let Some(included_keyword_match_start) =
+        'included_keyword_search: while let Some(included_keyword_match) =
             included_keyword_matches.next(regex_caches)
         {
             let true_positive_search = self.true_positive_matches(
                 content,
-                included_keyword_match_start,
+                // 71,
+                included_keyword_match.end,
                 regex_caches.get(&self.regex),
                 false,
                 exclusion_check,
@@ -146,7 +147,7 @@ impl RegexCompiledRule {
             for true_positive_match in true_positive_search {
                 if is_index_within_prefix(
                     content,
-                    included_keyword_match_start,
+                    included_keyword_match.start,
                     true_positive_match.start,
                     included_keywords.look_ahead_character_count,
                 ) {
@@ -252,6 +253,9 @@ impl Iterator for TruePositiveSearch<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
+            if self.start > self.content.len() {
+                return None;
+            }
             let input = Input::new(self.content).range(self.start..);
 
             if let Some(regex_match) = self.rule.regex.search_with(self.cache, &input) {

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -136,7 +136,6 @@ impl RegexCompiledRule {
         {
             let true_positive_search = self.true_positive_matches(
                 content,
-                // 71,
                 included_keyword_match.end,
                 regex_caches.get(&self.regex),
                 false,


### PR DESCRIPTION
A panic could happen if a regex matched at the exact same index as the _start_ of an included keyword. The code was adjusted to only start regex scanning at the _end_ of an included keyword, since those are required to be before a regex match to be valid anyway. This prevent them from overlapping.