### PR TITLE
♻️ [SDS-927] Deprecate match_validation_type and use third_party_active_checker instead

### DIFF
--- a/sds/benches/bench.rs
+++ b/sds/benches/bench.rs
@@ -162,9 +162,9 @@ pub fn included_keywords_on_path(c: &mut Criterion) {
 
     for i in 0..100 {
         let mut nested_event = BTreeMap::new();
-        for j in 0..1000 {
+        for _j in 0..1000 {
             let mut double_nested_event = BTreeMap::new();
-            for k in 0..100 {
+            for _k in 0..100 {
                 double_nested_event.insert(
                     "yet-another-key".to_string(),
                     SimpleEvent::String(format!("value-{}", i)),

--- a/sds/src/scanner/config.rs
+++ b/sds/src/scanner/config.rs
@@ -13,6 +13,7 @@ pub trait RuleConfig: Send + Sync {
     fn get_match_validation_type(&self) -> Option<&MatchValidationType>;
 
     fn get_internal_match_validation_type(&self) -> Option<InternalMatchValidationType> {
+        #[allow(deprecated)]
         self.get_match_validation_type()
             .map(|x| x.get_internal_match_validation_type())
     }

--- a/sds/src/scanner/test/match_validation.rs
+++ b/sds/src/scanner/test/match_validation.rs
@@ -14,7 +14,7 @@ fn test_should_return_match_with_match_validation() {
         .match_action(MatchAction::Redact {
             replacement: "[REDACTED]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
                 .build()
                 .unwrap(),
@@ -58,13 +58,13 @@ fn test_should_allocate_match_validator_depending_on_match_type() {
         .match_action(MatchAction::Redact {
             replacement: "[AWS ID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId))
+        .third_party_active_checker(MatchValidationType::Aws(AwsType::AwsId))
         .build();
     let rule_aws_secret = RegexRuleConfig::new("aws-secret")
         .match_action(MatchAction::Redact {
             replacement: "[AWS SECRET]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsSecret(
+        .third_party_active_checker(MatchValidationType::Aws(AwsType::AwsSecret(
             AwsConfig::default(),
         )))
         .build();
@@ -73,7 +73,7 @@ fn test_should_allocate_match_validator_depending_on_match_type() {
         .match_action(MatchAction::Redact {
             replacement: "[CUSTOM HTTP1]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
                 .build()
                 .unwrap(),
@@ -84,7 +84,7 @@ fn test_should_allocate_match_validator_depending_on_match_type() {
         .match_action(MatchAction::Redact {
             replacement: "[CUSTOM HTTP2]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
                 .build()
                 .unwrap(),
@@ -95,7 +95,7 @@ fn test_should_allocate_match_validator_depending_on_match_type() {
         .match_action(MatchAction::Redact {
             replacement: "[CUSTOM HTTP2]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new("http://localhost:8081".to_string())
                 .build()
                 .unwrap(),
@@ -149,7 +149,7 @@ fn test_aws_id_only_shall_not_validate() {
         .match_action(MatchAction::Redact {
             replacement: "[AWS_ID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId))
+        .third_party_active_checker(MatchValidationType::Aws(AwsType::AwsId))
         .build();
 
     let scanner = ScannerBuilder::new(&[rule_aws_id]).build().unwrap();
@@ -189,7 +189,7 @@ fn test_mock_same_http_validator_several_matches() {
         .match_action(MatchAction::Redact {
             replacement: "[VALID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new(server.url("/").to_string())
                 .build()
                 .unwrap(),
@@ -200,7 +200,7 @@ fn test_mock_same_http_validator_several_matches() {
         .match_action(MatchAction::Redact {
             replacement: "[INVALID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new(server.url("/").to_string())
                 .build()
                 .unwrap(),
@@ -211,7 +211,7 @@ fn test_mock_same_http_validator_several_matches() {
         .match_action(MatchAction::Redact {
             replacement: "[ERROR]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new(server.url("/").to_string())
                 .build()
                 .unwrap(),
@@ -254,7 +254,7 @@ fn test_mock_http_timeout() {
         .match_action(MatchAction::Redact {
             replacement: "[VALID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new(server.url("/").to_string())
                 .set_timeout(Duration::from_micros(0))
                 .build()
@@ -295,7 +295,7 @@ fn test_mock_multiple_match_validators() {
         .match_action(MatchAction::Redact {
             replacement: "[VALID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new(server.url("/http-service").to_string())
                 .build()
                 .unwrap(),
@@ -306,14 +306,14 @@ fn test_mock_multiple_match_validators() {
         .match_action(MatchAction::Redact {
             replacement: "[AWS_ID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId))
+        .third_party_active_checker(MatchValidationType::Aws(AwsType::AwsId))
         .build();
 
     let rule_aws_secret = RegexRuleConfig::new("\\baws_secret\\b")
         .match_action(MatchAction::Redact {
             replacement: "[AWS_SECRET]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsSecret(AwsConfig {
+        .third_party_active_checker(MatchValidationType::Aws(AwsType::AwsSecret(AwsConfig {
             aws_sts_endpoint: server.url("/aws-service").to_string(),
             forced_datetime_utc: None,
             timeout: Duration::from_secs(1),
@@ -356,7 +356,7 @@ fn test_mock_endpoint_with_multiple_hosts() {
         .match_action(MatchAction::Redact {
             replacement: "[VALID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::CustomHttp(
+        .third_party_active_checker(MatchValidationType::CustomHttp(
             HttpValidatorConfigBuilder::new(server.url("/$HOST-service").to_string())
                 .set_hosts(vec!["us".to_string(), "eu".to_string()])
                 .build()
@@ -442,7 +442,7 @@ fn test_mock_aws_validator() {
         .match_action(MatchAction::Redact {
             replacement: "[AWS_ID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId))
+        .third_party_active_checker(MatchValidationType::Aws(AwsType::AwsId))
         .build();
 
     let rule_aws_secret = RegexRuleConfig::new("[A-Za-z0-9/+]{40}")
@@ -454,7 +454,7 @@ fn test_mock_aws_validator() {
             included_keywords: vec!["aws_secret".to_string()],
             excluded_keywords: vec![],
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsSecret(AwsConfig {
+        .third_party_active_checker(MatchValidationType::Aws(AwsType::AwsSecret(AwsConfig {
             aws_sts_endpoint: server_url.clone(),
             forced_datetime_utc: Some(datetime),
             timeout: Duration::from_secs(5),


### PR DESCRIPTION
## Description

https://datadoghq.atlassian.net/browse/SDS-927

Deprecate `match_validation_type` and prefer `third_party_active_checker` instead