### PR TITLE
Fix Name of DutchBsnChecksum Secondary validator

### DIFF
--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -145,7 +145,7 @@ pub enum SecondaryValidator {
     CoordinationNumberChecksum,
     CzechPersonalIdentificationNumberChecksum,
     CzechTaxIdentificationNumberChecksum,
-    DutchDsnChecksum,
+    DutchBsnChecksum,
     DutchPassportChecksum,
     EthereumChecksum,
     FinnishHetuChecksum,

--- a/sds/src/secondary_validation/dutch_bsn_checksum.rs
+++ b/sds/src/secondary_validation/dutch_bsn_checksum.rs
@@ -1,11 +1,11 @@
 use crate::secondary_validation::Validator;
 
-pub struct DutchDsnChecksum;
+pub struct DutchBsnChecksum;
 const MULTIPLIERS: &[i32] = &[-1, 2, 3, 4, 5, 6, 7, 8, 9];
 const MODULO: i32 = 11;
 
 // https://nl.wikipedia.org/wiki/Burgerservicenummer
-impl Validator for DutchDsnChecksum {
+impl Validator for DutchBsnChecksum {
     fn is_valid_match(&self, regex_match: &str) -> bool {
         let valid_chars = regex_match.chars().filter(|c| c.is_ascii_alphanumeric());
 
@@ -37,7 +37,7 @@ mod test {
         ];
         for id in valid_ids {
             println!("testing for input {}", id);
-            assert!(DutchDsnChecksum.is_valid_match(id));
+            assert!(DutchBsnChecksum.is_valid_match(id));
         }
     }
 
@@ -54,7 +54,7 @@ mod test {
         ];
         for id in invalid_ids {
             println!("testing for input {}", id);
-            assert!(!DutchDsnChecksum.is_valid_match(id));
+            assert!(!DutchBsnChecksum.is_valid_match(id));
         }
     }
 }

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -51,7 +51,7 @@ pub use crate::secondary_validation::bulgarian_egn_checksum::BulgarianEGNChecksu
 pub use crate::secondary_validation::chinese_id_checksum::ChineseIdChecksum;
 pub use crate::secondary_validation::coordination_number_checksum::CoordinationNumberChecksum;
 pub use crate::secondary_validation::czech_tin_checksum::CzechTaxIdentificationNumberChecksum;
-pub use crate::secondary_validation::dutch_bsn_checksum::DutchDsnChecksum;
+pub use crate::secondary_validation::dutch_bsn_checksum::DutchBsnChecksum;
 pub use crate::secondary_validation::dutch_passport_checksum::DutchPassportChecksum;
 pub use crate::secondary_validation::ethereum_checksum::EthereumChecksum;
 pub use crate::secondary_validation::finnish_hetu_checksum::FinnishHetuChecksum;
@@ -147,7 +147,7 @@ impl Validator for SecondaryValidator {
             SecondaryValidator::CzechTaxIdentificationNumberChecksum => {
                 CzechTaxIdentificationNumberChecksum.is_valid_match(regex_match)
             }
-            SecondaryValidator::DutchDsnChecksum => DutchDsnChecksum.is_valid_match(regex_match),
+            SecondaryValidator::DutchBsnChecksum => DutchBsnChecksum.is_valid_match(regex_match),
             SecondaryValidator::DutchPassportChecksum => {
                 DutchPassportChecksum.is_valid_match(regex_match)
             }


### PR DESCRIPTION
`DutchDsnChecksum` contains a typo. This PR fixes it.

BSN is for BurgerServiceNummer.


_this is not related to any story._