### PR TITLE
Add missing RodneCisloNumberChecksum in validator mapping

### DIFF
--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -178,6 +178,7 @@ pub enum SecondaryValidator {
     PolishNationalIdChecksum,
     PolishNipChecksum,
     PortugueseTaxIdChecksum,
+    RodneCisloNumberChecksum,
     RomanianPersonalNumericCode,
     SlovenianPINChecksum,
     SpanishDniChecksum,

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use serde_with::DefaultOnNull;
 use std::sync::Arc;
-use strum::EnumIter;
+use strum::{AsRefStr, EnumIter};
 
 pub const DEFAULT_KEYWORD_LOOKAHEAD: usize = 30;
 
@@ -60,7 +60,7 @@ impl RegexRuleConfig {
 
     pub fn with_included_keywords(
         &self,
-        keywords: impl IntoIterator<Item = impl AsRef<str>>,
+        keywords: impl IntoIterator<Item=impl AsRef<str>>,
     ) -> Self {
         let mut this = self.clone();
         let mut config = self.get_or_create_proximity_keywords_config();
@@ -133,56 +133,56 @@ pub struct ProximityKeywordsConfig {
     pub excluded_keywords: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, EnumIter)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, EnumIter, AsRefStr)]
 #[serde(tag = "type")]
 pub enum SecondaryValidator {
     AbaRtnChecksum,
-    BrazilianCpfChecksum,
     BrazilianCnpjChecksum,
+    BrazilianCpfChecksum,
     BtcChecksum,
+    BulgarianEGNChecksum,
     ChineseIdChecksum,
+    CoordinationNumberChecksum,
+    CzechPersonalIdentificationNumberChecksum,
+    CzechTaxIdentificationNumberChecksum,
+    DutchDsnChecksum,
+    DutchPassportChecksum,
     EthereumChecksum,
+    FinnishHetuChecksum,
+    FranceNifChecksum,
+    FranceSsnChecksum,
+    GermanIdsChecksum,
+    GermanSvnrChecksum,
     GithubTokenChecksum,
     GreekTinChecksum,
+    HungarianTinChecksum,
     IbanChecker,
+    IrishPpsChecksum,
     ItalianNationalIdChecksum,
     JwtExpirationChecker,
+    LatviaNationalIdChecksum,
+    LithuanianPersonalIdentificationNumberChecksum,
     LuhnChecksum,
+    LuxembourgIndividualNINChecksum,
+    Mod11_10checksum,
     Mod11_2checksum,
-    Mod37_2checksum,
     Mod1271_36Checksum,
+    Mod27_26checksum,
+    Mod37_2checksum,
+    Mod37_36checksum,
     Mod661_26checksum,
     Mod97_10checksum,
-    Mod11_10checksum,
-    Mod27_26checksum,
-    Mod37_36checksum,
     MoneroAddress,
     NhsCheckDigit,
     NirChecksum,
     PolishNationalIdChecksum,
     PolishNipChecksum,
-    LuxembourgIndividualNINChecksum,
-    DutchPassportChecksum,
-    FranceSsnChecksum,
-    BulgarianEGNChecksum,
-    CzechTaxIdentificationNumberChecksum,
-    HungarianTinChecksum,
-    CzechPersonalIdentificationNumberChecksum,
-    SpanishNussChecksum,
-    DutchDsnChecksum,
-    FranceNifChecksum,
-    GermanSvnrChecksum,
-    SwedenPINChecksum,
-    LatviaNationalIdChecksum,
-    CoordinationNumberChecksum,
-    LithuanianPersonalIdentificationNumberChecksum,
-    GermanIdsChecksum,
-    SpanishDniChecksum,
-    SlovenianPINChecksum,
-    FinnishHetuChecksum,
-    IrishPpsChecksum,
     PortugueseTaxIdChecksum,
     RomanianPersonalNumericCode,
+    SlovenianPINChecksum,
+    SpanishDniChecksum,
+    SpanishNussChecksum,
+    SwedenPINChecksum,
 }
 
 #[cfg(test)]
@@ -289,5 +289,15 @@ mod test {
         // Verify some variants
         assert!(validators.contains(&SecondaryValidator::GithubTokenChecksum));
         assert!(validators.contains(&SecondaryValidator::JwtExpirationChecker));
+    }
+
+    #[test]
+    fn test_secondary_validator_are_sorted() {
+        let validator_names: Vec<String> = SecondaryValidator::iter()
+            .map(|a| a.as_ref().to_string())
+            .collect();
+        let mut sorted_validator_names = validator_names.clone();
+        sorted_validator_names.sort();
+        assert_eq!(sorted_validator_names, validator_names, "Secondary validators should be sorted by alphabetical order, but it's not the case, expected order:");
     }
 }

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -60,7 +60,7 @@ impl RegexRuleConfig {
 
     pub fn with_included_keywords(
         &self,
-        keywords: impl IntoIterator<Item=impl AsRef<str>>,
+        keywords: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Self {
         let mut this = self.clone();
         let mut config = self.get_or_create_proximity_keywords_config();

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -126,99 +126,99 @@ fn sum_all_digits(digits: u32) -> u32 {
 impl Validator for SecondaryValidator {
     fn is_valid_match(&self, regex_match: &str) -> bool {
         match self {
-            SecondaryValidator::LuhnChecksum => LuhnChecksum.is_valid_match(regex_match),
+            SecondaryValidator::AbaRtnChecksum => AbaRtnChecksum.is_valid_match(regex_match),
+            SecondaryValidator::BrazilianCnpjChecksum => {
+                BrazilianCnpjChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::BrazilianCpfChecksum => {
+                BrazilianCpfChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::BtcChecksum => BtcChecksum.is_valid_match(regex_match),
+            SecondaryValidator::BulgarianEGNChecksum => {
+                BulgarianEGNChecksum.is_valid_match(regex_match)
+            }
             SecondaryValidator::ChineseIdChecksum => ChineseIdChecksum.is_valid_match(regex_match),
+            SecondaryValidator::CoordinationNumberChecksum => {
+                CoordinationNumberChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::CzechPersonalIdentificationNumberChecksum => {
+                RodneCisloNumberChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::CzechTaxIdentificationNumberChecksum => {
+                CzechTaxIdentificationNumberChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::DutchDsnChecksum => DutchDsnChecksum.is_valid_match(regex_match),
+            SecondaryValidator::DutchPassportChecksum => {
+                DutchPassportChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::EthereumChecksum => EthereumChecksum.is_valid_match(regex_match),
+            SecondaryValidator::FinnishHetuChecksum => {
+                FinnishHetuChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::FranceNifChecksum => FranceNifChecksum.is_valid_match(regex_match),
+            SecondaryValidator::FranceSsnChecksum => FranceSsnChecksum.is_valid_match(regex_match),
+            SecondaryValidator::GermanIdsChecksum => GermanIdsChecksum.is_valid_match(regex_match),
+            SecondaryValidator::GermanSvnrChecksum => {
+                GermanSvnrChecksum.is_valid_match(regex_match)
+            }
             SecondaryValidator::GithubTokenChecksum => {
                 GithubTokenChecksum.is_valid_match(regex_match)
             }
-            SecondaryValidator::NhsCheckDigit => NhsCheckDigit.is_valid_match(regex_match),
-            SecondaryValidator::IbanChecker => IbanChecker.is_valid_match(regex_match),
-            SecondaryValidator::FranceSsnChecksum => FranceSsnChecksum.is_valid_match(regex_match),
-            SecondaryValidator::Mod11_2checksum => Mod11_2checksum.is_valid_match(regex_match),
-            SecondaryValidator::Mod37_2checksum => Mod37_2checksum.is_valid_match(regex_match),
-            SecondaryValidator::Mod1271_36Checksum => {
-                Mod1271_36Checksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::Mod661_26checksum => Mod661_26checksum.is_valid_match(regex_match),
-            SecondaryValidator::Mod97_10checksum => Mod97_10checksum.is_valid_match(regex_match),
-            SecondaryValidator::Mod11_10checksum => Mod11_10checksum.is_valid_match(regex_match),
-            SecondaryValidator::Mod27_26checksum => Mod27_26checksum.is_valid_match(regex_match),
-            SecondaryValidator::Mod37_36checksum => Mod37_36checksum.is_valid_match(regex_match),
-            SecondaryValidator::NirChecksum => NirChecksum.is_valid_match(regex_match),
             SecondaryValidator::GreekTinChecksum => GreekTinChecksum.is_valid_match(regex_match),
+            SecondaryValidator::HungarianTinChecksum => {
+                HungarianTinChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::IbanChecker => IbanChecker.is_valid_match(regex_match),
+            SecondaryValidator::IrishPpsChecksum => IrishPpsChecksum.is_valid_match(regex_match),
             SecondaryValidator::ItalianNationalIdChecksum => {
                 ItalianNationalIdChecksum.is_valid_match(regex_match)
             }
             SecondaryValidator::JwtExpirationChecker => {
                 JwtExpirationChecker.is_valid_match(regex_match)
             }
-            SecondaryValidator::BrazilianCpfChecksum => {
-                BrazilianCpfChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::BrazilianCnpjChecksum => {
-                BrazilianCnpjChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::BtcChecksum => BtcChecksum.is_valid_match(regex_match),
-            SecondaryValidator::AbaRtnChecksum => AbaRtnChecksum.is_valid_match(regex_match),
-            SecondaryValidator::PolishNationalIdChecksum => {
-                PolishNationalIdChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::PolishNipChecksum => PolishNipChecksum.is_valid_match(regex_match),
-            SecondaryValidator::LuxembourgIndividualNINChecksum => {
-                LuxembourgIndividualNINChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::BulgarianEGNChecksum => {
-                BulgarianEGNChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::CzechTaxIdentificationNumberChecksum => {
-                CzechTaxIdentificationNumberChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::HungarianTinChecksum => {
-                HungarianTinChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::CzechPersonalIdentificationNumberChecksum => {
-                RodneCisloNumberChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::SpanishNussChecksum => {
-                SpanishNussChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::DutchPassportChecksum => {
-                DutchPassportChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::DutchDsnChecksum => DutchDsnChecksum.is_valid_match(regex_match),
-            SecondaryValidator::FranceNifChecksum => FranceNifChecksum.is_valid_match(regex_match),
-            SecondaryValidator::GermanSvnrChecksum => {
-                GermanSvnrChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::SwedenPINChecksum => SwedenPINChecksum.is_valid_match(regex_match),
             SecondaryValidator::LatviaNationalIdChecksum => {
                 LatviaNationalIdChecksum.is_valid_match(regex_match)
-            }
-            SecondaryValidator::CoordinationNumberChecksum => {
-                CoordinationNumberChecksum.is_valid_match(regex_match)
             }
             SecondaryValidator::LithuanianPersonalIdentificationNumberChecksum => {
                 LithuanianPersonalIdentificationNumberChecksum.is_valid_match(regex_match)
             }
-            SecondaryValidator::GermanIdsChecksum => GermanIdsChecksum.is_valid_match(regex_match),
-            SecondaryValidator::SpanishDniChecksum => {
-                SpanishDniChecksum.is_valid_match(regex_match)
+            SecondaryValidator::LuhnChecksum => LuhnChecksum.is_valid_match(regex_match),
+            SecondaryValidator::LuxembourgIndividualNINChecksum => {
+                LuxembourgIndividualNINChecksum.is_valid_match(regex_match)
             }
-            SecondaryValidator::SlovenianPINChecksum => {
-                SlovenianPINChecksum.is_valid_match(regex_match)
+            SecondaryValidator::Mod11_10checksum => Mod11_10checksum.is_valid_match(regex_match),
+            SecondaryValidator::Mod11_2checksum => Mod11_2checksum.is_valid_match(regex_match),
+            SecondaryValidator::Mod1271_36Checksum => {
+                Mod1271_36Checksum.is_valid_match(regex_match)
             }
-            SecondaryValidator::FinnishHetuChecksum => {
-                FinnishHetuChecksum.is_valid_match(regex_match)
+            SecondaryValidator::Mod27_26checksum => Mod27_26checksum.is_valid_match(regex_match),
+            SecondaryValidator::Mod37_2checksum => Mod37_2checksum.is_valid_match(regex_match),
+            SecondaryValidator::Mod37_36checksum => Mod37_36checksum.is_valid_match(regex_match),
+            SecondaryValidator::Mod661_26checksum => Mod661_26checksum.is_valid_match(regex_match),
+            SecondaryValidator::Mod97_10checksum => Mod97_10checksum.is_valid_match(regex_match),
+            SecondaryValidator::MoneroAddress => MoneroAddress.is_valid_match(regex_match),
+            SecondaryValidator::NhsCheckDigit => NhsCheckDigit.is_valid_match(regex_match),
+            SecondaryValidator::NirChecksum => NirChecksum.is_valid_match(regex_match),
+            SecondaryValidator::PolishNationalIdChecksum => {
+                PolishNationalIdChecksum.is_valid_match(regex_match)
             }
-            SecondaryValidator::IrishPpsChecksum => IrishPpsChecksum.is_valid_match(regex_match),
+            SecondaryValidator::PolishNipChecksum => PolishNipChecksum.is_valid_match(regex_match),
             SecondaryValidator::PortugueseTaxIdChecksum => {
                 PortugueseTaxIdChecksum.is_valid_match(regex_match)
             }
             SecondaryValidator::RomanianPersonalNumericCode => {
                 RomanianPersonalNumericCode.is_valid_match(regex_match)
             }
-            SecondaryValidator::EthereumChecksum => EthereumChecksum.is_valid_match(regex_match),
-            SecondaryValidator::MoneroAddress => MoneroAddress.is_valid_match(regex_match),
+            SecondaryValidator::SlovenianPINChecksum => {
+                SlovenianPINChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::SpanishDniChecksum => {
+                SpanishDniChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::SpanishNussChecksum => {
+                SpanishNussChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::SwedenPINChecksum => SwedenPINChecksum.is_valid_match(regex_match),
         }
     }
 }

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -206,6 +206,9 @@ impl Validator for SecondaryValidator {
             SecondaryValidator::PortugueseTaxIdChecksum => {
                 PortugueseTaxIdChecksum.is_valid_match(regex_match)
             }
+            SecondaryValidator::RodneCisloNumberChecksum => {
+                RodneCisloNumberChecksum.is_valid_match(regex_match)
+            }
             SecondaryValidator::RomanianPersonalNumericCode => {
                 RomanianPersonalNumericCode.is_valid_match(regex_match)
             }


### PR DESCRIPTION
Add missing `RodneCisloNumberChecksum` in validator mapping. This validator has been not correctly mapped in https://github.com/DataDog/dd-sensitive-data-scanner/pull/204 due to a bad merge conflict.


[Jira ticket](https://datadoghq.atlassian.net/browse/SDS-1265?atlOrigin=eyJpIjoiZmVkZjA1MWM2N2JiNGIxMDg2MDk4ZWQ5ODk3OTUxMDQiLCJwIjoiaiJ9)