### PR TITLE
Prevent empty matches

### DIFF
--- a/sds/src/normalization/rust_regex_adapter.rs
+++ b/sds/src/normalization/rust_regex_adapter.rs
@@ -37,9 +37,13 @@ pub const QUANTIFIER_LIMIT: u32 = 3000;
 /// makes no attempt to preserve the exact syntax used. This is only intended
 /// to feed directly into a regex engine, and not intended for human readability.
 pub fn convert_to_rust_regex(pattern: &str) -> Result<String, ParseError> {
+    convert_to_rust_regex_ast(pattern).map(|s| s.to_string())
+}
+
+pub fn convert_to_rust_regex_ast(pattern: &str) -> Result<RegexAst, ParseError> {
     let sds_ast = parse_regex_pattern(pattern)?;
     let regex_ast = convert_ast(&sds_ast)?;
-    Ok(regex_ast.to_string())
+    Ok(regex_ast)
 }
 
 // This is private since only ASTs generated from the parser are supported.

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -789,6 +789,10 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
             {
                 // creating the emitter is basically free, it will get mostly optimized away
                 let mut emitter = |rule_match: StringMatch| {
+                    // This should never happen, but to ensure no empty match is ever generated
+                    // (which may cause an infinite loop), this will panic instead.
+                    assert_ne!(rule_match.start, rule_match.end, "empty match detected");
+
                     path_rules_matches.push(InternalRuleMatch {
                         rule_index,
                         utf8_start: rule_match.start,

--- a/sds/src/validation.rs
+++ b/sds/src/validation.rs
@@ -1,6 +1,10 @@
-use crate::normalization::rust_regex_adapter::{convert_to_rust_regex, QUANTIFIER_LIMIT};
+use crate::normalization::rust_regex_adapter::{
+    convert_to_rust_regex, convert_to_rust_regex_ast, QUANTIFIER_LIMIT,
+};
 use crate::parser::error::ParseError;
 use regex_automata::meta::{self};
+use regex_syntax::ast::Ast;
+use regex_syntax::hir::translate::Translator;
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -63,12 +67,33 @@ pub fn get_regex_complexity_estimate_very_slow(input: &str) -> Result<usize, Reg
 
 pub fn validate_and_create_regex(input: &str) -> Result<meta::Regex, RegexValidationError> {
     // This validates that the syntax is valid and normalizes behavior.
-    let converted_pattern = convert_to_rust_regex(input)?;
-    let regex = build_regex(&converted_pattern, REGEX_COMPLEXITY_LIMIT)?;
-    if regex.is_match("") {
-        return Err(RegexValidationError::MatchesEmptyString);
-    }
+    let ast = convert_to_rust_regex_ast(input)?;
+    let pattern = ast.to_string();
+
+    // Ensure that zero-length matches are not possible
+    check_minimum_match_length(&ast, &pattern)?;
+
+    let regex = build_regex(&pattern.to_string(), REGEX_COMPLEXITY_LIMIT)?;
     Ok(regex)
+}
+
+fn check_minimum_match_length(ast: &Ast, ast_str: &str) -> Result<(), RegexValidationError> {
+    let hir = Translator::new()
+        .translate(ast_str, ast)
+        .map_err(|_| RegexValidationError::InvalidSyntax)?;
+    match hir.properties().minimum_len() {
+        None => {
+            // This pattern cannot ever match
+            Err(RegexValidationError::InvalidSyntax)
+        }
+        Some(min_length) => {
+            if min_length == 0 {
+                Err(RegexValidationError::MatchesEmptyString)
+            } else {
+                Ok(())
+            }
+        }
+    }
 }
 
 fn is_regex_within_complexity_limit(
@@ -117,6 +142,7 @@ mod test {
         get_regex_complexity_estimate_very_slow, validate_and_create_regex, validate_regex,
         RegexValidationError,
     };
+    use crate::{MatchAction, RegexRuleConfig, RootRuleConfig, ScannerBuilder};
 
     #[test]
     fn pattern_matching_empty_string_is_invalid() {
@@ -181,6 +207,14 @@ mod test {
         assert_eq!(
             get_regex_complexity_estimate_very_slow(".{1,1000}"),
             Ok(1_040_136)
+        );
+    }
+
+    #[test]
+    fn test_empty_match_without_empty_string() {
+        assert_eq!(
+            validate_regex("\\bx{0,2}\\b"),
+            Err(RegexValidationError::MatchesEmptyString)
         );
     }
 }


### PR DESCRIPTION
Validation was in place previously to ensure a regex could not match on an empty string, however that wasn't enough to prevent empty-string matches. A regex pattern such as `\bx+\b` will _not_ match on the empty string, but it can still have empty-string matches. This is because assertions (such as the `/b` word-boundary assertion) don't consume characters (can produce empty matches) but don't match on an empty string so it got around the existing validation.

The validation has been improved to directly query the minimum size that the regex can match (provided through the `regex-syntax` crate). It _should_ now be impossible to generate zero-size matches with regex rules. However, just to ensure this never happens (especially for rule types created outside of this repo) a runtime check has been added which will panic if a zero-sized match is detected. A zero-size match is likely to cause an infinite loop which can consume an unbounded amount of memory, so a panic is preferable here.