### PR TITLE
Make rules more generic

### DIFF
--- a/sds-go/rust/src/native/rule.rs
+++ b/sds-go/rust/src/native/rule.rs
@@ -1,21 +1,18 @@
-use std::ffi::{c_char};
+use dd_sds::{RegexRuleConfig, RootRuleConfig};
+use std::ffi::c_char;
 use std::mem::ManuallyDrop;
 use std::sync::{Arc, Mutex};
-use dd_sds::RegexRuleConfig;
 
 use crate::native::{convert_panic_to_go_error, handle_panic_ptr_return, read_json};
 use crate::{RuleDoublePtr, RuleList, RulePtr};
 
-
 #[no_mangle]
-pub extern "C" fn create_regex_rule(
-    json_config: *const c_char,
-) -> i64 {
+pub extern "C" fn create_regex_rule(json_config: *const c_char) -> i64 {
     handle_panic_ptr_return(None, || {
         // parse the json
-        let config: RegexRuleConfig = unsafe {read_json(json_config).unwrap()};
-        
-        let rule: RulePtr = Arc::new(config);
+        let config: RootRuleConfig<RegexRuleConfig> = unsafe { read_json(json_config).unwrap() };
+
+        let rule: RulePtr = config.into_dyn();
         // A trait object in Rust is a fat-pointer (1 data + 1 vtable pointer). This is boxed again
         // to get a single (normal) pointer to the fat pointer so only 1 value needs to be sent over FFI
         let double_pointer = RuleDoublePtr::new(rule);
@@ -25,11 +22,9 @@ pub extern "C" fn create_regex_rule(
 }
 
 #[no_mangle]
-pub extern "C" fn free_any_rule(
-    rule_ptr: i64
-) {
+pub extern "C" fn free_any_rule(rule_ptr: i64) {
     let _ = convert_panic_to_go_error(|| {
-        let double_pointer = unsafe {RuleDoublePtr::from_raw(rule_ptr as usize as *const _)};
+        let double_pointer = unsafe { RuleDoublePtr::from_raw(rule_ptr as usize as *const _) };
         drop(double_pointer);
     });
 }
@@ -49,8 +44,9 @@ pub extern "C" fn create_rule_list() -> i64 {
 #[no_mangle]
 pub extern "C" fn append_rule_to_list(rule: i64, list: i64) {
     let _ = convert_panic_to_go_error(|| {
-        let list = ManuallyDrop::new(unsafe {RuleList::from_raw(list as usize as *const _)});
-        let rule_double_ptr = ManuallyDrop::new(unsafe {RuleDoublePtr::from_raw(rule as usize as *const _)});
+        let list = ManuallyDrop::new(unsafe { RuleList::from_raw(list as usize as *const _) });
+        let rule_double_ptr =
+            ManuallyDrop::new(unsafe { RuleDoublePtr::from_raw(rule as usize as *const _) });
 
         let rule_ptr = rule_double_ptr.as_ref().clone();
         list.lock().unwrap().push(rule_ptr);
@@ -61,9 +57,7 @@ pub extern "C" fn append_rule_to_list(rule: i64, list: i64) {
 #[no_mangle]
 pub extern "C" fn free_rule_list(list: i64) {
     let _ = convert_panic_to_go_error(|| {
-        let list = unsafe {RuleList::from_raw(list as usize as *const _)};
+        let list = unsafe { RuleList::from_raw(list as usize as *const _) };
         drop(list);
     });
 }
-
-

--- a/sds/benches/bench.rs
+++ b/sds/benches/bench.rs
@@ -116,7 +116,7 @@ pub fn luhn_checksum(c: &mut Criterion) {
 
 pub fn included_keywords(c: &mut Criterion) {
     let scanner = Scanner::builder(&[RegexRuleConfig::new("[a-zA-z0-9]{4,25}")
-        .proximity_keywords(ProximityKeywordsConfig {
+        .with_proximity_keywords(ProximityKeywordsConfig {
             look_ahead_character_count: 30,
             included_keywords: vec![
                 "secret".to_string(),
@@ -182,7 +182,7 @@ pub fn included_keywords_on_path(c: &mut Criterion) {
     let mut event = SimpleEvent::Map(event_map);
 
     let scanner = Scanner::builder(&[RegexRuleConfig::new("value")
-        .proximity_keywords(ProximityKeywordsConfig {
+        .with_proximity_keywords(ProximityKeywordsConfig {
             look_ahead_character_count: 30,
             included_keywords: vec!["secret".to_string(), "ssn".to_string()],
             excluded_keywords: vec![],

--- a/sds/benches/multithreaded_scanning.rs
+++ b/sds/benches/multithreaded_scanning.rs
@@ -22,7 +22,7 @@ pub fn multithread_scanning(c: &mut Criterion) {
         .into_iter()
         .map(|(keywords, regex)| {
             RegexRuleConfig::new(&regex)
-                .proximity_keywords(ProximityKeywordsConfig {
+                .with_proximity_keywords(ProximityKeywordsConfig {
                     look_ahead_character_count: 30,
                     included_keywords: keywords,
                     excluded_keywords: vec![],

--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -47,8 +47,8 @@ pub use scanner::{
     regex_rule::config::{ProximityKeywordsConfig, RegexRuleConfig, SecondaryValidator},
     regex_rule::RegexCaches,
     scope::Scope,
-    CompiledRule, CompiledRuleDyn, MatchEmitter, ScanOptionBuilder, Scanner, ScannerBuilder,
-    StringMatch,
+    CompiledRule, CompiledRuleDyn, MatchEmitter, RootCompiledRule, RootRuleConfig,
+    ScanOptionBuilder, Scanner, ScannerBuilder, SharedData, StringMatch,
 };
 pub use scoped_ruleset::ExclusionCheck;
 pub use validation::{

--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -47,8 +47,8 @@ pub use scanner::{
     regex_rule::config::{ProximityKeywordsConfig, RegexRuleConfig, SecondaryValidator},
     regex_rule::RegexCaches,
     scope::Scope,
-    CompiledRule, CompiledRuleDyn, MatchEmitter, RootCompiledRule, RootRuleConfig,
-    ScanOptionBuilder, Scanner, ScannerBuilder, SharedData, StringMatch,
+    CompiledRule, MatchEmitter, RootCompiledRule, RootRuleConfig, ScanOptionBuilder, Scanner,
+    ScannerBuilder, SharedData, StringMatch,
 };
 pub use scoped_ruleset::ExclusionCheck;
 pub use validation::{

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -2,7 +2,8 @@ use super::{
     config::{HttpValidatorConfig, HttpValidatorConfigBuilder, RequestHeader},
     match_validator::MatchValidator,
 };
-use crate::{match_validation::config::HttpMethod, CompiledRuleDyn, MatchStatus, RuleMatch};
+use crate::scanner::RootCompiledRule;
+use crate::{match_validation::config::HttpMethod, MatchStatus, RuleMatch};
 use ahash::AHashMap;
 use lazy_static::lazy_static;
 use rayon::prelude::*;
@@ -99,7 +100,7 @@ impl HttpValidatorHelper {
 }
 
 impl MatchValidator for HttpValidator {
-    fn validate(&self, matches: &mut Vec<RuleMatch>, _: &[Box<dyn CompiledRuleDyn>]) {
+    fn validate(&self, matches: &mut Vec<RuleMatch>, _: &[RootCompiledRule]) {
         // build a map of match status per endpoint and per match_idx
         let mut match_status_per_endpoint_and_match: AHashMap<_, _> = matches
             .iter()

--- a/sds/src/match_validation/match_validator.rs
+++ b/sds/src/match_validation/match_validator.rs
@@ -1,8 +1,9 @@
-use crate::{CompiledRuleDyn, RuleMatch};
+use crate::scanner::RootCompiledRule;
+use crate::RuleMatch;
 use std::vec::Vec;
 
 pub trait MatchValidator: Send + Sync {
     // Trait use to validate the matches and update the match status
     // It requires the matches found by the scans and the scanner rules to retrieve the match validation type
-    fn validate(&self, matches: &mut Vec<RuleMatch>, scanner_rules: &[Box<dyn CompiledRuleDyn>]);
+    fn validate(&self, matches: &mut Vec<RuleMatch>, scanner_rules: &[RootCompiledRule]);
 }

--- a/sds/src/scanner/config.rs
+++ b/sds/src/scanner/config.rs
@@ -1,11 +1,10 @@
 use crate::scanner::error::CreateScannerError;
-use crate::scanner::CompiledRuleDyn;
-use crate::Labels;
+use crate::{CompiledRule, Labels};
 
 pub trait RuleConfig: Send + Sync {
     fn convert_to_compiled_rule(
         &self,
         rule_index: usize,
         label: Labels,
-    ) -> Result<Box<dyn CompiledRuleDyn>, CreateScannerError>;
+    ) -> Result<Box<dyn CompiledRule>, CreateScannerError>;
 }

--- a/sds/src/scanner/config.rs
+++ b/sds/src/scanner/config.rs
@@ -1,4 +1,3 @@
-use crate::match_validation::config::{InternalMatchValidationType, MatchValidationType};
 use crate::scanner::error::CreateScannerError;
 use crate::scanner::CompiledRuleDyn;
 use crate::Labels;
@@ -9,11 +8,4 @@ pub trait RuleConfig: Send + Sync {
         rule_index: usize,
         label: Labels,
     ) -> Result<Box<dyn CompiledRuleDyn>, CreateScannerError>;
-
-    fn get_match_validation_type(&self) -> Option<&MatchValidationType>;
-
-    fn get_internal_match_validation_type(&self) -> Option<InternalMatchValidationType> {
-        self.get_match_validation_type()
-            .map(|x| x.get_internal_match_validation_type())
-    }
 }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -70,6 +70,7 @@ pub struct RootRuleConfig<T> {
     #[deprecated(note = "Use `third_party_active_checker` instead")]
     match_validation_type: Option<MatchValidationType>,
     third_party_active_checker: Option<MatchValidationType>,
+    #[serde(flatten)]
     pub inner: T,
 }
 

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -80,6 +80,17 @@ where
     pub fn new_dyn(inner: T) -> RootRuleConfig<Arc<dyn RuleConfig>> {
         RootRuleConfig::new(Arc::new(inner) as Arc<dyn RuleConfig>)
     }
+
+    pub fn into_dyn(self) -> RootRuleConfig<Arc<dyn RuleConfig>> {
+        #[allow(deprecated)]
+        RootRuleConfig {
+            match_action: self.match_action,
+            scope: self.scope,
+            match_validation_type: self.match_validation_type,
+            third_party_active_checker: self.third_party_active_checker,
+            inner: Arc::new(self.inner),
+        }
+    }
 }
 
 impl<T> RootRuleConfig<T> {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -83,14 +83,7 @@ where
     }
 
     pub fn into_dyn(self) -> RootRuleConfig<Arc<dyn RuleConfig>> {
-        #[allow(deprecated)]
-        RootRuleConfig {
-            match_action: self.match_action,
-            scope: self.scope,
-            match_validation_type: self.match_validation_type,
-            third_party_active_checker: self.third_party_active_checker,
-            inner: Arc::new(self.inner),
-        }
+        self.map_inner(|x| Arc::new(x) as Arc<dyn RuleConfig>)
     }
 }
 
@@ -103,6 +96,17 @@ impl<T> RootRuleConfig<T> {
             match_validation_type: None,
             third_party_active_checker: None,
             inner,
+        }
+    }
+
+    pub fn map_inner<U>(self, func: impl FnOnce(T) -> U) -> RootRuleConfig<U> {
+        #[allow(deprecated)]
+        RootRuleConfig {
+            match_action: self.match_action,
+            scope: self.scope,
+            match_validation_type: self.match_validation_type,
+            third_party_active_checker: self.third_party_active_checker,
+            inner: func(self.inner),
         }
     }
 

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -194,6 +194,7 @@ pub trait CompiledRule: Send + Sync {
     /// or finding multiple matches. The default implementation just calls
     /// `get_string_matches`, but this can be overridden with a more efficient
     /// implementation if applicable
+    #[allow(clippy::too_many_arguments)]
     fn has_string_match(
         &self,
         content: &str,
@@ -431,7 +432,7 @@ impl Scanner {
             if let Some(match_validation_type) = rule.internal_match_validation_type() {
                 match_validator_rule_match_per_type
                     .entry(match_validation_type)
-                    .or_insert_with(|| vec![])
+                    .or_insert_with(Vec::new)
                     .push(rule_match)
             }
         }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -330,7 +330,6 @@ pub struct Scanner {
     labels: Labels,
     match_validators_per_type: AHashMap<InternalMatchValidationType, Box<dyn MatchValidator>>,
     per_scanner_data: SharedData,
-    // group_configs: AHashMap<TypeId, Box<dyn Any + Send + Sync>>,
 }
 
 impl Scanner {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -164,7 +164,7 @@ impl Deref for RootCompiledRule {
 
 // This is the public trait that is used to define the behavior of a compiled rule.
 pub trait CompiledRule: Send + Sync {
-    fn setup_per_scanner_data(&self, _per_scanner_data: &mut SharedData) {
+    fn init_per_scanner_data(&self, _per_scanner_data: &mut SharedData) {
         // by default, no per-scanner data is initialized
     }
 
@@ -718,7 +718,7 @@ impl ScannerBuilder<'_> {
         let mut per_scanner_data = SharedData::new();
 
         compiled_rules.iter().for_each(|rule| {
-            rule.setup_per_scanner_data(&mut per_scanner_data);
+            rule.init_per_scanner_data(&mut per_scanner_data);
         });
 
         let scoped_ruleset = ScopedRuleSet::new(

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -5,6 +5,7 @@ use crate::proximity_keywords::{
 use crate::scanner::metrics::RuleMetrics;
 use crate::scanner::regex_rule::regex_store::SharedRegex;
 use crate::scanner::regex_rule::RegexCaches;
+use crate::scanner::shared_data::SharedData;
 use crate::scanner::{get_next_regex_start, is_false_positive_match};
 use crate::secondary_validation::Validator;
 use crate::{CompiledRule, ExclusionCheck, Labels, MatchEmitter, Path, StringMatch};
@@ -26,11 +27,9 @@ pub struct RegexCompiledRule {
 impl CompiledRule for RegexCompiledRule {
     // no special data
     type GroupData = ();
-    type GroupConfig = ();
     type RuleScanCache = ();
 
     fn create_group_data(&self, _: &Labels) {}
-    fn create_group_config(&self) {}
     fn create_rule_scan_cache(&self) {}
     fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
         self.included_keywords.as_ref()
@@ -42,7 +41,7 @@ impl CompiledRule for RegexCompiledRule {
         path: &Path,
         regex_caches: &mut RegexCaches,
         _group_data: &mut (),
-        _group_config: &(),
+        _per_scanner_data: &SharedData,
         _rule_scan_cache: &mut (),
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
@@ -83,10 +82,6 @@ impl CompiledRule for RegexCompiledRule {
 
     fn on_excluded_match_multipass_v0(&self) {
         self.metrics.false_positive_excluded_attributes.increment(1);
-    }
-
-    fn process_scanner_config(&self, _: &mut Self::GroupConfig) {
-        // no special processing
     }
 }
 

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -8,7 +8,7 @@ use crate::scanner::regex_rule::RegexCaches;
 use crate::scanner::shared_data::SharedData;
 use crate::scanner::{get_next_regex_start, is_false_positive_match};
 use crate::secondary_validation::Validator;
-use crate::{CompiledRule, ExclusionCheck, Labels, MatchEmitter, Path, StringMatch};
+use crate::{CompiledRule, ExclusionCheck, MatchEmitter, Path, StringMatch};
 use ahash::AHashSet;
 use regex_automata::meta::Cache;
 use regex_automata::Input;
@@ -25,24 +25,14 @@ pub struct RegexCompiledRule {
 }
 
 impl CompiledRule for RegexCompiledRule {
-    // no special data
-    type GroupData = ();
-    type RuleScanCache = ();
-
-    fn create_group_data(&self, _: &Labels) {}
-    fn create_rule_scan_cache(&self) {}
-    fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
-        self.included_keywords.as_ref()
-    }
-
     fn get_string_matches(
         &self,
         content: &str,
         path: &Path,
         regex_caches: &mut RegexCaches,
-        _group_data: &mut (),
+        _per_string_data: &mut SharedData,
         _per_scanner_data: &SharedData,
-        _rule_scan_cache: &mut (),
+        _per_event_data: &mut SharedData,
         exclusion_check: &ExclusionCheck<'_>,
         excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -1,4 +1,3 @@
-use crate::match_validation::config::{InternalMatchValidationType, MatchValidationType};
 use crate::proximity_keywords::{
     contains_keyword_in_path, get_prefix_start, is_index_within_prefix,
     CompiledExcludedProximityKeywords, CompiledIncludedProximityKeywords,
@@ -6,10 +5,9 @@ use crate::proximity_keywords::{
 use crate::scanner::metrics::RuleMetrics;
 use crate::scanner::regex_rule::regex_store::SharedRegex;
 use crate::scanner::regex_rule::RegexCaches;
-use crate::scanner::scope::Scope;
 use crate::scanner::{get_next_regex_start, is_false_positive_match};
 use crate::secondary_validation::Validator;
-use crate::{CompiledRule, ExclusionCheck, Labels, MatchAction, MatchEmitter, Path, StringMatch};
+use crate::{CompiledRule, ExclusionCheck, Labels, MatchEmitter, Path, StringMatch};
 use ahash::AHashSet;
 use regex_automata::meta::Cache;
 use regex_automata::Input;
@@ -19,14 +17,10 @@ use std::sync::Arc;
 pub struct RegexCompiledRule {
     pub rule_index: usize,
     pub regex: SharedRegex,
-    pub match_action: MatchAction,
-    pub scope: Scope,
     pub included_keywords: Option<CompiledIncludedProximityKeywords>,
     pub excluded_keywords: Option<CompiledExcludedProximityKeywords>,
     pub validator: Option<Arc<dyn Validator>>,
     pub metrics: RuleMetrics,
-    pub match_validation_type: Option<MatchValidationType>,
-    pub internal_match_validation_type: Option<InternalMatchValidationType>,
 }
 
 impl CompiledRule for RegexCompiledRule {
@@ -35,15 +29,9 @@ impl CompiledRule for RegexCompiledRule {
     type GroupConfig = ();
     type RuleScanCache = ();
 
-    fn get_match_action(&self) -> &MatchAction {
-        &self.match_action
-    }
-    fn get_scope(&self) -> &Scope {
-        &self.scope
-    }
-    fn create_group_data(_: &Labels) {}
-    fn create_group_config() {}
-    fn create_rule_scan_cache() {}
+    fn create_group_data(&self, _: &Labels) {}
+    fn create_group_config(&self) {}
+    fn create_rule_scan_cache(&self) {}
     fn get_included_keywords(&self) -> Option<&CompiledIncludedProximityKeywords> {
         self.included_keywords.as_ref()
     }
@@ -97,19 +85,6 @@ impl CompiledRule for RegexCompiledRule {
         self.metrics.false_positive_excluded_attributes.increment(1);
     }
 
-    fn get_match_validation_type(&self) -> Option<&MatchValidationType> {
-        match &self.match_validation_type {
-            Some(match_validation_type) => Some(match_validation_type),
-            None => None,
-        }
-    }
-
-    fn get_internal_match_validation_type(&self) -> Option<&InternalMatchValidationType> {
-        match &self.internal_match_validation_type {
-            Some(internal_match_validation_type) => Some(internal_match_validation_type),
-            None => None,
-        }
-    }
     fn process_scanner_config(&self, _: &mut Self::GroupConfig) {
         // no special processing
     }

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -36,12 +36,6 @@ impl RegexRuleConfig {
         self.mutate_clone(|x| x.pattern = pattern)
     }
 
-    // pub fn match_action(&self, match_action: MatchAction) -> Self {
-    //     self.mutate_clone(|x| x.match_action = match_action)
-    // }
-    // pub fn scope(&self, scope: Scope) -> Self {
-    //     self.mutate_clone(|x| x.scope = scope)
-    // }
     pub fn proximity_keywords(&self, proximity_keywords: ProximityKeywordsConfig) -> Self {
         self.mutate_clone(|x| x.proximity_keywords = Some(proximity_keywords))
     }
@@ -53,10 +47,6 @@ impl RegexRuleConfig {
     pub fn labels(&self, labels: Labels) -> Self {
         self.mutate_clone(|x| x.labels = labels)
     }
-
-    // pub fn match_validation_type(&self, match_validation_type: MatchValidationType) -> Self {
-    //     self.mutate_clone(|x| x.match_validation_type = Some(match_validation_type))
-    // }
 
     pub fn build(&self) -> Arc<dyn RuleConfig> {
         Arc::new(self.clone())

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -5,7 +5,7 @@ use crate::scanner::regex_rule::compiled::RegexCompiledRule;
 use crate::scanner::regex_rule::regex_store::get_memoized_regex;
 use crate::secondary_validation::Validator;
 use crate::validation::validate_and_create_regex;
-use crate::{CompiledRuleDyn, CreateScannerError, Labels};
+use crate::{CompiledRule, CreateScannerError, Labels};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use serde_with::DefaultOnNull;
@@ -74,7 +74,7 @@ impl RuleConfig for RegexRuleConfig {
         &self,
         rule_index: usize,
         scanner_labels: Labels,
-    ) -> Result<Box<dyn CompiledRuleDyn>, CreateScannerError> {
+    ) -> Result<Box<dyn CompiledRule>, CreateScannerError> {
         let regex = get_memoized_regex(&self.pattern, validate_and_create_regex)?;
 
         let rule_labels = scanner_labels.clone_with_labels(self.labels.clone());

--- a/sds/src/scanner/shared_data.rs
+++ b/sds/src/scanner/shared_data.rs
@@ -12,7 +12,7 @@ impl SharedData {
         }
     }
 
-    pub fn get_mut<T: Default + Send + Sync + 'static>(&mut self) -> &mut T {
+    pub fn get_mut_or_default<T: Default + Send + Sync + 'static>(&mut self) -> &mut T {
         let any = self
             .map
             .entry(TypeId::of::<T>())
@@ -20,7 +20,29 @@ impl SharedData {
         any.downcast_mut().unwrap()
     }
 
-    pub fn get<T: Default + Send + Sync + 'static>(&self) -> Option<&T> {
+    pub fn get<T: Send + Sync + 'static>(&self) -> Option<&T> {
         Some(self.map.get(&TypeId::of::<T>())?.downcast_ref().unwrap())
+    }
+
+    pub fn get_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
+        Some(
+            self.map
+                .get_mut(&TypeId::of::<T>())?
+                .downcast_mut()
+                .unwrap(),
+        )
+    }
+
+    pub fn insert<T: Send + Sync + 'static>(&mut self, value: T) {
+        self.map.insert(TypeId::of::<T>(), Box::new(value));
+    }
+
+    pub fn insert_if_not_contains<T: Send + Sync + 'static>(
+        &mut self,
+        get_value: impl FnOnce() -> T,
+    ) {
+        self.map
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Box::new(get_value()));
     }
 }

--- a/sds/src/scanner/shared_data.rs
+++ b/sds/src/scanner/shared_data.rs
@@ -1,0 +1,26 @@
+use ahash::AHashMap;
+use std::any::{Any, TypeId};
+
+pub struct SharedData {
+    map: AHashMap<TypeId, Box<dyn Any + Send + Sync>>,
+}
+
+impl SharedData {
+    pub fn new() -> Self {
+        Self {
+            map: AHashMap::new(),
+        }
+    }
+
+    pub fn get_mut<T: Default + Send + Sync + 'static>(&mut self) -> &mut T {
+        let any = self
+            .map
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Box::new(T::default()));
+        any.downcast_mut().unwrap()
+    }
+
+    pub fn get<T: Default + Send + Sync + 'static>(&self) -> Option<&T> {
+        Some(self.map.get(&TypeId::of::<T>())?.downcast_ref().unwrap())
+    }
+}

--- a/sds/src/scanner/test/included_keywords.rs
+++ b/sds/src/scanner/test/included_keywords.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 fn test_included_keywords_match_content() {
     let redact_test_rule = RootRuleConfig::new(
         RegexRuleConfig::new("world")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["hello".to_string()],
                 excluded_keywords: vec![],
@@ -120,7 +120,7 @@ fn test_included_keywords_path_deep() {
 fn test_included_keyword_not_match_further_than_look_ahead_character_count() {
     let redact_test_rule = RootRuleConfig::new(
         RegexRuleConfig::new("world")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["hello".to_string()],
                 excluded_keywords: vec![],
@@ -143,7 +143,7 @@ fn test_included_keyword_not_match_further_than_look_ahead_character_count() {
 fn test_included_keyword_multiple_matches_in_one_prefix() {
     let redact_test_rule = RootRuleConfig::new(
         RegexRuleConfig::new("world")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["hello".to_string()],
                 excluded_keywords: vec![],
@@ -167,7 +167,7 @@ fn test_included_keyword_multiple_matches_in_one_prefix() {
 fn test_included_keyword_multiple_prefix_matches() {
     let redact_test_rule = RootRuleConfig::new(
         RegexRuleConfig::new("world")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["hello".to_string()],
                 excluded_keywords: vec![],
@@ -193,7 +193,7 @@ fn test_included_keyword_multiple_prefix_matches() {
 fn test_included_keywords_on_start_boundary_with_space_including_word_boundary() {
     let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
         RegexRuleConfig::new("ab")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["id".to_string()],
                 excluded_keywords: vec![],
@@ -215,7 +215,7 @@ fn test_included_keywords_on_start_boundary_with_space_including_word_boundary()
 fn test_included_keywords_on_end_boundary() {
     let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
         RegexRuleConfig::new("abc")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["id".to_string()],
                 excluded_keywords: vec![],
@@ -235,7 +235,7 @@ fn test_included_keywords_on_end_boundary() {
 fn should_not_look_ahead_too_far() {
     let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
         RegexRuleConfig::new("x")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 10,
                 included_keywords: vec!["host".to_string()],
                 excluded_keywords: vec![],
@@ -262,7 +262,7 @@ fn should_not_look_ahead_too_far() {
 fn should_verify_included_keywords_on_path_even_if_included_keywords_are_in_string() {
     let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
         RegexRuleConfig::new("world")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 10,
                 included_keywords: vec!["hello".to_string()],
                 excluded_keywords: vec![],
@@ -286,7 +286,7 @@ fn should_verify_included_keywords_on_path_even_if_included_keywords_are_in_stri
 fn test_included_and_excluded_keyword() {
     let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
         RegexRuleConfig::new("world")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 11,
                 included_keywords: vec!["hey".to_string()],
                 excluded_keywords: vec!["hello".to_string()],

--- a/sds/src/scanner/test/included_keywords.rs
+++ b/sds/src/scanner/test/included_keywords.rs
@@ -1,19 +1,22 @@
 use crate::scanner::test::build_test_scanner;
+use crate::scanner::RootRuleConfig;
 use crate::{MatchAction, ProximityKeywordsConfig, RegexRuleConfig, ScannerBuilder, SimpleEvent};
 use std::collections::BTreeMap;
 
 #[test]
 fn test_included_keywords_match_content() {
-    let redact_test_rule = RegexRuleConfig::new("world")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec!["hello".to_string()],
-            excluded_keywords: vec![],
-        })
-        .build();
+    let redact_test_rule = RootRuleConfig::new(
+        RegexRuleConfig::new("world")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["hello".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    });
 
     let scanner = ScannerBuilder::new(&[redact_test_rule]).build().unwrap();
     let mut content = "hello world".to_string();
@@ -115,16 +118,18 @@ fn test_included_keywords_path_deep() {
 
 #[test]
 fn test_included_keyword_not_match_further_than_look_ahead_character_count() {
-    let redact_test_rule = RegexRuleConfig::new("world")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec!["hello".to_string()],
-            excluded_keywords: vec![],
-        })
-        .build();
+    let redact_test_rule = RootRuleConfig::new(
+        RegexRuleConfig::new("world")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["hello".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    });
 
     let scanner = ScannerBuilder::new(&[redact_test_rule]).build().unwrap();
 
@@ -136,16 +141,18 @@ fn test_included_keyword_not_match_further_than_look_ahead_character_count() {
 
 #[test]
 fn test_included_keyword_multiple_matches_in_one_prefix() {
-    let redact_test_rule = RegexRuleConfig::new("world")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec!["hello".to_string()],
-            excluded_keywords: vec![],
-        })
-        .build();
+    let redact_test_rule = RootRuleConfig::new(
+        RegexRuleConfig::new("world")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["hello".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    });
 
     let scanner = ScannerBuilder::new(&[redact_test_rule]).build().unwrap();
 
@@ -158,16 +165,18 @@ fn test_included_keyword_multiple_matches_in_one_prefix() {
 
 #[test]
 fn test_included_keyword_multiple_prefix_matches() {
-    let redact_test_rule = RegexRuleConfig::new("world")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec!["hello".to_string()],
-            excluded_keywords: vec![],
-        })
-        .build();
+    let redact_test_rule = RootRuleConfig::new(
+        RegexRuleConfig::new("world")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["hello".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    });
 
     let scanner = ScannerBuilder::new(&[redact_test_rule]).build().unwrap();
 
@@ -182,13 +191,15 @@ fn test_included_keyword_multiple_prefix_matches() {
 
 #[test]
 fn test_included_keywords_on_start_boundary_with_space_including_word_boundary() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("ab")
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec!["id".to_string()],
-            excluded_keywords: vec![],
-        })
-        .build()])
+    let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
+        RegexRuleConfig::new("ab")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["id".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )])
     .build()
     .unwrap();
 
@@ -202,13 +213,15 @@ fn test_included_keywords_on_start_boundary_with_space_including_word_boundary()
 
 #[test]
 fn test_included_keywords_on_end_boundary() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("abc")
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec!["id".to_string()],
-            excluded_keywords: vec![],
-        })
-        .build()])
+    let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
+        RegexRuleConfig::new("abc")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["id".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )])
     .build()
     .unwrap();
 
@@ -220,13 +233,15 @@ fn test_included_keywords_on_end_boundary() {
 
 #[test]
 fn should_not_look_ahead_too_far() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("x")
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 10,
-            included_keywords: vec!["host".to_string()],
-            excluded_keywords: vec![],
-        })
-        .build()])
+    let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
+        RegexRuleConfig::new("x")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 10,
+                included_keywords: vec!["host".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )])
     .build()
     .unwrap();
 
@@ -245,13 +260,15 @@ fn should_not_look_ahead_too_far() {
 
 #[test]
 fn should_verify_included_keywords_on_path_even_if_included_keywords_are_in_string() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("world")
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 10,
-            included_keywords: vec!["hello".to_string()],
-            excluded_keywords: vec![],
-        })
-        .build()])
+    let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
+        RegexRuleConfig::new("world")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 10,
+                included_keywords: vec!["hello".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )])
     .build()
     .unwrap();
 
@@ -267,13 +284,15 @@ fn should_verify_included_keywords_on_path_even_if_included_keywords_are_in_stri
 
 #[test]
 fn test_included_and_excluded_keyword() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("world")
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 11,
-            included_keywords: vec!["hey".to_string()],
-            excluded_keywords: vec!["hello".to_string()],
-        })
-        .build()])
+    let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
+        RegexRuleConfig::new("world")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 11,
+                included_keywords: vec!["hey".to_string()],
+                excluded_keywords: vec!["hello".to_string()],
+            })
+            .build(),
+    )])
     .build()
     .unwrap();
 

--- a/sds/src/scanner/test/match_validation.rs
+++ b/sds/src/scanner/test/match_validation.rs
@@ -437,7 +437,7 @@ fn test_mock_aws_validator() {
 
     let rule_aws_secret = RootRuleConfig::new(
         RegexRuleConfig::new("[A-Za-z0-9/+]{40}")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["aws_secret".to_string()],
                 excluded_keywords: vec![],

--- a/sds/src/scanner/test/match_validation.rs
+++ b/sds/src/scanner/test/match_validation.rs
@@ -1,4 +1,5 @@
 use crate::match_validation::validator_utils::generate_aws_headers_and_body;
+use crate::scanner::RootRuleConfig;
 use crate::{
     AwsConfig, AwsType, HttpValidatorConfigBuilder, InternalMatchValidationType, MatchAction,
     MatchStatus, MatchValidationType, ProximityKeywordsConfig, RegexRuleConfig, ScannerBuilder,
@@ -10,18 +11,18 @@ use std::time::Duration;
 
 #[test]
 fn test_should_return_match_with_match_validation() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("world")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .match_validation_type(MatchValidationType::CustomHttp(
-            HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
-                .build()
-                .unwrap(),
-        ))
-        .build()])
-    .build()
-    .unwrap();
+    let scanner =
+        ScannerBuilder::new(&[RootRuleConfig::new(RegexRuleConfig::new("world").build())
+            .match_action(MatchAction::Redact {
+                replacement: "[REDACTED]".to_string(),
+            })
+            .match_validation_type(MatchValidationType::CustomHttp(
+                HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
+                    .build()
+                    .unwrap(),
+            ))])
+        .build()
+        .unwrap();
 
     let mut content = "hey world".to_string();
     let rule_match = scanner.scan(&mut content);
@@ -32,13 +33,13 @@ fn test_should_return_match_with_match_validation() {
 
 #[test]
 fn test_should_error_if_no_match_validation() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("world")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .build()])
-    .build()
-    .unwrap();
+    let scanner =
+        ScannerBuilder::new(&[RootRuleConfig::new(RegexRuleConfig::new("world").build())
+            .match_action(MatchAction::Redact {
+                replacement: "[REDACTED]".to_string(),
+            })])
+        .build()
+        .unwrap();
 
     let mut content = "hey world".to_string();
     let mut rule_match = scanner.scan(&mut content);
@@ -54,53 +55,51 @@ fn test_should_error_if_no_match_validation() {
 fn test_should_allocate_match_validator_depending_on_match_type() {
     use crate::match_validation::config::AwsConfig;
 
-    let rule_aws_id = RegexRuleConfig::new("aws-id")
+    let rule_aws_id = RootRuleConfig::new(RegexRuleConfig::new("aws-id").build())
         .match_action(MatchAction::Redact {
             replacement: "[AWS ID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId))
-        .build();
-    let rule_aws_secret = RegexRuleConfig::new("aws-secret")
+        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId));
+    let rule_aws_secret = RootRuleConfig::new(RegexRuleConfig::new("aws-secret").build())
         .match_action(MatchAction::Redact {
             replacement: "[AWS SECRET]".to_string(),
         })
         .match_validation_type(MatchValidationType::Aws(AwsType::AwsSecret(
             AwsConfig::default(),
-        )))
-        .build();
+        )));
 
-    let rule_custom_http_1_domain_1 = RegexRuleConfig::new("custom-http1")
-        .match_action(MatchAction::Redact {
-            replacement: "[CUSTOM HTTP1]".to_string(),
-        })
-        .match_validation_type(MatchValidationType::CustomHttp(
-            HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
-                .build()
-                .unwrap(),
-        ))
-        .build();
+    let rule_custom_http_1_domain_1 =
+        RootRuleConfig::new(RegexRuleConfig::new("custom-http1").build())
+            .match_action(MatchAction::Redact {
+                replacement: "[CUSTOM HTTP1]".to_string(),
+            })
+            .match_validation_type(MatchValidationType::CustomHttp(
+                HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
+                    .build()
+                    .unwrap(),
+            ));
 
-    let rule_custom_http_2_domain_1 = RegexRuleConfig::new("custom-http2")
-        .match_action(MatchAction::Redact {
-            replacement: "[CUSTOM HTTP2]".to_string(),
-        })
-        .match_validation_type(MatchValidationType::CustomHttp(
-            HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
-                .build()
-                .unwrap(),
-        ))
-        .build();
+    let rule_custom_http_2_domain_1 =
+        RootRuleConfig::new(RegexRuleConfig::new("custom-http2").build())
+            .match_action(MatchAction::Redact {
+                replacement: "[CUSTOM HTTP2]".to_string(),
+            })
+            .match_validation_type(MatchValidationType::CustomHttp(
+                HttpValidatorConfigBuilder::new("http://localhost:8080".to_string())
+                    .build()
+                    .unwrap(),
+            ));
 
-    let rule_custom_http_domain_2 = RegexRuleConfig::new("custom-http3")
-        .match_action(MatchAction::Redact {
-            replacement: "[CUSTOM HTTP2]".to_string(),
-        })
-        .match_validation_type(MatchValidationType::CustomHttp(
-            HttpValidatorConfigBuilder::new("http://localhost:8081".to_string())
-                .build()
-                .unwrap(),
-        ))
-        .build();
+    let rule_custom_http_domain_2 =
+        RootRuleConfig::new(RegexRuleConfig::new("custom-http3").build())
+            .match_action(MatchAction::Redact {
+                replacement: "[CUSTOM HTTP2]".to_string(),
+            })
+            .match_validation_type(MatchValidationType::CustomHttp(
+                HttpValidatorConfigBuilder::new("http://localhost:8081".to_string())
+                    .build()
+                    .unwrap(),
+            ));
 
     let scanner = ScannerBuilder::new(&[
         rule_aws_id,
@@ -145,12 +144,11 @@ fn test_should_allocate_match_validator_depending_on_match_type() {
 
 #[test]
 fn test_aws_id_only_shall_not_validate() {
-    let rule_aws_id = RegexRuleConfig::new("aws_id")
+    let rule_aws_id = RootRuleConfig::new(RegexRuleConfig::new("aws_id").build())
         .match_action(MatchAction::Redact {
             replacement: "[AWS_ID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId))
-        .build();
+        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId));
 
     let scanner = ScannerBuilder::new(&[rule_aws_id]).build().unwrap();
     let mut content = "this is an aws_id".to_string();
@@ -185,7 +183,7 @@ fn test_mock_same_http_validator_several_matches() {
         then.status(500).header("content-type", "text/html");
     });
 
-    let rule_valid_match = RegexRuleConfig::new("\\bvalid_match\\b")
+    let rule_valid_match = RootRuleConfig::new(RegexRuleConfig::new("\\bvalid_match\\b").build())
         .match_action(MatchAction::Redact {
             replacement: "[VALID]".to_string(),
         })
@@ -193,21 +191,20 @@ fn test_mock_same_http_validator_several_matches() {
             HttpValidatorConfigBuilder::new(server.url("/").to_string())
                 .build()
                 .unwrap(),
-        ))
-        .build();
+        ));
 
-    let rule_invalid_match = RegexRuleConfig::new("\\binvalid_match\\b")
-        .match_action(MatchAction::Redact {
-            replacement: "[INVALID]".to_string(),
-        })
-        .match_validation_type(MatchValidationType::CustomHttp(
-            HttpValidatorConfigBuilder::new(server.url("/").to_string())
-                .build()
-                .unwrap(),
-        ))
-        .build();
+    let rule_invalid_match =
+        RootRuleConfig::new(RegexRuleConfig::new("\\binvalid_match\\b").build())
+            .match_action(MatchAction::Redact {
+                replacement: "[INVALID]".to_string(),
+            })
+            .match_validation_type(MatchValidationType::CustomHttp(
+                HttpValidatorConfigBuilder::new(server.url("/").to_string())
+                    .build()
+                    .unwrap(),
+            ));
 
-    let rule_error_match = RegexRuleConfig::new("\\berror_match\\b")
+    let rule_error_match = RootRuleConfig::new(RegexRuleConfig::new("\\berror_match\\b").build())
         .match_action(MatchAction::Redact {
             replacement: "[ERROR]".to_string(),
         })
@@ -215,8 +212,7 @@ fn test_mock_same_http_validator_several_matches() {
             HttpValidatorConfigBuilder::new(server.url("/").to_string())
                 .build()
                 .unwrap(),
-        ))
-        .build();
+        ));
     let scanner = ScannerBuilder::new(&[rule_valid_match, rule_invalid_match, rule_error_match])
         .build()
         .unwrap();
@@ -250,7 +246,7 @@ fn test_mock_http_timeout() {
             .header("authorization", "Bearer valid_match");
         then.status(200);
     });
-    let rule_valid_match = RegexRuleConfig::new("\\bvalid_match\\b")
+    let rule_valid_match = RootRuleConfig::new(RegexRuleConfig::new("\\bvalid_match\\b").build())
         .match_action(MatchAction::Redact {
             replacement: "[VALID]".to_string(),
         })
@@ -259,8 +255,7 @@ fn test_mock_http_timeout() {
                 .set_timeout(Duration::from_micros(0))
                 .build()
                 .unwrap(),
-        ))
-        .build();
+        ));
 
     let scanner = ScannerBuilder::new(&[rule_valid_match]).build().unwrap();
 
@@ -291,7 +286,7 @@ fn test_mock_multiple_match_validators() {
         then.status(200);
     });
 
-    let rule_valid_match = RegexRuleConfig::new("\\bvalid_match\\b")
+    let rule_valid_match = RootRuleConfig::new(RegexRuleConfig::new("\\bvalid_match\\b").build())
         .match_action(MatchAction::Redact {
             replacement: "[VALID]".to_string(),
         })
@@ -299,17 +294,15 @@ fn test_mock_multiple_match_validators() {
             HttpValidatorConfigBuilder::new(server.url("/http-service").to_string())
                 .build()
                 .unwrap(),
-        ))
-        .build();
+        ));
 
-    let rule_aws_id = RegexRuleConfig::new("\\baws_id\\b")
+    let rule_aws_id = RootRuleConfig::new(RegexRuleConfig::new("\\baws_id\\b").build())
         .match_action(MatchAction::Redact {
             replacement: "[AWS_ID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId))
-        .build();
+        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId));
 
-    let rule_aws_secret = RegexRuleConfig::new("\\baws_secret\\b")
+    let rule_aws_secret = RootRuleConfig::new(RegexRuleConfig::new("\\baws_secret\\b").build())
         .match_action(MatchAction::Redact {
             replacement: "[AWS_SECRET]".to_string(),
         })
@@ -317,8 +310,7 @@ fn test_mock_multiple_match_validators() {
             aws_sts_endpoint: server.url("/aws-service").to_string(),
             forced_datetime_utc: None,
             timeout: Duration::from_secs(1),
-        })))
-        .build();
+        })));
 
     let scanner = ScannerBuilder::new(&[rule_valid_match, rule_aws_id, rule_aws_secret])
         .build()
@@ -352,7 +344,7 @@ fn test_mock_endpoint_with_multiple_hosts() {
         when.method(GET).path("/eu-service");
         then.status(403);
     });
-    let rule_valid_match = RegexRuleConfig::new("\\bvalid_match\\b")
+    let rule_valid_match = RootRuleConfig::new(RegexRuleConfig::new("\\bvalid_match\\b").build())
         .match_action(MatchAction::Redact {
             replacement: "[VALID]".to_string(),
         })
@@ -361,8 +353,7 @@ fn test_mock_endpoint_with_multiple_hosts() {
                 .set_hosts(vec!["us".to_string(), "eu".to_string()])
                 .build()
                 .unwrap(),
-        ))
-        .build();
+        ));
 
     let scanner = ScannerBuilder::new(&[rule_valid_match]).build().unwrap();
     let mut content = "this is a content with a valid_match on multiple hosts".to_string();
@@ -438,28 +429,29 @@ fn test_mock_aws_validator() {
             .header("authorization", error_authorization_2.to_str().unwrap());
         then.status(500);
     });
-    let rule_aws_id = RegexRuleConfig::new("AKIA[0-9A-Z]{16}")
+    let rule_aws_id = RootRuleConfig::new(RegexRuleConfig::new("AKIA[0-9A-Z]{16}").build())
         .match_action(MatchAction::Redact {
             replacement: "[AWS_ID]".to_string(),
         })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId))
-        .build();
+        .match_validation_type(MatchValidationType::Aws(AwsType::AwsId));
 
-    let rule_aws_secret = RegexRuleConfig::new("[A-Za-z0-9/+]{40}")
-        .match_action(MatchAction::Redact {
-            replacement: "[AWS_SECRET]".to_string(),
-        })
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec!["aws_secret".to_string()],
-            excluded_keywords: vec![],
-        })
-        .match_validation_type(MatchValidationType::Aws(AwsType::AwsSecret(AwsConfig {
-            aws_sts_endpoint: server_url.clone(),
-            forced_datetime_utc: Some(datetime),
-            timeout: Duration::from_secs(5),
-        })))
-        .build();
+    let rule_aws_secret = RootRuleConfig::new(
+        RegexRuleConfig::new("[A-Za-z0-9/+]{40}")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["aws_secret".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )
+    .match_validation_type(MatchValidationType::Aws(AwsType::AwsSecret(AwsConfig {
+        aws_sts_endpoint: server_url.clone(),
+        forced_datetime_utc: Some(datetime),
+        timeout: Duration::from_secs(5),
+    })))
+    .match_action(MatchAction::Redact {
+        replacement: "[AWS_SECRET]".to_string(),
+    });
 
     let scanner = ScannerBuilder::new(&[rule_aws_id, rule_aws_secret])
         .build()

--- a/sds/src/scanner/test/metrics.rs
+++ b/sds/src/scanner/test/metrics.rs
@@ -104,7 +104,7 @@ fn should_submit_excluded_keywords_metric() {
     metrics::with_local_recorder(&recorder, || {
         let redact_test_rule = RootRuleConfig::new(
             RegexRuleConfig::new("world")
-                .proximity_keywords(ProximityKeywordsConfig {
+                .with_proximity_keywords(ProximityKeywordsConfig {
                     look_ahead_character_count: 30,
                     included_keywords: vec![],
                     excluded_keywords: vec!["hello".to_string()],
@@ -143,7 +143,7 @@ fn should_submit_excluded_keywords_metric() {
 fn test_regex_match_and_included_keyword_same_index() {
     let email_rule = RootRuleConfig::new(
         RegexRuleConfig::new(".+")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["email".to_string()],
                 excluded_keywords: vec![],

--- a/sds/src/scanner/test/mod.rs
+++ b/sds/src/scanner/test/mod.rs
@@ -290,7 +290,7 @@ fn test_indices() {
 fn build_test_scanner() -> Scanner {
     let redact_test_rule = RootRuleConfig::new(
         RegexRuleConfig::new("world")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["awsAccess".to_string(), "access/key".to_string()],
                 excluded_keywords: vec![],
@@ -373,7 +373,7 @@ fn test_blocked_rules() {
 fn test_excluded_keywords() {
     let redact_test_rule = RootRuleConfig::new(
         RegexRuleConfig::new("world")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec![],
                 excluded_keywords: vec!["hello".to_string()],
@@ -544,7 +544,7 @@ fn should_not_exclude_false_positive_matches() {
     // it is not saved in the excluded matches.
     let rule_0 = RootRuleConfig::new(
         RegexRuleConfig::new("b.*")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec!["secret".to_string()],
                 excluded_keywords: vec![],
@@ -684,7 +684,7 @@ fn test_internal_overlapping_matches() {
     // A simple "credit-card rule is modified a bit to allow a multi-char character in the match
     let rule_0 = RootRuleConfig::new(
         RegexRuleConfig::new("([\\d€]+){1}(,\\d+){3}")
-            .validator(LuhnChecksum)
+            .with_validator(Some(LuhnChecksum))
             .build(),
     )
     .match_action(MatchAction::Redact {
@@ -713,7 +713,7 @@ fn test_next_regex_start_after_false_positive() {
 fn test_excluded_keyword_with_excluded_chars_in_content() {
     let rule_0 = RootRuleConfig::new(
         RegexRuleConfig::new("value")
-            .proximity_keywords(ProximityKeywordsConfig {
+            .with_proximity_keywords(ProximityKeywordsConfig {
                 look_ahead_character_count: 30,
                 included_keywords: vec![],
                 excluded_keywords: vec!["test".to_string()],

--- a/sds/src/scanner/test/mod.rs
+++ b/sds/src/scanner/test/mod.rs
@@ -9,7 +9,6 @@ use super::*;
 use super::{MatchEmitter, ScannerBuilder, StringMatch};
 use crate::match_action::{MatchAction, MatchActionValidationError};
 
-use crate::match_validation::config::MatchValidationType;
 use crate::observability::labels::Labels;
 use crate::scanner::regex_rule::config::{
     ProximityKeywordsConfig, RegexRuleConfig, SecondaryValidator::*,
@@ -31,26 +30,16 @@ use super::RuleConfig;
 
 pub struct DumbRuleConfig {}
 
-pub struct DumbCompiledRule {
-    pub match_action: MatchAction,
-    pub scope: Scope,
-}
+pub struct DumbCompiledRule {}
 
 impl CompiledRule for DumbCompiledRule {
     type GroupData = ();
     type GroupConfig = ();
     type RuleScanCache = ();
 
-    fn get_match_action(&self) -> &MatchAction {
-        &self.match_action
-    }
-    fn get_scope(&self) -> &Scope {
-        &self.scope
-    }
-
-    fn create_group_data(_: &Labels) {}
-    fn create_group_config() {}
-    fn create_rule_scan_cache() {}
+    fn create_group_data(&self, _: &Labels) {}
+    fn create_group_config(&self) {}
+    fn create_rule_scan_cache(&self) {}
 
     fn get_string_matches(
         &self,
@@ -68,13 +57,6 @@ impl CompiledRule for DumbCompiledRule {
         match_emitter.emit(StringMatch { start: 10, end: 16 });
     }
 
-    fn get_match_validation_type(&self) -> Option<&MatchValidationType> {
-        None
-    }
-
-    fn get_internal_match_validation_type(&self) -> Option<&InternalMatchValidationType> {
-        None
-    }
     fn process_scanner_config(&self, _: &mut Self::GroupConfig) {
         // do nothing
     }
@@ -86,24 +68,20 @@ impl RuleConfig for DumbRuleConfig {
         _content: usize,
         _: Labels,
     ) -> Result<Box<dyn CompiledRuleDyn>, CreateScannerError> {
-        Ok(Box::new(DumbCompiledRule {
-            match_action: MatchAction::Redact {
-                replacement: "[REDACTED]".to_string(),
-            },
-            scope: Scope::default(),
-        }))
-    }
-
-    fn get_match_validation_type(&self) -> Option<&MatchValidationType> {
-        None
+        Ok(Box::new(DumbCompiledRule {}))
     }
 }
 
 #[test]
 fn dumb_custom_rule() {
-    let scanner = ScannerBuilder::new(&[Arc::new(DumbRuleConfig {})])
-        .build()
-        .unwrap();
+    let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
+        Arc::new(DumbRuleConfig {}) as Arc<dyn RuleConfig>
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    })])
+    .build()
+    .unwrap();
 
     let mut input = "this is a secret with random data".to_owned();
 
@@ -116,12 +94,16 @@ fn dumb_custom_rule() {
 #[test]
 fn test_mixed_rules() {
     let scanner = ScannerBuilder::new(&[
-        Arc::new(DumbRuleConfig {}),
-        RegexRuleConfig::new("secret")
-            .match_action(MatchAction::Redact {
+        RootRuleConfig::new(Arc::new(DumbRuleConfig {}) as Arc<dyn RuleConfig>).match_action(
+            MatchAction::Redact {
+                replacement: "[REDACTED]".to_string(),
+            },
+        ),
+        RootRuleConfig::new(RegexRuleConfig::new("secret").build()).match_action(
+            MatchAction::Redact {
                 replacement: "[SECRET]".to_string(),
-            })
-            .build(),
+            },
+        ),
     ])
     .build()
     .unwrap();
@@ -139,11 +121,12 @@ fn test_mixed_rules() {
 
 #[test]
 fn simple_redaction() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("secret")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .build()])
+    let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
+        RegexRuleConfig::new("secret").build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    })])
     .build()
     .unwrap();
 
@@ -157,11 +140,12 @@ fn simple_redaction() {
 
 #[test]
 fn simple_redaction_with_additional_labels() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("secret")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .build()])
+    let scanner = ScannerBuilder::new(&[RootRuleConfig::new(
+        RegexRuleConfig::new("secret").build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    })])
     .labels(Labels::new(&[("key".to_string(), "value".to_string())]))
     .build()
     .unwrap();
@@ -176,7 +160,8 @@ fn simple_redaction_with_additional_labels() {
 
 #[test]
 fn should_fail_on_compilation_error() {
-    let scanner_result = ScannerBuilder::new(&[RegexRuleConfig::new("\\u").build()]).build();
+    let scanner_result =
+        ScannerBuilder::new(&[RootRuleConfig::new(RegexRuleConfig::new("\\u").build())]).build();
     assert!(scanner_result.is_err());
     assert_eq!(
         scanner_result.err().unwrap(),
@@ -186,12 +171,13 @@ fn should_fail_on_compilation_error() {
 
 #[test]
 fn should_validate_zero_char_count_partial_redact() {
-    let scanner_result = ScannerBuilder::new(&[RegexRuleConfig::new("secret")
-        .match_action(MatchAction::PartialRedact {
-            direction: PartialRedactDirection::LastCharacters,
-            character_count: 0,
-        })
-        .build()])
+    let scanner_result = ScannerBuilder::new(&[RootRuleConfig::new(
+        RegexRuleConfig::new("secret").build(),
+    )
+    .match_action(MatchAction::PartialRedact {
+        direction: PartialRedactDirection::LastCharacters,
+        character_count: 0,
+    })])
     .build();
 
     assert!(scanner_result.is_err());
@@ -205,11 +191,10 @@ fn should_validate_zero_char_count_partial_redact() {
 
 #[test]
 fn multiple_replacements() {
-    let scanner = ScannerBuilder::new(&[RegexRuleConfig::new("\\d")
+    let scanner = ScannerBuilder::new(&[RootRuleConfig::new(RegexRuleConfig::new("\\d").build())
         .match_action(MatchAction::Redact {
             replacement: "[REDACTED]".to_string(),
-        })
-        .build()])
+        })])
     .build()
     .unwrap();
 
@@ -224,8 +209,8 @@ fn multiple_replacements() {
 #[test]
 fn match_rule_index() {
     let scanner = ScannerBuilder::new(&[
-        RegexRuleConfig::new("a").build(),
-        RegexRuleConfig::new("b").build(),
+        RootRuleConfig::new(RegexRuleConfig::new("a").build()),
+        RootRuleConfig::new(RegexRuleConfig::new("b").build()),
     ])
     .build()
     .unwrap();
@@ -259,17 +244,16 @@ fn match_rule_index() {
 #[test]
 fn test_indices() {
     let test_builder = RegexRuleConfig::new("test");
-    let detect_test_rule = test_builder.build();
-    let redact_test_rule = test_builder
-        .match_action(MatchAction::Redact {
+    let detect_test_rule = RootRuleConfig::new(test_builder.build());
+    let redact_test_rule =
+        RootRuleConfig::new(test_builder.build()).match_action(MatchAction::Redact {
             replacement: "[test]".to_string(),
-        })
-        .build();
-    let redact_test_rule_2 = RegexRuleConfig::new("ab")
-        .match_action(MatchAction::Redact {
+        });
+
+    let redact_test_rule_2 =
+        RootRuleConfig::new(RegexRuleConfig::new("ab").build()).match_action(MatchAction::Redact {
             replacement: "[ab]".to_string(),
-        })
-        .build();
+        });
 
     let test_cases = vec![
         (vec![detect_test_rule.clone()], "test1", vec![(0, 4, 0)]),
@@ -317,18 +301,19 @@ fn test_indices() {
 }
 
 fn build_test_scanner() -> Scanner {
-    let redact_test_rule = RegexRuleConfig::new("world")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec!["awsAccess".to_string(), "access/key".to_string()],
-            excluded_keywords: vec![],
-        })
-        .build();
-
-    return Scanner::builder(&[redact_test_rule]).build().unwrap();
+    let redact_test_rule = RootRuleConfig::new(
+        RegexRuleConfig::new("world")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["awsAccess".to_string(), "access/key".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    });
+    Scanner::builder(&[redact_test_rule]).build().unwrap()
 }
 
 #[test]
@@ -371,11 +356,11 @@ fn test_included_keywords_path_not_matching() {
 
 #[test]
 fn test_blocked_rules() {
-    let redact_test_rule = RegexRuleConfig::new("world")
-        .match_action(MatchAction::Redact {
+    let redact_test_rule = RootRuleConfig::new(RegexRuleConfig::new("world").build()).match_action(
+        MatchAction::Redact {
             replacement: "[REDACTED]".to_string(),
-        })
-        .build();
+        },
+    );
 
     let scanner = ScannerBuilder::new(&[redact_test_rule]).build().unwrap();
     let mut content = "hello world".to_string();
@@ -399,16 +384,18 @@ fn test_blocked_rules() {
 
 #[test]
 fn test_excluded_keywords() {
-    let redact_test_rule = RegexRuleConfig::new("world")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec![],
-            excluded_keywords: vec!["hello".to_string()],
-        })
-        .build();
+    let redact_test_rule = RootRuleConfig::new(
+        RegexRuleConfig::new("world")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec![],
+                excluded_keywords: vec!["hello".to_string()],
+            })
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    });
 
     let scanner = ScannerBuilder::new(&[redact_test_rule]).build().unwrap();
     let mut content = "hello world".to_string();
@@ -424,12 +411,12 @@ fn test_excluded_keywords() {
 
 #[test]
 fn test_multiple_partial_redactions() {
-    let rule = RegexRuleConfig::new("...")
-        .match_action(MatchAction::PartialRedact {
+    let rule = RootRuleConfig::new(RegexRuleConfig::new("...").build()).match_action(
+        MatchAction::PartialRedact {
             direction: PartialRedactDirection::FirstCharacters,
             character_count: 1,
-        })
-        .build();
+        },
+    );
 
     let scanner = ScannerBuilder::new(&[rule.clone(), rule]).build().unwrap();
     let mut content = "hello world".to_string();
@@ -500,15 +487,13 @@ fn assert_scanner_is_sync_send() {
 #[test]
 fn should_skip_match_when_present_in_excluded_matches() {
     // If 2 matches have the same mutation and same start, the longer one is taken
-
-    let rule_0 = RegexRuleConfig::new("b.*")
+    let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("b.*").build())
         .scope(Scope::exclude(vec![Path::from(vec![PathSegment::Field(
             "test".into(),
         )])]))
         .match_action(MatchAction::Redact {
             replacement: "[scrub]".to_string(),
-        })
-        .build();
+        });
 
     let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
 
@@ -534,14 +519,13 @@ fn should_skip_match_when_present_in_excluded_matches() {
 
 #[test]
 fn should_be_able_to_disable_multipass_v0() {
-    let rule_0 = RegexRuleConfig::new("b.*")
+    let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("b.*").build())
         .scope(Scope::exclude(vec![Path::from(vec![PathSegment::Field(
             "test".into(),
         )])]))
         .match_action(MatchAction::Redact {
             replacement: "[scrub]".to_string(),
-        })
-        .build();
+        });
 
     let scanner = ScannerBuilder::new(&[rule_0])
         .with_multipass_v0(false)
@@ -571,20 +555,21 @@ fn should_be_able_to_disable_multipass_v0() {
 fn should_not_exclude_false_positive_matches() {
     // If a match in an excluded scope is a false-positive due to keyword proximity matching,
     // it is not saved in the excluded matches.
-
-    let rule_0 = RegexRuleConfig::new("b.*")
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec!["secret".to_string()],
-            excluded_keywords: vec![],
-        })
-        .scope(Scope::exclude(vec![Path::from(vec![PathSegment::Field(
-            "test".into(),
-        )])]))
-        .match_action(MatchAction::Redact {
-            replacement: "[scrub]".to_string(),
-        })
-        .build();
+    let rule_0 = RootRuleConfig::new(
+        RegexRuleConfig::new("b.*")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec!["secret".to_string()],
+                excluded_keywords: vec![],
+            })
+            .build(),
+    )
+    .scope(Scope::exclude(vec![Path::from(vec![PathSegment::Field(
+        "test".into(),
+    )])]))
+    .match_action(MatchAction::Redact {
+        replacement: "[scrub]".to_string(),
+    });
 
     let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
 
@@ -659,8 +644,8 @@ fn test_calculate_indices_is_called_with_sorted_start_index() {
     }
 
     // `rule_0` has a match after `rule_1` (out of order)
-    let rule_0 = RegexRuleConfig::new("efg").build();
-    let rule_1 = RegexRuleConfig::new("abc").build();
+    let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("efg").build());
+    let rule_1 = RootRuleConfig::new(RegexRuleConfig::new("abc").build());
 
     let scanner = ScannerBuilder::new(&[rule_0, rule_1]).build().unwrap();
 
@@ -675,9 +660,8 @@ fn test_calculate_indices_is_called_with_sorted_start_index() {
 
 #[test]
 fn test_hash_with_leading_zero() {
-    let rule_0 = RegexRuleConfig::new(".+")
-        .match_action(MatchAction::Hash)
-        .build();
+    let rule_0 =
+        RootRuleConfig::new(RegexRuleConfig::new(".+").build()).match_action(MatchAction::Hash);
 
     let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
 
@@ -694,9 +678,8 @@ fn test_hash_with_leading_zero() {
 #[test]
 fn test_hash_with_leading_zero_utf16() {
     #[allow(deprecated)]
-    let rule_0 = RegexRuleConfig::new(".+")
-        .match_action(MatchAction::Utf16Hash)
-        .build();
+    let rule_0 = RootRuleConfig::new(RegexRuleConfig::new(".+").build())
+        .match_action(MatchAction::Utf16Hash);
 
     let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
 
@@ -712,12 +695,14 @@ fn test_hash_with_leading_zero_utf16() {
 #[test]
 fn test_internal_overlapping_matches() {
     // A simple "credit-card rule is modified a bit to allow a multi-char character in the match
-    let rule_0 = RegexRuleConfig::new("([\\d€]+){1}(,\\d+){3}")
-        .match_action(MatchAction::Redact {
-            replacement: "[credit card]".to_string(),
-        })
-        .validator(LuhnChecksum)
-        .build();
+    let rule_0 = RootRuleConfig::new(
+        RegexRuleConfig::new("([\\d€]+){1}(,\\d+){3}")
+            .validator(LuhnChecksum)
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[credit card]".to_string(),
+    });
 
     let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
 
@@ -739,16 +724,18 @@ fn test_next_regex_start_after_false_positive() {
 
 #[test]
 fn test_excluded_keyword_with_excluded_chars_in_content() {
-    let rule_0 = RegexRuleConfig::new("value")
-        .match_action(MatchAction::Redact {
-            replacement: "[REDACTED]".to_string(),
-        })
-        .proximity_keywords(ProximityKeywordsConfig {
-            look_ahead_character_count: 30,
-            included_keywords: vec![],
-            excluded_keywords: vec!["test".to_string()],
-        })
-        .build();
+    let rule_0 = RootRuleConfig::new(
+        RegexRuleConfig::new("value")
+            .proximity_keywords(ProximityKeywordsConfig {
+                look_ahead_character_count: 30,
+                included_keywords: vec![],
+                excluded_keywords: vec!["test".to_string()],
+            })
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[REDACTED]".to_string(),
+    });
 
     let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
 

--- a/sds/src/scanner/test/mod.rs
+++ b/sds/src/scanner/test/mod.rs
@@ -4,7 +4,6 @@ mod metrics;
 mod overlapping_matches;
 mod validators;
 
-use super::CompiledRuleDyn;
 use super::*;
 use super::{MatchEmitter, ScannerBuilder, StringMatch};
 use crate::match_action::{MatchAction, MatchActionValidationError};
@@ -33,32 +32,20 @@ pub struct DumbRuleConfig {}
 pub struct DumbCompiledRule {}
 
 impl CompiledRule for DumbCompiledRule {
-    type GroupData = ();
-    type GroupConfig = ();
-    type RuleScanCache = ();
-
-    fn create_group_data(&self, _: &Labels) {}
-    fn create_group_config(&self) {}
-    fn create_rule_scan_cache(&self) {}
-
     fn get_string_matches(
         &self,
         _content: &str,
         _path: &Path,
         _regex_caches: &mut RegexCaches,
-        _group_data: &mut Self::GroupData,
-        _group_config: &Self::GroupConfig,
-        _rule_scan_cache: &mut Self::RuleScanCache,
+        _per_string_data: &mut SharedData,
+        _per_scanner_data: &SharedData,
+        _per_event_data: &mut SharedData,
         _exclusion_check: &ExclusionCheck<'_>,
         _excluded_matches: &mut AHashSet<String>,
         match_emitter: &mut dyn MatchEmitter,
         _: Option<&Vec<(usize, usize)>>,
     ) {
         match_emitter.emit(StringMatch { start: 10, end: 16 });
-    }
-
-    fn process_scanner_config(&self, _: &mut Self::GroupConfig) {
-        // do nothing
     }
 }
 
@@ -67,7 +54,7 @@ impl RuleConfig for DumbRuleConfig {
         &self,
         _content: usize,
         _: Labels,
-    ) -> Result<Box<dyn CompiledRuleDyn>, CreateScannerError> {
+    ) -> Result<Box<dyn CompiledRule>, CreateScannerError> {
         Ok(Box::new(DumbCompiledRule {}))
     }
 }

--- a/sds/src/scanner/test/overlapping_matches.rs
+++ b/sds/src/scanner/test/overlapping_matches.rs
@@ -1,16 +1,16 @@
+use crate::scanner::RootRuleConfig;
 use crate::{MatchAction, MatchStatus, Path, RegexRuleConfig, RuleMatch, ScannerBuilder};
 
 #[test]
 fn matches_should_take_precedence_over_non_mutating_overlapping_matches() {
-    let rule_0 = RegexRuleConfig::new("...")
-        .match_action(MatchAction::None)
-        .build();
+    let rule_0 =
+        RootRuleConfig::new(RegexRuleConfig::new("...").build()).match_action(MatchAction::None);
 
-    let rule_1 = RegexRuleConfig::new("...")
-        .match_action(MatchAction::Redact {
+    let rule_1 = RootRuleConfig::new(RegexRuleConfig::new("...").build()).match_action(
+        MatchAction::Redact {
             replacement: "***".to_string(),
-        })
-        .build();
+        },
+    );
 
     let scanner = ScannerBuilder::new(&[rule_0, rule_1]).build().unwrap();
     let mut content = "hello world".to_string();
@@ -73,15 +73,14 @@ fn matches_should_take_precedence_over_non_mutating_overlapping_matches() {
 fn test_overlapping_mutation_higher_priority() {
     // A mutating match is a higher priority even if it starts after a non-mutating match
 
-    let rule_0 = RegexRuleConfig::new("abc")
-        .match_action(MatchAction::None)
-        .build();
+    let rule_0 =
+        RootRuleConfig::new(RegexRuleConfig::new("abc").build()).match_action(MatchAction::None);
 
-    let rule_1 = RegexRuleConfig::new("bcd")
-        .match_action(MatchAction::Redact {
+    let rule_1 = RootRuleConfig::new(RegexRuleConfig::new("bcd").build()).match_action(
+        MatchAction::Redact {
             replacement: "***".to_string(),
-        })
-        .build();
+        },
+    );
 
     let scanner = ScannerBuilder::new(&[rule_0, rule_1]).build().unwrap();
     let mut content = "abcdef".to_string();
@@ -112,13 +111,11 @@ fn test_overlapping_mutation_higher_priority() {
 fn test_overlapping_start_offset() {
     // The match that starts first is used (if the mutation is the same)
 
-    let rule_0 = RegexRuleConfig::new("abc")
-        .match_action(MatchAction::None)
-        .build();
+    let rule_0 =
+        RootRuleConfig::new(RegexRuleConfig::new("abc").build()).match_action(MatchAction::None);
 
-    let rule_1 = RegexRuleConfig::new("bcd")
-        .match_action(MatchAction::None)
-        .build();
+    let rule_1 =
+        RootRuleConfig::new(RegexRuleConfig::new("bcd").build()).match_action(MatchAction::None);
 
     let scanner = ScannerBuilder::new(&[rule_0, rule_1]).build().unwrap();
     let mut content = "abcdef".to_string();
@@ -149,13 +146,11 @@ fn test_overlapping_start_offset() {
 fn test_overlapping_length() {
     // If 2 matches have the same mutation and same start, the longer one is taken
 
-    let rule_0 = RegexRuleConfig::new("abc")
-        .match_action(MatchAction::None)
-        .build();
+    let rule_0 =
+        RootRuleConfig::new(RegexRuleConfig::new("abc").build()).match_action(MatchAction::None);
 
-    let rule_1 = RegexRuleConfig::new("abcd")
-        .match_action(MatchAction::None)
-        .build();
+    let rule_1 =
+        RootRuleConfig::new(RegexRuleConfig::new("abcd").build()).match_action(MatchAction::None);
 
     let scanner = ScannerBuilder::new(&[rule_0, rule_1]).build().unwrap();
     let mut content = "abcdef".to_string();
@@ -186,13 +181,11 @@ fn test_overlapping_length() {
 fn test_overlapping_rule_order() {
     // If 2 matches have the same mutation, same start, and the same length, the one with the lower rule index is used
 
-    let rule_0 = RegexRuleConfig::new("abc")
-        .match_action(MatchAction::None)
-        .build();
+    let rule_0 =
+        RootRuleConfig::new(RegexRuleConfig::new("abc").build()).match_action(MatchAction::None);
 
-    let rule_1 = RegexRuleConfig::new("abc")
-        .match_action(MatchAction::None)
-        .build();
+    let rule_1 =
+        RootRuleConfig::new(RegexRuleConfig::new("abc").build()).match_action(MatchAction::None);
 
     let scanner = ScannerBuilder::new(&[rule_0, rule_1]).build().unwrap();
     let mut content = "abcdef".to_string();
@@ -224,11 +217,11 @@ fn test_overlapping_mutations() {
     // This reproduces a bug where overlapping mutations weren't filtered out, resulting in invalid
     // UTF-8 indices being calculated which resulted in a panic if they were used.
 
-    let rule = RegexRuleConfig::new("hello")
-        .match_action(MatchAction::Redact {
+    let rule = RootRuleConfig::new(RegexRuleConfig::new("hello").build()).match_action(
+        MatchAction::Redact {
             replacement: "*".to_string(),
-        })
-        .build();
+        },
+    );
 
     let scanner = ScannerBuilder::new(&[rule.clone(), rule]).build().unwrap();
     let mut content = "hello world".to_string();

--- a/sds/src/scanner/test/validators.rs
+++ b/sds/src/scanner/test/validators.rs
@@ -13,9 +13,11 @@ fn test_luhn_checksum() {
 
     let rule = RegexRuleConfig::new("(\\d{16})|((\\d{4} ){3}\\d{4})");
 
-    let rule_with_checksum =
-        RootRuleConfig::new(rule.validator(SecondaryValidator::LuhnChecksum).build())
-            .match_action(match_action.clone());
+    let rule_with_checksum = RootRuleConfig::new(
+        rule.with_validator(Some(SecondaryValidator::LuhnChecksum))
+            .build(),
+    )
+    .match_action(match_action.clone());
 
     let scanner =
         ScannerBuilder::new(&[RootRuleConfig::new(rule.build()).match_action(match_action)])
@@ -41,8 +43,9 @@ fn test_chinese_id_checksum() {
 
     let rule = RegexRuleConfig::new("\\d+"); //.match_action(match_action);
 
-    let rule_with_checksum = RootRuleConfig::new(rule.validator(ChineseIdChecksum).build())
-        .match_action(match_action.clone());
+    let rule_with_checksum =
+        RootRuleConfig::new(rule.with_validator(Some(ChineseIdChecksum)).build())
+            .match_action(match_action.clone());
 
     let scanner =
         ScannerBuilder::new(&[RootRuleConfig::new(rule.build()).match_action(match_action)])
@@ -64,7 +67,7 @@ fn test_chinese_id_checksum() {
 fn test_iban_checksum() {
     let rule_with_checksum = RootRuleConfig::new(
         RegexRuleConfig::new("DE[0-9]+")
-            .validator(IbanChecker)
+            .with_validator(Some(IbanChecker))
             .build(),
     )
     .match_action(MatchAction::Redact {
@@ -97,8 +100,9 @@ fn test_github_token_checksum() {
         replacement: "[GITHUB]".to_string(),
     };
 
-    let rule_with_checksum = RootRuleConfig::new(rule.validator(GithubTokenChecksum).build())
-        .match_action(match_action.clone());
+    let rule_with_checksum =
+        RootRuleConfig::new(rule.with_validator(Some(GithubTokenChecksum)).build())
+            .match_action(match_action.clone());
 
     let scanner =
         ScannerBuilder::new(&[RootRuleConfig::new(rule.build()).match_action(match_action)])
@@ -126,7 +130,7 @@ fn test_jwt_expiration_checker() {
     use crate::secondary_validation::generate_jwt;
     let rule = RootRuleConfig::new(
         RegexRuleConfig::new("[A-Za-z0-9._-]+")
-            .validator(JwtExpirationChecker)
+            .with_validator(Some(JwtExpirationChecker))
             .build(),
     )
     .match_action(MatchAction::Redact {
@@ -148,11 +152,14 @@ fn test_jwt_expiration_checker() {
 
 #[test]
 fn test_nhs_checksum() {
-    let rule_with_checksum =
-        RootRuleConfig::new(RegexRuleConfig::new(".+").validator(NhsCheckDigit).build())
-            .match_action(MatchAction::Redact {
-                replacement: "[NHS]".to_string(),
-            });
+    let rule_with_checksum = RootRuleConfig::new(
+        RegexRuleConfig::new(".+")
+            .with_validator(Some(NhsCheckDigit))
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[NHS]".to_string(),
+    });
 
     let mut content = "1234567881".to_string();
     // Test matching NHS number with checksum

--- a/sds/src/scanner/test/validators.rs
+++ b/sds/src/scanner/test/validators.rs
@@ -1,3 +1,4 @@
+use crate::scanner::RootRuleConfig;
 use crate::SecondaryValidator::{
     ChineseIdChecksum, GithubTokenChecksum, IbanChecker, JwtExpirationChecker, NhsCheckDigit,
 };
@@ -6,14 +7,20 @@ use chrono::Utc;
 
 #[test]
 fn test_luhn_checksum() {
-    let rule =
-        RegexRuleConfig::new("(\\d{16})|((\\d{4} ){3}\\d{4})").match_action(MatchAction::Redact {
-            replacement: "[credit card]".to_string(),
-        });
+    let match_action = MatchAction::Redact {
+        replacement: "[credit card]".to_string(),
+    };
 
-    let rule_with_checksum = rule.validator(SecondaryValidator::LuhnChecksum).build();
+    let rule = RegexRuleConfig::new("(\\d{16})|((\\d{4} ){3}\\d{4})");
 
-    let scanner = ScannerBuilder::new(&[rule.build()]).build().unwrap();
+    let rule_with_checksum =
+        RootRuleConfig::new(rule.validator(SecondaryValidator::LuhnChecksum).build())
+            .match_action(match_action.clone());
+
+    let scanner =
+        ScannerBuilder::new(&[RootRuleConfig::new(rule.build()).match_action(match_action)])
+            .build()
+            .unwrap();
     let mut content = "4556997807150071  4111 1111 1111 1111".to_string();
     let matches = scanner.scan(&mut content);
     assert_eq!(matches.len(), 2);
@@ -28,13 +35,19 @@ fn test_luhn_checksum() {
 
 #[test]
 fn test_chinese_id_checksum() {
-    let rule = RegexRuleConfig::new("\\d+").match_action(MatchAction::Redact {
+    let match_action = MatchAction::Redact {
         replacement: "[IDCARD]".to_string(),
-    });
+    };
 
-    let rule_with_checksum = rule.validator(ChineseIdChecksum).build();
+    let rule = RegexRuleConfig::new("\\d+"); //.match_action(match_action);
 
-    let scanner = ScannerBuilder::new(&[rule.build()]).build().unwrap();
+    let rule_with_checksum = RootRuleConfig::new(rule.validator(ChineseIdChecksum).build())
+        .match_action(match_action.clone());
+
+    let scanner =
+        ScannerBuilder::new(&[RootRuleConfig::new(rule.build()).match_action(match_action)])
+            .build()
+            .unwrap();
     let mut content = "513231200012121657 513231200012121651".to_string();
     let matches = scanner.scan(&mut content);
     assert_eq!(matches.len(), 2);
@@ -49,12 +62,14 @@ fn test_chinese_id_checksum() {
 
 #[test]
 fn test_iban_checksum() {
-    let rule_with_checksum = RegexRuleConfig::new("DE[0-9]+")
-        .match_action(MatchAction::Redact {
-            replacement: "[IBAN]".to_string(),
-        })
-        .validator(IbanChecker)
-        .build();
+    let rule_with_checksum = RootRuleConfig::new(
+        RegexRuleConfig::new("DE[0-9]+")
+            .validator(IbanChecker)
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[IBAN]".to_string(),
+    });
 
     // Valid content with checksum
     let mut content = "number=DE44500105175407324931".to_string();
@@ -77,13 +92,19 @@ fn test_iban_checksum() {
 
 #[test]
 fn test_github_token_checksum() {
-    let rule = RegexRuleConfig::new("[^ ]+").match_action(MatchAction::Redact {
+    let rule = RegexRuleConfig::new("[^ ]+");
+    let match_action = MatchAction::Redact {
         replacement: "[GITHUB]".to_string(),
-    });
+    };
 
-    let rule_with_checksum = rule.validator(GithubTokenChecksum).build();
+    let rule_with_checksum = RootRuleConfig::new(rule.validator(GithubTokenChecksum).build())
+        .match_action(match_action.clone());
 
-    let scanner = ScannerBuilder::new(&[rule.build()]).build().unwrap();
+    let scanner =
+        ScannerBuilder::new(&[RootRuleConfig::new(rule.build()).match_action(match_action)])
+            .build()
+            .unwrap();
+
     let mut content =
         "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 ghp_M7H4jxUDDWHP4kZ6A4dxlQYsQIWJuq11T4V5"
             .to_string();
@@ -103,12 +124,14 @@ fn test_github_token_checksum() {
 #[test]
 fn test_jwt_expiration_checker() {
     use crate::secondary_validation::generate_jwt;
-    let rule = RegexRuleConfig::new("[A-Za-z0-9._-]+")
-        .match_action(MatchAction::Redact {
-            replacement: "[JWT]".to_string(),
-        })
-        .validator(JwtExpirationChecker)
-        .build();
+    let rule = RootRuleConfig::new(
+        RegexRuleConfig::new("[A-Za-z0-9._-]+")
+            .validator(JwtExpirationChecker)
+            .build(),
+    )
+    .match_action(MatchAction::Redact {
+        replacement: "[JWT]".to_string(),
+    });
     let scanner = ScannerBuilder::new(&[rule]).build().unwrap();
     let future_time_as_string = (Utc::now().timestamp() + 1000000).to_string();
 
@@ -125,12 +148,11 @@ fn test_jwt_expiration_checker() {
 
 #[test]
 fn test_nhs_checksum() {
-    let rule_with_checksum = RegexRuleConfig::new(".+")
-        .match_action(MatchAction::Redact {
-            replacement: "[NHS]".to_string(),
-        })
-        .validator(NhsCheckDigit)
-        .build();
+    let rule_with_checksum =
+        RootRuleConfig::new(RegexRuleConfig::new(".+").validator(NhsCheckDigit).build())
+            .match_action(MatchAction::Redact {
+                replacement: "[NHS]".to_string(),
+            });
 
     let mut content = "1234567881".to_string();
     // Test matching NHS number with checksum

--- a/sds/tools/fuzz/src/main.rs
+++ b/sds/tools/fuzz/src/main.rs
@@ -3,7 +3,9 @@
 
 use afl::fuzz;
 use ahash::AHashMap;
-use dd_sds::{MatchAction, PartialRedactDirection, RegexRuleConfig, ScannerBuilder, Scope};
+use dd_sds::{
+    MatchAction, PartialRedactDirection, RegexRuleConfig, RootRuleConfig, ScannerBuilder, Scope,
+};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 #[cfg(not(feature = "manual_test"))]
@@ -86,10 +88,11 @@ fn run_fuzz(pattern: &str, input: &str, mut rng: StdRng) {
         println!("Match action: {:?}", match_action);
     }
 
-    let scanner_result = ScannerBuilder::new(&[RegexRuleConfig::new(pattern)
-        .match_action(match_action)
-        .build()])
-    .build();
+    let scanner_result =
+        ScannerBuilder::new(&[
+            RootRuleConfig::new(RegexRuleConfig::new(pattern).build()).match_action(match_action)
+        ])
+        .build();
 
     if let Ok(scanner) = scanner_result {
         let mut mutated_input = input.to_string();


### PR DESCRIPTION
To be able to make rules that are composed of other rules, some significant changes were made.

## Shared Data
The `CompiledRule` trait used to have 3 associated types to be able to store shared data, these were
`GroupData`,  `GroupConfig`, and `RuleScanCache`. These were not flexible enough, since it was not feasible to implement a rule that "contained" other rules with different types of shared data. These have been removed, in favor of a new struct that was introduced, `SharedData`.

`SharedData` is a light wrapper around a `Map<TypeId, Any>`, and is now available instead of the associated types. There are different lifetimes that each associated type used, and they were replaced with a `SharedData` matching that lifetime.

`GroupConfig` -> `per_scanner_data`
`GroupData` -> `per_string_data`
`RuleScanCache` -> `per_event_data`

This `SharedData` is significantly more flexible, allowing storing of multiple types dynamically. It also prevents some unnecessary allocations that were being done when shared data wasn't needed.

## CompiledRuleDyn
The main `CompiledRule` trait has been made "dyn compatible" (object safe), which means the `CompiledRuleDyn` trait is no longer needed and was removed 🎉 

## Config

Each configuration currently includes _all_ config fields, even if they aren't specific to the rule type. Common fields were moved out of individual rule configs, and moved to a wrapper type, `RootRuleConfig`, which now contains `match_action`, `scope`, and `match_validation_type`. This not only simplifies adding new rules (don't need to worry about the common fields), but it makes it possible to nest configs.