### PR TITLE
Make sort of licenses system agnostic

### DIFF
--- a/scripts/generate_license_3rdparty.sh
+++ b/scripts/generate_license_3rdparty.sh
@@ -10,7 +10,7 @@ for path in "${paths[@]}"; do
   dd-rust-license-tool -c $license_config write
 done
 
-expected=$(cat "${root}"/*/**/LICENSE-3rdparty.csv | LC_COLLATE=C  sort -u)
+expected=$(cat "${root}"/*/**/LICENSE-3rdparty.csv | LC_COLLATE=C sort -u)
 
 for path in "${paths[@]}"; do
   cd "${root}${path}"

--- a/scripts/generate_license_3rdparty.sh
+++ b/scripts/generate_license_3rdparty.sh
@@ -10,7 +10,7 @@ for path in "${paths[@]}"; do
   dd-rust-license-tool -c $license_config write
 done
 
-expected=$(cat "${root}"/*/**/LICENSE-3rdparty.csv | sort | uniq)
+expected=$(cat "${root}"/*/**/LICENSE-3rdparty.csv | LC_COLLATE=C  sort -u)
 
 for path in "${paths[@]}"; do
   cd "${root}${path}"


### PR DESCRIPTION
 Make `scripts/generate_license_3rdparty.sh` generates the same output on both MacOS & Linux  - see [discussion](https://stackoverflow.com/questions/19851940/how-can-i-make-gnu-sort-put-uppercase-letters-first)


- [`LC_COLLATE=C`](https://www.ibm.com/docs/en/i/7.5.0?topic=categories-lc-collate-category) defines the character order
- `-u` parameter is the same as `uniq`, it removes duplicated lines.
