### PR TITLE
[SDS-968] Refactor MatchValidation to support Bijection between shared library and open source lib

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -31,10 +31,9 @@ pub use event::{Event, EventVisitor, VisitStringResult};
 pub use match_action::{MatchAction, PartialRedactDirection};
 
 pub use match_validation::{
-    config::AwsConfig, config::AwsType, config::HttpMethod, config::HttpValidatorConfig,
-    config::HttpValidatorConfigBuilder, config::HttpValidatorOption,
-    config::InternalMatchValidationType, config::MatchValidationType, config::RequestHeader,
-    http_validator::HttpValidatorHelper, match_status::MatchStatus,
+    config::AwsConfig, config::AwsType, config::CustomHttpConfig, config::HttpMethod,
+    config::HttpValidatorOption, config::InternalMatchValidationType, config::MatchValidationType,
+    config::RequestHeader, match_status::MatchStatus,
 };
 pub use observability::labels::Labels;
 pub use path::{Path, PathSegment};

--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -32,8 +32,8 @@ pub use match_action::{MatchAction, PartialRedactDirection};
 
 pub use match_validation::{
     config::AwsConfig, config::AwsType, config::CustomHttpConfig, config::HttpMethod,
-    config::HttpValidatorOption, config::InternalMatchValidationType, config::MatchValidationType,
-    config::RequestHeader, match_status::MatchStatus,
+    config::HttpStatusCodeRange, config::HttpValidatorOption, config::InternalMatchValidationType,
+    config::MatchValidationType, config::RequestHeader, match_status::MatchStatus,
 };
 pub use observability::labels::Labels;
 pub use path::{Path, PathSegment};

--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -102,10 +102,14 @@ pub struct CustomHttpConfig {
     pub endpoint: String,
     #[serde(default)]
     pub hosts: Vec<String>,
+    #[serde(default = "default_http_method")]
     pub http_method: HttpMethod,
     pub request_headers: BTreeMap<String, String>,
+    #[serde(default = "default_valid_http_status_code")]
     pub valid_http_status_code: Vec<HttpStatusCodeRange>,
+    #[serde(default = "default_invalid_http_status_code")]
     pub invalid_http_status_code: Vec<HttpStatusCodeRange>,
+    #[serde(default = "default_timeout_seconds")]
     pub timeout_seconds: u32,
 }
 
