### PR TITLE
[SDS-summit] Latvian National Identification Number checksum

### DIFF
--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -148,6 +148,7 @@ pub enum SecondaryValidator {
     PolishNationalIdChecksum,
     LuxembourgIndividualNINChecksum,
     FranceSsnChecksum,
+    LatviaNationalIdChecksum,
 }
 
 #[cfg(test)]

--- a/sds/src/secondary_validation/latvia_national_id_checksum.rs
+++ b/sds/src/secondary_validation/latvia_national_id_checksum.rs
@@ -1,0 +1,88 @@
+use crate::secondary_validation::{get_next_digit, Validator};
+
+pub struct LatviaNationalIdChecksum;
+
+const LATVIA_NATIONAL_ID_LENGTH: usize = 11;
+const LATVIA_NATIONAL_ID_OLD_FORMAT_MULTIPLIERS: &[u32] = &[1, 6, 3, 7, 9, 10, 5, 8, 4, 2];
+
+impl Validator for LatviaNationalIdChecksum {
+    fn is_valid_match(&self, regex_match: &str) -> bool {
+        /*
+         * Latvia national identification number has 2 formats:
+         * 1. Since July 1st 2017, an 11-digit number, starting with "32" with possible '-' after the 6th digit
+         * 2. Before July 1st 2017, an 11 digits number, in the format DDMMYY-XNNNZ, where:
+         *    - DDMMYY is the date of birth
+         *    - X represents the century digit (0 for 19, 1 for 20, 2 for 21)
+         *    - NNN is a birth serial number in that day
+         *    - Z is the checksum digit
+         */
+
+        // Remove possible '-'
+        let digits_str: String = regex_match.chars().filter(|c| c.is_ascii_digit()).collect();
+        if digits_str.len() != LATVIA_NATIONAL_ID_LENGTH {
+            return false;
+        }
+
+        let mut digits = digits_str.chars();
+        let first_2_digits: String = digits.clone().take(2).collect();
+        // No checksum validation needed for the new format
+        if first_2_digits == "32" {
+            return true;
+        }
+
+        // Checksum validation for the old format ABCDEF-XGHIZ
+        // Z must equal to (1101-(1*A + 6*B + 3*C + 7*D + 9*E + 10*F + 5*X + 8*G + 4*H + 2*I)) | Mod 11 | Mod 10.
+        let mut sum = 0;
+        for i in 0..10 {
+            let digit = match get_next_digit(&mut digits) {
+                Some(d) => d,
+                None => return false,
+            };
+            sum += digit * LATVIA_NATIONAL_ID_OLD_FORMAT_MULTIPLIERS[i];
+        }
+
+        let checksum = ((1101 - sum) % 11) % 10;
+        let actual_checksum = digits.last().unwrap().to_digit(10).unwrap();
+
+        checksum == actual_checksum
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::secondary_validation::*;
+
+    #[test]
+    fn validate_latvia_national_ids() {
+        let old_latvia_national_ids = vec![
+            // old format
+            "121282-11210",
+            "280794-12344",
+        ];
+        for id in old_latvia_national_ids {
+            println!("Old latvia national identification number: {}", id);
+            assert!(LatviaNationalIdChecksum.is_valid_match(id));
+
+            let checksum = id.chars().last().unwrap();
+            let id_without_checksum = &id[..id.len() - 1];
+
+            let mut invalid_checksum = id_without_checksum.to_string();
+            invalid_checksum.push_str(&((checksum.to_digit(10).unwrap() + 1) % 10).to_string());
+            println!(
+                "latvia national identification number with invalid checksum: {}",
+                invalid_checksum
+            );
+            assert!(!LatviaNationalIdChecksum.is_valid_match(&invalid_checksum));
+        }
+
+        let new_latvia_national_ids = vec![
+            // new format
+            "320010-10002",
+            "32001010003",
+        ];
+        for id in new_latvia_national_ids {
+            println!("New latvia national identification number: {}", id);
+            assert!(LatviaNationalIdChecksum.is_valid_match(id));
+        }
+    }
+}

--- a/sds/src/secondary_validation/latvia_national_id_checksum.rs
+++ b/sds/src/secondary_validation/latvia_national_id_checksum.rs
@@ -1,50 +1,34 @@
-use crate::secondary_validation::{get_next_digit, Validator};
+use crate::secondary_validation::Validator;
 
 pub struct LatviaNationalIdChecksum;
 
-const LATVIA_NATIONAL_ID_LENGTH: usize = 11;
-const LATVIA_NATIONAL_ID_OLD_FORMAT_MULTIPLIERS: &[u32] = &[1, 6, 3, 7, 9, 10, 5, 8, 4, 2];
+const LATVIA_NATIONAL_ID_OLD_FORMAT_MULTIPLIERS: &[u32; 10] = &[1, 6, 3, 7, 9, 10, 5, 8, 4, 2];
 
 impl Validator for LatviaNationalIdChecksum {
+    // https://en.wikipedia.org/wiki/National_identification_number
     fn is_valid_match(&self, regex_match: &str) -> bool {
-        /*
-         * Latvia national identification number has 2 formats:
-         * 1. Since July 1st 2017, an 11-digit number, starting with "32" with possible '-' after the 6th digit
-         * 2. Before July 1st 2017, an 11 digits number, in the format DDMMYY-XNNNZ, where:
-         *    - DDMMYY is the date of birth
-         *    - X represents the century digit (0 for 19, 1 for 20, 2 for 21)
-         *    - NNN is a birth serial number in that day
-         *    - Z is the checksum digit
-         */
-
-        // Remove possible '-'
-        let digits_str: String = regex_match.chars().filter(|c| c.is_ascii_digit()).collect();
-        if digits_str.len() != LATVIA_NATIONAL_ID_LENGTH {
-            return false;
-        }
-
-        let mut digits = digits_str.chars();
-        let first_2_digits: String = digits.clone().take(2).collect();
+        let mut digits = regex_match.chars().filter_map(|c| c.to_digit(10));
+        let first_2_digits: Vec<u32> = digits.clone().take(2).collect();
         // No checksum validation needed for the new format
-        if first_2_digits == "32" {
+        if first_2_digits == vec![3, 2] {
             return true;
         }
 
-        // Checksum validation for the old format ABCDEF-XGHIZ
-        // Z must equal to (1101-(1*A + 6*B + 3*C + 7*D + 9*E + 10*F + 5*X + 8*G + 4*H + 2*I)) | Mod 11 | Mod 10.
         let mut sum = 0;
-        for mult in LATVIA_NATIONAL_ID_OLD_FORMAT_MULTIPLIERS {
-            let digit = match get_next_digit(&mut digits) {
-                Some(d) => d,
-                None => return false,
-            };
-            sum += digit * mult;
+        for (index, digit) in digits
+            .by_ref()
+            .take(LATVIA_NATIONAL_ID_OLD_FORMAT_MULTIPLIERS.len())
+            .enumerate()
+        {
+            let multiplier = LATVIA_NATIONAL_ID_OLD_FORMAT_MULTIPLIERS[index];
+            sum += digit * multiplier;
         }
 
-        let checksum = ((1101 - sum) % 11) % 10;
-        let actual_checksum = digits.last().unwrap().to_digit(10).unwrap();
-
-        checksum == actual_checksum
+        if let Some(actual_checksum) = digits.next() {
+            let computed_checksum = ((1101 - sum) % 11) % 10;
+            return actual_checksum == computed_checksum;
+        }
+        false
     }
 }
 

--- a/sds/src/secondary_validation/latvia_national_id_checksum.rs
+++ b/sds/src/secondary_validation/latvia_national_id_checksum.rs
@@ -33,12 +33,12 @@ impl Validator for LatviaNationalIdChecksum {
         // Checksum validation for the old format ABCDEF-XGHIZ
         // Z must equal to (1101-(1*A + 6*B + 3*C + 7*D + 9*E + 10*F + 5*X + 8*G + 4*H + 2*I)) | Mod 11 | Mod 10.
         let mut sum = 0;
-        for i in 0..10 {
+        for mult in LATVIA_NATIONAL_ID_OLD_FORMAT_MULTIPLIERS {
             let digit = match get_next_digit(&mut digits) {
                 Some(d) => d,
                 None => return false,
             };
-            sum += digit * LATVIA_NATIONAL_ID_OLD_FORMAT_MULTIPLIERS[i];
+            sum += digit * mult;
         }
 
         let checksum = ((1101 - sum) % 11) % 10;

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -6,6 +6,7 @@ mod france_ssn_checksum;
 mod github_token_checksum;
 mod iban_checker;
 mod jwt_expiration_checker;
+mod latvia_national_id_checksum;
 mod luhn_checksum;
 mod luxembourg_individual_nin_checksum;
 mod nhs_check_digit;
@@ -25,6 +26,7 @@ pub use crate::secondary_validation::france_ssn_checksum::FranceSsnChecksum;
 pub use crate::secondary_validation::github_token_checksum::GithubTokenChecksum;
 pub use crate::secondary_validation::iban_checker::IbanChecker;
 pub use crate::secondary_validation::jwt_expiration_checker::JwtExpirationChecker;
+pub use crate::secondary_validation::latvia_national_id_checksum::LatviaNationalIdChecksum;
 pub use crate::secondary_validation::luhn_checksum::LuhnChecksum;
 pub use crate::secondary_validation::luxembourg_individual_nin_checksum::LuxembourgIndividualNINChecksum;
 pub use crate::secondary_validation::nhs_check_digit::NhsCheckDigit;
@@ -82,6 +84,9 @@ impl Validator for SecondaryValidator {
                 LuxembourgIndividualNINChecksum.is_valid_match(regex_match)
             }
             SecondaryValidator::FranceSsnChecksum => FranceSsnChecksum.is_valid_match(regex_match),
+            SecondaryValidator::LatviaNationalIdChecksum => {
+                LatviaNationalIdChecksum.is_valid_match(regex_match)
+            }
         }
     }
 }


### PR DESCRIPTION
Latvia national identification number has 2 formats:

1. Since July 1st 2017, an 11-digit number, starting with "32" with possible '-' after the 6th digit
2. Before July 1st 2017, an 11 digits number, in the format DDMMYY-XNNNZ, where:
  a. `DDMMYY` is the date of birth
  b. `X` represents the century digit (0 for 19, 1 for 20, 2 for 21)
  c. `NNN` is a birth serial number in that day
  d. `Z` is the checksum digit

So we only need to check the validity of `Z` when the match doesn't start with `32`