### PR TITLE
Fix match validation dropping matches without a validator

### DIFF
--- a/sds/src/match_validation/match_status.rs
+++ b/sds/src/match_validation/match_status.rs
@@ -1,5 +1,6 @@
 #[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Clone)]
 pub enum MatchStatus {
+    // The ordering here is important, values further down the list have a higher priority when merging.
     NotChecked,
     NotAvailable,
     Invalid,
@@ -9,7 +10,7 @@ pub enum MatchStatus {
 
 impl MatchStatus {
     // Order matters as we want to update the match_status only if the new match_status has higher priority.
-    // (in case of split key where we try different combinations of id and secret (aws usecase))
+    // (in case of split key where we try different combinations of id and secret (aws use-case))
     pub fn merge(&mut self, new_status: MatchStatus) {
         if new_status > *self {
             *self = new_status;

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -691,6 +691,8 @@ impl ScannerBuilder<'_> {
                         if !match_validators_per_type.contains_key(&internal_type) {
                             match_validators_per_type.insert(internal_type, match_validator);
                             // Let's add return_matches to the scanner features
+                            // TODO Fixme, this implicit behavior could cause issue in case the config is reloaded.
+                            // The scanner features should only be enabled at build time and not based on custom rules.
                             scanner_features.return_matches = true;
                         }
                     } else {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -431,17 +431,23 @@ impl Scanner {
         }
         // Create MatchValidatorRuleMatch per match_validator_type to pass it to each match_validator
         let mut match_validator_rule_match_per_type = AHashMap::new();
-        for rule_match in rule_matches.drain(..) {
+
+        let mut validated_rule_matches = vec![];
+
+        for mut rule_match in rule_matches.drain(..) {
             let rule = &self.rules[rule_match.rule_index];
             if let Some(match_validation_type) = rule.internal_match_validation_type() {
                 match_validator_rule_match_per_type
                     .entry(match_validation_type)
                     .or_insert_with(Vec::new)
                     .push(rule_match)
+            } else {
+                // There is no match validator for this rule, so mark it as not available.
+                rule_match.match_status.merge(MatchStatus::NotAvailable);
+                validated_rule_matches.push(rule_match);
             }
         }
 
-        // Call the validate per match_validator_type with their matches and the RuleMatch list and collect the results
         match_validator_rule_match_per_type.par_iter_mut().for_each(
             |(match_validation_type, matches_per_type)| {
                 let match_validator = self.match_validators_per_type.get(match_validation_type);
@@ -455,11 +461,12 @@ impl Scanner {
 
         // Refill the rule_matches with the validated matches
         for (_, mut matches) in match_validator_rule_match_per_type {
-            rule_matches.append(&mut matches);
+            validated_rule_matches.append(&mut matches);
         }
 
         // Sort rule_matches by start index
-        rule_matches.sort_by_key(|rule_match| rule_match.start_index);
+        validated_rule_matches.sort_by_key(|rule_match| rule_match.start_index);
+        *rule_matches = validated_rule_matches;
         Ok(())
     }
 

--- a/sds/src/scanner/test/match_validation.rs
+++ b/sds/src/scanner/test/match_validation.rs
@@ -286,9 +286,10 @@ fn test_matches_from_rule_without_validation_are_ignored() {
     assert_eq!(matches.len(), 1);
     assert_eq!(content, "this is a content with a [VALID]");
     assert!(scanner.validate_matches(&mut matches).is_ok());
-    //TODO FIXME This is a bug, the rule should be returned with an unverified match validation
-    // status
-    assert_eq!(matches.len(), 0);
+
+    // Even though the match doesn't have a match-validator, it is still returned, with a `NotAvailable` status
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].match_status, MatchStatus::NotAvailable);
 }
 
 #[test]

--- a/sds/src/scanner/test/match_validation.rs
+++ b/sds/src/scanner/test/match_validation.rs
@@ -270,7 +270,7 @@ fn test_mock_http_timeout() {
 }
 
 #[test]
-fn test_matches_from_rule_without_validation_are_ignored() {
+fn test_matches_from_rule_without_validation_are_not_ignored() {
     let rule_valid_match = RootRuleConfig::new(RegexRuleConfig::new("\\bvalid_match\\b").build())
         .match_action(MatchAction::Redact {
             replacement: "[VALID]".to_string(),


### PR DESCRIPTION
`validate_matches` would previously only return matches that had an associated "match validator", meaning matches without a validator were removed from the `rule_matches` list.

Rules are now never removed from the list, and instead marked as `NotAvailable` if a match validator is not available for the match.

This fixes the bug found [here](https://github.com/DataDog/dd-sensitive-data-scanner/pull/176)