### PR TITLE
Temporary workaround for the regex cache unwrap panic

### DIFF
--- a/sds/src/proximity_keywords/included_keywords.rs
+++ b/sds/src/proximity_keywords/included_keywords.rs
@@ -34,11 +34,12 @@ impl IncludedKeywordSearch<'_> {
     pub fn next(&mut self, regex_caches: &mut RegexCaches) -> Option<Range<usize>> {
         let input = Input::new(self.content).range(self.start..).earliest(true);
 
-        if let Some(included_keyword_match) =
-            self.keywords.keywords_pattern.content_regex.search_with(
-                regex_caches.get(&self.keywords.keywords_pattern.content_regex),
-                &input,
-            )
+        let mut cache = regex_caches.get(&self.keywords.keywords_pattern.content_regex);
+        if let Some(included_keyword_match) = self
+            .keywords
+            .keywords_pattern
+            .content_regex
+            .search_with(cache.as_mut(), &input)
         {
             // The next scan starts at the next character after the start of the keyword since
             // multi-word keywords can overlap

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -51,10 +51,11 @@ impl CompiledRule for RegexCompiledRule {
                 );
             }
             None => {
+                let mut cache = regex_caches.get(&self.regex);
                 let true_positive_search = self.true_positive_matches(
                     content,
                     0,
-                    regex_caches.get(&self.regex),
+                    cache.as_mut(),
                     true,
                     exclusion_check,
                     excluded_matches,
@@ -92,10 +93,11 @@ impl RegexCompiledRule {
         'included_keyword_search: while let Some(included_keyword_match) =
             included_keyword_matches.next(regex_caches)
         {
+            let mut cache = regex_caches.get(&self.regex);
             let true_positive_search = self.true_positive_matches(
                 content,
                 included_keyword_match.end,
-                regex_caches.get(&self.regex),
+                cache.as_mut(),
                 false,
                 exclusion_check,
                 excluded_matches,
@@ -140,11 +142,8 @@ impl RegexCompiledRule {
 
         {
             let input = Input::new(content);
-            if self
-                .regex
-                .search_with(regex_caches.get(&self.regex), &input)
-                .is_some()
-            {
+            let mut cache = regex_caches.get(&self.regex);
+            if self.regex.search_with(cache.as_mut(), &input).is_some() {
                 has_verified_kws_in_path = Some(contains_keyword_in_path(
                     &path.sanitize(),
                     &included_keywords.keywords_pattern,
@@ -158,10 +157,11 @@ impl RegexCompiledRule {
             return;
         }
 
+        let mut cache = regex_caches.get(&self.regex);
         let true_positive_search = self.true_positive_matches(
             content,
             0,
-            regex_caches.get(&self.regex),
+            cache.as_mut(),
             false,
             exclusion_check,
             excluded_matches,

--- a/sds/src/scanner/regex_rule/regex_cache_store.rs
+++ b/sds/src/scanner/regex_rule/regex_cache_store.rs
@@ -25,7 +25,7 @@ pub fn access_regex_caches<T>(func: impl FnOnce(&mut RegexCaches) -> T) -> T {
 
 pub enum CacheHandle<'a> {
     Borrowed(&'a mut Cache),
-    Owned(Cache),
+    Owned(Box<Cache>),
 }
 
 impl<'a> AsMut<Cache> for CacheHandle<'a> {
@@ -56,7 +56,7 @@ impl RegexCaches {
             // one-off cache is created. This will work but can be slow if it happens often.
             // This is tracked by a new metric since otherwise this would no longer be visible.
             GLOBAL_STATS.regex_store_errors.increment(1);
-            CacheHandle::Owned(shared_regex.create_cache())
+            CacheHandle::Owned(Box::new(shared_regex.create_cache()))
         }
     }
 

--- a/sds/src/scanner/regex_rule/regex_store.rs
+++ b/sds/src/scanner/regex_rule/regex_store.rs
@@ -125,8 +125,8 @@ impl RegexStore {
             existing_regex
         } else {
             let shared_regex = Arc::new(regex);
-
             let regex_cache = shared_regex.create_cache();
+
             let cache_key = self.key_map.insert(WeakSharedRegex {
                 regex: Arc::downgrade(&shared_regex),
                 cache_size: regex_cache.memory_usage() + std::mem::size_of::<Cache>(),
@@ -155,7 +155,8 @@ mod test {
         get_memoized_regex_with_custom_store, RegexStore, GC_FREQUENCY,
     };
     use regex_automata::meta::Regex;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
 
     #[test]
     fn dropped_regexes_should_be_removed_from_global_store() {
@@ -189,5 +190,28 @@ mod test {
         }
         // The insertion that triggered the GC is itself not cleaned up yet, but everything else is
         assert_eq!(store.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_remove_while_in_use() {
+        let store = Arc::new(Mutex::new(RegexStore::new()));
+
+        // First, get a SharedRegex and keep it alive
+        let shared_regex =
+            get_memoized_regex_with_custom_store("test_pattern", Regex::new, &store).unwrap();
+
+        // Spawn a thread that will try to insert the same pattern while the first SharedRegex is still alive
+        let store_clone = store.clone();
+        let handle = thread::spawn(move || {
+            // This should NOT remove the old cache key because shared_regex is still alive
+            let _ = get_memoized_regex_with_custom_store("test_pattern", Regex::new, &store_clone)
+                .unwrap();
+        });
+
+        // Wait for the thread to complete
+        handle.join().unwrap();
+
+        // The original shared_regex should still be valid
+        let _ = shared_regex.regex.is_match("test_pattern");
     }
 }

--- a/sds/src/stats.rs
+++ b/sds/src/stats.rs
@@ -19,6 +19,8 @@ pub struct Stats {
 
     total_regex_cache_size_count: AtomicI64,
     total_regex_cache_size: Gauge,
+
+    pub regex_store_errors: Counter,
 }
 
 impl Stats {
@@ -31,6 +33,7 @@ impl Stats {
             total_regexes: gauge!("scanner.total_regexes"),
             total_regex_cache_size_count: AtomicI64::new(0),
             total_regex_cache_size: gauge!("scanner.total_regex_cache_size"),
+            regex_store_errors: counter!("scanner.regex_store_error"),
         }
     }
 


### PR DESCRIPTION
Somehow the `.unwrap()` of `raw_get` can panic, and the root cause hasn't been identified yet. As a temporary workaround, in the case the cache is not available for a regex, a temporary one is created. The main downside here is creating a new cache is way more expensive than re-using one, but it does avoid a panic. As long as this doesn't happen very often the overall perf impact should be negligible.

Since the panic will no longer be visible, a new metric was created to track this error.