### PR TITLE
Add log when rule is skipped

### DIFF
--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -732,6 +732,8 @@ impl ScannerBuilder<'_> {
                                     RegexValidationError::MatchesEmptyString,
                                 )
                         {
+                            // this is a temporary feature to skip rules that should be considered invalid.
+                            println!("skipping rule that matches empty string: rule_index={}, labels={:?}", rule_index, self.labels.clone());
                             return None;
                         } else {
                             Err(err)


### PR DESCRIPTION
Adds a log when rules are skipped to be able to verify this never happens. This is temporary and will be removed in the near future.