### PR TITLE
add checksum for Portuguese Tax ID number (NIF)

### DIFF
--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -148,6 +148,7 @@ pub enum SecondaryValidator {
     PolishNationalIdChecksum,
     LuxembourgIndividualNINChecksum,
     FranceSsnChecksum,
+    PortugueseTaxIdChecksum,
 }
 
 #[cfg(test)]

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -11,6 +11,7 @@ mod luxembourg_individual_nin_checksum;
 mod nhs_check_digit;
 mod nir_checksum;
 mod polish_national_id_checksum;
+mod portuguese_tax_id_checksum;
 mod verhoeff_checksum;
 
 #[cfg(test)]
@@ -30,6 +31,7 @@ pub use crate::secondary_validation::luxembourg_individual_nin_checksum::Luxembo
 pub use crate::secondary_validation::nhs_check_digit::NhsCheckDigit;
 pub use crate::secondary_validation::nir_checksum::NirChecksum;
 pub use crate::secondary_validation::polish_national_id_checksum::PolishNationalIdChecksum;
+pub use crate::secondary_validation::portuguese_tax_id_checksum::PortugueseTaxIdChecksum;
 pub use crate::secondary_validation::verhoeff_checksum::VerhoeffChecksum;
 use std::str::Chars;
 
@@ -82,6 +84,9 @@ impl Validator for SecondaryValidator {
                 LuxembourgIndividualNINChecksum.is_valid_match(regex_match)
             }
             SecondaryValidator::FranceSsnChecksum => FranceSsnChecksum.is_valid_match(regex_match),
+            SecondaryValidator::PortugueseTaxIdChecksum => {
+                PortugueseTaxIdChecksum.is_valid_match(regex_match)
+            }
         }
     }
 }

--- a/sds/src/secondary_validation/portuguese_tax_id_checksum.rs
+++ b/sds/src/secondary_validation/portuguese_tax_id_checksum.rs
@@ -1,0 +1,76 @@
+use crate::secondary_validation::{get_next_digit, Validator};
+
+/// Validates the checksum of Portuguese Tax ID numbers (NIF).
+/// See: https://pt.wikipedia.org/wiki/Número_de_identificação_fiscal
+pub struct PortugueseTaxIdChecksum;
+
+impl Validator for PortugueseTaxIdChecksum {
+    fn is_valid_match(&self, regex_match: &str) -> bool {
+        let mut chars = regex_match.chars();
+        let mut sum = 0;
+
+        // multiply each digit by its weight (9 to 2)
+        for i in 0..8 {
+            let digit = match get_next_digit(&mut chars) {
+                Some(d) => d,
+                None => return false,
+            };
+            sum += digit * (9 - i);
+        }
+
+        let expected_check_digit = match 11 - (sum % 11) {
+            n if n > 9 => 0,
+            n => n,
+        };
+
+        let actual_check_digit = match get_next_digit(&mut chars) {
+            Some(d) => d,
+            None => return false,
+        };
+
+        if get_next_digit(&mut chars).is_some() {
+            return false; // too many digits
+        }
+
+        expected_check_digit == actual_check_digit
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::secondary_validation::*;
+
+    #[test]
+    fn test_valid_nif() {
+        let valid_ids = vec![
+            // See: https://billing.pt/nif-validator/
+            "581348915",
+            "581 348 915",
+            "389982482",
+            "389 982 482",
+            "248915967",
+            "248 915 967",
+        ];
+        for id in valid_ids {
+            assert!(PortugueseTaxIdChecksum.is_valid_match(id));
+        }
+    }
+
+    #[test]
+    fn test_invalid_nif() {
+        let invalid_ids = vec![
+            // wrong checksum
+            "581348910",
+            "581 348 910",
+            "389982489",
+            "389 982 489",
+            // too many digits
+            "5813489150",
+            // too few digits
+            "58134891",
+        ];
+        for id in invalid_ids {
+            assert!(!PortugueseTaxIdChecksum.is_valid_match(id));
+        }
+    }
+}


### PR DESCRIPTION
Add a secondary validation by checksum for Portuguese Tax ID numbers (NIF), based on the [Número de identificação fiscal
Wikipedia page](https://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal)

[SDS-728](https://datadoghq.atlassian.net/browse/SDS-728)

[SDS-728]: https://datadoghq.atlassian.net/browse/SDS-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