@@ -210,6 +214,28 @@ impl CustomHttpConfig {
     pub fn set_timeout_seconds(&mut self, timeout_seconds: u32) {
         self.timeout_seconds = timeout_seconds;
     }
+}
+
+fn default_timeout_seconds() -> u32 {
+    DEFAULT_HTTPS_TIMEOUT_SEC as u32
+}
+
+fn default_http_method() -> HttpMethod {
+    HttpMethod::Get
+}
+
+fn default_valid_http_status_code() -> Vec<HttpStatusCodeRange> {
+    vec![HttpStatusCodeRange {
+        start: 200,
+        end: 300,
+    }]
+}
+
+fn default_invalid_http_status_code() -> Vec<HttpStatusCodeRange> {
+    vec![HttpStatusCodeRange {
+        start: 400,
+        end: 500,
+    }]
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -114,8 +114,8 @@ pub struct CustomHttpConfig {
     pub timeout_seconds: u32,
 }
 
-impl CustomHttpConfig {
-    pub fn default() -> Self {
+impl Default for CustomHttpConfig {
+    fn default() -> Self {
         CustomHttpConfig {
             endpoint: "".to_string(),
             hosts: vec![],
@@ -126,7 +126,9 @@ impl CustomHttpConfig {
             timeout_seconds: DEFAULT_HTTPS_TIMEOUT_SEC as u32,
         }
     }
+}
 
+impl CustomHttpConfig {
     pub fn get_endpoints(&self) -> Result<Vec<String>, String> {
         // Handle errors cases
         // - endpoint contains $HOST but no hosts are provided

--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -285,7 +285,7 @@ impl MatchValidationType {
 // This is the match validation type stored in the compiled rule
 // It is used to retrieve the MatchValidator. We don't need the full configuration for that purpose
 // as it would be heavy to compute hash and compare the full configuration.
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(PartialEq, Eq, Hash)]
 pub enum InternalMatchValidationType {
     Aws,
     CustomHttp(Vec<String>),

--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -49,6 +49,7 @@ pub enum AwsType {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
 pub enum HttpMethod {
     Get,
     Post,

--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::str::FromStr;
-use std::{hash::Hash, ops::Range, time::Duration, vec};
+use std::{hash::Hash, time::Duration};
 
 use super::aws_validator::AwsValidator;
 use super::http_validator::HttpValidator;
@@ -97,127 +98,131 @@ pub struct HttpValidatorOption {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-pub struct HttpValidatorConfig {
-    pub endpoints: Vec<String>,
-    pub method: HttpMethod,
-    pub request_header: Vec<RequestHeader>,
-    pub valid_http_status_code: Vec<Range<u16>>,
-    pub invalid_http_status_code: Vec<Range<u16>>,
-    pub options: HttpValidatorOption,
+pub struct CustomHttpConfig {
+    pub endpoint: String,
+    #[serde(default)]
+    pub hosts: Vec<String>,
+    pub http_method: HttpMethod,
+    pub request_headers: BTreeMap<String, String>,
+    pub valid_http_status_code: Vec<HttpStatusCodeRange>,
+    pub invalid_http_status_code: Vec<HttpStatusCodeRange>,
+    pub timeout_seconds: u32,
 }
 
-impl HttpValidatorConfig {
-    fn new(endpoint: &str, hosts: Vec<String>) -> Result<Self, String> {
+impl CustomHttpConfig {
+    pub fn default() -> Self {
+        CustomHttpConfig {
+            endpoint: "".to_string(),
+            hosts: vec![],
+            http_method: HttpMethod::Get,
+            request_headers: BTreeMap::new(),
+            valid_http_status_code: vec![],
+            invalid_http_status_code: vec![],
+            timeout_seconds: DEFAULT_HTTPS_TIMEOUT_SEC as u32,
+        }
+    }
+
+    pub fn get_endpoints(&self) -> Result<Vec<String>, String> {
         // Handle errors cases
         // - endpoint contains $HOST but no hosts are provided
         // - endpoint does not contain $HOST but hosts are provided
-        if endpoint.contains("$HOST") && hosts.is_empty() {
+        if self.endpoint.contains("$HOST") && self.hosts.is_empty() {
             return Err("Endpoint contains $HOST but no hosts are provided".to_string());
         }
-        if !endpoint.contains("$HOST") && !hosts.is_empty() {
+        if !self.endpoint.contains("$HOST") && !self.hosts.is_empty() {
             return Err("Endpoint does not contain $HOST but hosts are provided".to_string());
         }
 
         // Replace $HOST in endpoint and build the endpoints vector
         let mut endpoints = vec![];
-        for host in hosts {
-            endpoints.push(endpoint.replace("$HOST", &host));
+        for host in self.hosts.clone() {
+            endpoints.push(self.endpoint.replace("$HOST", &host));
         }
         if endpoints.is_empty() {
             // If no hosts are provided, use the endpoint as is
-            endpoints.push(endpoint.to_string());
+            endpoints.push(self.endpoint.to_string());
         }
-        Ok(HttpValidatorConfig {
-            endpoints,
-            method: HttpMethod::Get,
-            request_header: vec![],
-            #[allow(clippy::single_range_in_vec_init)]
-            valid_http_status_code: vec![200..300],
-            #[allow(clippy::single_range_in_vec_init)]
-            invalid_http_status_code: vec![400..500],
-            options: HttpValidatorOption {
-                timeout: Duration::from_secs(DEFAULT_HTTPS_TIMEOUT_SEC),
-            },
-        })
+        Ok(endpoints)
     }
-}
 
-pub struct HttpValidatorConfigBuilder {
-    endpoint: String,
-    hosts: Vec<String>,
-    method: HttpMethod,
-    request_header: Vec<RequestHeader>,
-    valid_http_status_code: Vec<Range<u16>>,
-    invalid_http_status_code: Vec<Range<u16>>,
-    options: HttpValidatorOption,
-}
+    // Builders
 
-impl HttpValidatorConfigBuilder {
-    pub fn new(endpoint: String) -> Self {
-        HttpValidatorConfigBuilder {
-            endpoint,
-            hosts: vec![],
-            method: HttpMethod::Get,
-            request_header: vec![RequestHeader {
-                key: "Authorization".to_string(),
-                value: "Bearer $MATCH".to_string(),
-            }],
-            #[allow(clippy::single_range_in_vec_init)]
-            valid_http_status_code: vec![200..300],
-            #[allow(clippy::single_range_in_vec_init)]
-            invalid_http_status_code: vec![400..500],
-            options: HttpValidatorOption {
-                timeout: Duration::from_secs(DEFAULT_HTTPS_TIMEOUT_SEC),
-            },
-        }
-    }
-    pub fn set_request_header(&mut self, request_header: Vec<RequestHeader>) -> &mut Self {
-        self.request_header = request_header;
+    pub fn with_endpoint(mut self, endpoint: String) -> Self {
+        self.endpoint = endpoint;
         self
     }
-    pub fn set_hosts(&mut self, hosts: Vec<String>) -> &mut Self {
+
+    pub fn with_hosts(mut self, hosts: Vec<String>) -> Self {
         self.hosts = hosts;
         self
     }
-    pub fn set_method(&mut self, method: HttpMethod) -> &mut Self {
-        self.method = method;
+
+    pub fn with_request_headers(mut self, request_headers: BTreeMap<String, String>) -> Self {
+        self.request_headers = request_headers;
         self
     }
-    pub fn set_valid_http_status_code(
-        &mut self,
-        valid_http_status_code: Vec<Range<u16>>,
-    ) -> &mut Self {
+
+    pub fn with_valid_http_status_code(
+        mut self,
+        valid_http_status_code: Vec<HttpStatusCodeRange>,
+    ) -> Self {
         self.valid_http_status_code = valid_http_status_code;
         self
     }
-    pub fn set_invalid_http_status_code(
-        &mut self,
-        invalid_http_status_code: Vec<Range<u16>>,
-    ) -> &mut Self {
+
+    pub fn with_invalid_http_status_code(
+        mut self,
+        invalid_http_status_code: Vec<HttpStatusCodeRange>,
+    ) -> Self {
         self.invalid_http_status_code = invalid_http_status_code;
         self
     }
-    pub fn set_timeout(&mut self, timeout: Duration) -> &mut Self {
-        self.options.timeout = timeout;
-        self
+
+    // Setters
+
+    pub fn set_endpoint(&mut self, endpoint: String) {
+        self.endpoint = endpoint;
     }
-    pub fn build(&self) -> Result<HttpValidatorConfig, String> {
-        let mut config = HttpValidatorConfig::new(self.endpoint.as_str(), self.hosts.clone())?;
-        config.invalid_http_status_code = self.invalid_http_status_code.clone();
-        config.method = self.method.clone();
-        config.request_header = self.request_header.clone();
-        config.valid_http_status_code = self.valid_http_status_code.clone();
-        config.options = self.options.clone();
-        config.invalid_http_status_code = self.invalid_http_status_code.clone();
-        Ok(config)
+
+    pub fn set_hosts(&mut self, hosts: Vec<String>) {
+        self.hosts = hosts;
     }
+
+    pub fn set_http_method(&mut self, http_method: HttpMethod) {
+        self.http_method = http_method;
+    }
+
+    pub fn set_request_headers(&mut self, request_headers: BTreeMap<String, String>) {
+        self.request_headers = request_headers;
+    }
+
+    pub fn set_valid_http_status_code(&mut self, valid_http_status_code: Vec<HttpStatusCodeRange>) {
+        self.valid_http_status_code = valid_http_status_code;
+    }
+
+    pub fn set_invalid_http_status_code(
+        &mut self,
+        invalid_http_status_code: Vec<HttpStatusCodeRange>,
+    ) {
+        self.invalid_http_status_code = invalid_http_status_code;
+    }
+
+    pub fn set_timeout_seconds(&mut self, timeout_seconds: u32) {
+        self.timeout_seconds = timeout_seconds;
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct HttpStatusCodeRange {
+    pub start: u16,
+    pub end: u16,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "type", content = "config")]
 pub enum MatchValidationType {
     Aws(AwsType),
-    CustomHttp(HttpValidatorConfig),
+    CustomHttp(CustomHttpConfig),
 }
 
 impl MatchValidationType {
@@ -232,7 +237,7 @@ impl MatchValidationType {
         match self {
             MatchValidationType::Aws(_) => InternalMatchValidationType::Aws,
             MatchValidationType::CustomHttp(http_config) => {
-                InternalMatchValidationType::CustomHttp(http_config.endpoints.clone())
+                InternalMatchValidationType::CustomHttp(http_config.get_endpoints().unwrap())
             }
         }
     }
@@ -254,70 +259,8 @@ impl MatchValidationType {
 // This is the match validation type stored in the compiled rule
 // It is used to retrieve the MatchValidator. We don't need the full configuration for that purpose
 // as it would be heavy to compute hash and compare the full configuration.
-#[derive(PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, Hash, Debug)]
 pub enum InternalMatchValidationType {
     Aws,
     CustomHttp(Vec<String>),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_http_validator_config_no_hosts() {
-        let config = HttpValidatorConfig::new("http://localhost/test", vec![]).unwrap();
-        assert_eq!(config.endpoints, vec!["http://localhost/test"]);
-    }
-
-    #[test]
-    fn test_http_validator_config_with_hosts() {
-        let config = HttpValidatorConfig::new(
-            "http://localhost/$HOST",
-            vec!["us".to_string(), "eu".to_string()],
-        )
-        .unwrap();
-        assert_eq!(
-            config.endpoints,
-            vec!["http://localhost/us", "http://localhost/eu"]
-        );
-    }
-
-    #[test]
-    fn test_http_validator_config_error_cases() {
-        let config = HttpValidatorConfig::new("http://localhost/$HOST", vec![]).unwrap_err();
-        assert_eq!(
-            config,
-            "Endpoint contains $HOST but no hosts are provided".to_string()
-        );
-    }
-
-    #[test]
-    fn test_http_validator_config_error_cases_with_hosts() {
-        let config =
-            HttpValidatorConfig::new("http://localhost/test", vec!["us".to_string()]).unwrap_err();
-        assert_eq!(
-            config,
-            "Endpoint does not contain $HOST but hosts are provided".to_string()
-        );
-    }
-    #[test]
-    fn test_http_validator_builder_config_no_hosts() {
-        let config = HttpValidatorConfigBuilder::new("http://localhost/test".to_string())
-            .build()
-            .unwrap();
-        assert_eq!(config.endpoints, vec!["http://localhost/test"]);
-    }
-
-    #[test]
-    fn test_http_validator_builder_config_with_hosts() {
-        let config = HttpValidatorConfigBuilder::new("http://localhost/$HOST".to_string())
-            .set_hosts(vec!["us".to_string(), "eu".to_string()])
-            .build()
-            .unwrap();
-        assert_eq!(
-            config.endpoints,
-            vec!["http://localhost/us", "http://localhost/eu"]
-        );
-    }
 }

--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -90,7 +90,6 @@ impl RequestHeader {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-
 pub struct HttpValidatorOption {
     pub timeout: Duration,
     // TODO(trosenblatt) add more options

--- a/sds/src/match_validation/helpers.rs
+++ b/sds/src/match_validation/helpers.rs
@@ -11,19 +11,6 @@ pub struct HttpValidatorHelper;
 ///
 /// The configurations include appropriate endpoints, headers, and status code ranges
 /// that indicate whether matches are valid or not.
-///
-/// # Examples
-///
-/// ```
-/// use crate::match_validation::helpers::HttpValidatorHelper;
-///
-/// // Create GitHub API validator config
-/// let github_config = HttpValidatorHelper::new_github_config();
-///
-/// // Create Datadog API validator config
-/// let datadog_config = HttpValidatorHelper::new_datadog_config();
-/// ```
-
 impl HttpValidatorHelper {
     #[allow(dead_code)]
     pub fn new_github_config() -> CustomHttpConfig {

--- a/sds/src/match_validation/helpers.rs
+++ b/sds/src/match_validation/helpers.rs
@@ -1,0 +1,75 @@
+use crate::{CustomHttpConfig, HttpStatusCodeRange};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HttpValidatorHelper;
+
+/// Helper functions to create common HTTP validator configurations.
+///
+/// This module provides pre-configured HTTP validator settings for popular services
+/// like GitHub and Datadog.
+///
+/// The configurations include appropriate endpoints, headers, and status code ranges
+/// that indicate whether matches are valid or not.
+///
+/// # Examples
+///
+/// ```
+/// use crate::match_validation::helpers::HttpValidatorHelper;
+///
+/// // Create GitHub API validator config
+/// let github_config = HttpValidatorHelper::new_github_config();
+///
+/// // Create Datadog API validator config
+/// let datadog_config = HttpValidatorHelper::new_datadog_config();
+/// ```
+
+impl HttpValidatorHelper {
+    #[allow(dead_code)]
+    pub fn new_github_config() -> CustomHttpConfig {
+        let mut headers = BTreeMap::new();
+        headers.insert("Authorization".to_string(), "Bearer $MATCH".to_string());
+        headers.insert("User-Agent".to_string(), "TEST_DD_SDS".to_string());
+        headers.insert("X-GitHub-Api-Version".to_string(), "2022-11-28".to_string());
+
+        CustomHttpConfig::default()
+            .with_endpoint("https://api.github.com/octocat".to_string())
+            .with_request_headers(headers)
+            .with_invalid_http_status_code(vec![HttpStatusCodeRange {
+                start: 401,
+                end: 404,
+            }])
+            .with_valid_http_status_code(vec![HttpStatusCodeRange {
+                start: 200,
+                end: 300,
+            }])
+    }
+
+    #[allow(dead_code)]
+    pub fn new_datadog_config() -> CustomHttpConfig {
+        let mut headers = BTreeMap::new();
+        headers.insert("DD-API-KEY".to_string(), "$MATCH".to_string());
+        headers.insert("User-Agent".to_string(), "TEST_DD_SDS".to_string());
+        headers.insert("Accept".to_string(), "application/json".to_string());
+
+        CustomHttpConfig::default()
+            .with_endpoint("https://$HOST/api/v1/validate".to_string())
+            .with_hosts(vec![
+                "api.datadoghq.com".to_string(),
+                "api.datadoghq.eu".to_string(),
+                "api.us3.datadoghq.com".to_string(),
+                "api.us5.datadoghq.com".to_string(),
+                "api.ddog-gov.com".to_string(),
+                "api.ap1.datadoghq.com".to_string(),
+            ])
+            .with_request_headers(headers)
+            .with_invalid_http_status_code(vec![HttpStatusCodeRange {
+                start: 403,
+                end: 404,
+            }])
+            .with_valid_http_status_code(vec![HttpStatusCodeRange {
+                start: 200,
+                end: 300,
+            }])
+    }
+}

--- a/sds/src/match_validation/mod.rs
+++ b/sds/src/match_validation/mod.rs
@@ -1,5 +1,6 @@
 mod aws_validator;
 pub(crate) mod config;
+pub(crate) mod helpers;
 pub(crate) mod http_validator;
 pub(crate) mod match_status;
 pub(crate) mod match_validator;

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -150,7 +150,7 @@ pub enum SecondaryValidator {
 
 #[cfg(test)]
 mod test {
-    use crate::{AwsType, HttpValidatorConfigBuilder, MatchValidationType, RootRuleConfig};
+    use crate::{AwsType, CustomHttpConfig, MatchValidationType, RootRuleConfig};
 
     use super::*;
 
@@ -204,9 +204,7 @@ mod test {
     #[allow(deprecated)]
     fn test_third_party_active_checker() {
         // Test setting only the new field
-        let http_config = HttpValidatorConfigBuilder::new("http://test.com".to_string())
-            .build()
-            .unwrap();
+        let http_config = CustomHttpConfig::default().with_endpoint("http://test.com".to_string());
         let validation_type = MatchValidationType::CustomHttp(http_config.clone());
         let rule_config = RootRuleConfig::new(RegexRuleConfig::new("123"))
             .third_party_active_checker(validation_type.clone());


### PR DESCRIPTION
## Description

Add `CustomHttpConfig` struct in place of `HttpValidatorConfig`.

I moved `HttpValidatorConfig` to a new struct called `InternalHttpValidatorConfig`, that is kept private.

I'm doing this to be able to reuse `CustomHttpConfig` in the shared library.