### PR TITLE
Unify path/content regex behavior

### DIFF
--- a/sds/src/proximity_keywords/included_keywords.rs
+++ b/sds/src/proximity_keywords/included_keywords.rs
@@ -178,4 +178,14 @@ mod test {
             vec![5]
         );
     }
+
+    #[test]
+    fn multi_word_keyword_matches() {
+        let keywords = compile_keywords(30, &["hello world"]);
+
+        assert_eq!(
+            collect_keyword_matches(keywords.keyword_matches("hello-world secret")),
+            vec![0]
+        );
+    }
 }

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -178,8 +178,7 @@ fn compile_keywords_to_ast(
             }
             Ok((
                 calculate_keyword_content_pattern(&trimmed_keyword),
-                calculate_keyword_path_ptus
-               attern(&trimmed_keyword),
+                calculate_keyword_path_pattern(&trimmed_keyword),
             ))
         })
         .collect::<Result<Vec<_>, _>>()?
@@ -252,12 +251,10 @@ fn calculate_keyword_content_pattern(keyword: &str) -> Ast {
     if should_push_word_boundary(keyword.chars().next_back().unwrap()) {
         keyword_pattern.push(word_boundary_or_link_char())
     }
-    let out = Ast::Concat(Concat {
+    Ast::Concat(Concat {
         span: span(),
         asts: keyword_pattern,
-    });
-    println!("Ast: {}", out);
-    out
+    })
 }
 
 fn any_link_char() -> Ast {

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -255,6 +255,14 @@ fn calculate_keyword_content_pattern(keyword: &str) -> Ast {
     if should_push_word_boundary(keyword.chars().next_back().unwrap()) {
         keyword_pattern.push(word_boundary_or_link_char())
     }
+    println!(
+        "Pattern: \"{}\"",
+        Ast::Concat(Concat {
+            span: span(),
+            asts: keyword_pattern.clone(),
+        })
+    );
+
     Ast::Concat(Concat {
         span: span(),
         asts: keyword_pattern,
@@ -821,6 +829,14 @@ mod test {
     fn test_calculate_multi_word_keyword_pattern() {
         assert_eq!(
             calculate_keyword_content_pattern("multi word-KEYWORD").to_string(),
+            "(?:(?-u:\\b)|(?:_))multi(?:\\-|_|\\.| |/)word(?:\\-|_|\\.| |/)KEYWORD(?:(?-u:\\b)|(?:_))"
+        )
+    }
+
+    #[test]
+    fn test_calculate_hello_world_pattern() {
+        assert_eq!(
+            calculate_keyword_content_pattern("hello world").to_string(),
             "(?:(?-u:\\b)|(?:_))multi(?:\\-|_|\\.| |/)word(?:\\-|_|\\.| |/)KEYWORD(?:(?-u:\\b)|(?:_))"
         )
     }

--- a/sds/src/proximity_keywords/mod.rs
+++ b/sds/src/proximity_keywords/mod.rs
@@ -255,13 +255,6 @@ fn calculate_keyword_content_pattern(keyword: &str) -> Ast {
     if should_push_word_boundary(keyword.chars().next_back().unwrap()) {
         keyword_pattern.push(word_boundary_or_link_char())
     }
-    println!(
-        "Pattern: \"{}\"",
-        Ast::Concat(Concat {
-            span: span(),
-            asts: keyword_pattern.clone(),
-        })
-    );
 
     Ast::Concat(Concat {
         span: span(),
@@ -829,14 +822,6 @@ mod test {
     fn test_calculate_multi_word_keyword_pattern() {
         assert_eq!(
             calculate_keyword_content_pattern("multi word-KEYWORD").to_string(),
-            "(?:(?-u:\\b)|(?:_))multi(?:\\-|_|\\.| |/)word(?:\\-|_|\\.| |/)KEYWORD(?:(?-u:\\b)|(?:_))"
-        )
-    }
-
-    #[test]
-    fn test_calculate_hello_world_pattern() {
-        assert_eq!(
-            calculate_keyword_content_pattern("hello world").to_string(),
             "(?:(?-u:\\b)|(?:_))multi(?:\\-|_|\\.| |/)word(?:\\-|_|\\.| |/)KEYWORD(?:(?-u:\\b)|(?:_))"
         )
     }

--- a/sds/src/scanner/test/included_keywords.rs
+++ b/sds/src/scanner/test/included_keywords.rs
@@ -190,6 +190,54 @@ fn test_included_keyword_multiple_prefix_matches() {
 }
 
 #[test]
+fn test_multi_word_underscore_separator() {
+    let redact_test_rule = RootRuleConfig::new(
+        RegexRuleConfig::new("secret")
+            .with_proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["hello world".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    });
+
+    let scanner = ScannerBuilder::new(&[redact_test_rule]).build().unwrap();
+
+    let mut content = "hello_world secret".to_string();
+    let matches = scanner.scan(&mut content);
+
+    // 1 match because "hello_world" matches "hello world" keyword
+    assert_eq!(matches.len(), 1);
+}
+
+#[test]
+fn test_multi_word_underscore_word_boundaries_separator() {
+    let redact_test_rule = RootRuleConfig::new(
+        RegexRuleConfig::new("secret")
+            .with_proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["hello world".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    });
+
+    let scanner = ScannerBuilder::new(&[redact_test_rule]).build().unwrap();
+
+    let mut content = "a_hello_world_b secret".to_string();
+    let matches = scanner.scan(&mut content);
+
+    // 1 match because "hello_world" matches "hello world" keyword
+    assert_eq!(matches.len(), 1);
+}
+
+#[test]
 fn test_included_keywords_on_start_boundary_with_space_including_word_boundary() {
     let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
         RegexRuleConfig::new("ab")


### PR DESCRIPTION
[RFC](https://datadoghq.atlassian.net/wiki/spaces/SDS/pages/4792189564/Unifying+path+content+included+keyword+searches)

This unifies the included keyword matching behavior a bit more for path vs content matching.

Path matching allows multiple "word link characters" for multi-word keywords. These are now also added to the content matching regex. If any of the following chars show up in a keyword, _any_ of them are allowed to match in the content itself. They are `-_./<space>`

`_` is also added to the start/end word boundary that is automatically added so `_` can act as a word boundary.