### PR TITLE
use a local rayon thread pool

### DIFF
--- a/sds/src/match_validation/aws_validator.rs
+++ b/sds/src/match_validation/aws_validator.rs
@@ -5,11 +5,12 @@ use super::{
     match_validator::MatchValidator,
     validator_utils::generate_aws_headers_and_body,
 };
+use crate::match_validation::match_validator::RAYON_THREAD_POOL;
 use crate::scanner::RootCompiledRule;
 use crate::{MatchStatus, RuleMatch};
 use ahash::AHashMap;
 use lazy_static::lazy_static;
-use rayon::prelude::*;
+use rayon::iter::IntoParallelRefMutIterator;
 use reqwest::Client;
 
 lazy_static! {
@@ -122,50 +123,55 @@ impl MatchValidator for AwsValidator {
             self.get_match_status_per_pairs_of_matches_idx(matches, scanner_rules);
 
         // Let's try all combination of aws_id and aws_secret
-        match_status_per_pairs_of_matches_idx
-            .par_iter_mut()
-            .for_each(|((id_index, secret_index), match_status)| {
-                let match_id = &matches[*id_index].match_value;
-                let match_secret = &matches[*secret_index].match_value;
-                if match_secret.is_none() {
-                    *match_status =
-                        MatchStatus::Error("Missing match value for aws_secret".to_string());
-                    return;
-                }
-                if match_id.is_none() {
-                    *match_status =
-                        MatchStatus::Error("Missing match value for aws_id".to_string());
-                    return;
-                }
-                let match_secret = extract_aws_secret_from_match(match_secret.as_ref().unwrap());
-                let match_id = match_id.as_ref().unwrap();
-                // Let's reqwest the HTTP API endpoint to validate the matches
-                let mut datetime = chrono::Utc::now();
-                if self.config.forced_datetime_utc.is_some() {
-                    datetime = self.config.forced_datetime_utc.unwrap()
-                }
-                let (body, headers) = generate_aws_headers_and_body(
-                    &datetime,
-                    &self.config.aws_sts_endpoint,
-                    match_id,
-                    &match_secret,
-                );
-                let res = AWS_BLOCKING_CLIENT
-                    .post(self.config.aws_sts_endpoint.as_str())
-                    .headers(headers)
-                    .body(body)
-                    .timeout(self.config.timeout)
-                    .send();
+        RAYON_THREAD_POOL.install(|| {
+            use rayon::prelude::*;
 
-                match res {
-                    Ok(val) => handle_reqwest_response(match_status, &val),
-                    Err(err) => {
-                        *match_status = MatchStatus::Error(fmt::format(format_args!(
-                            "Error making HTTP request: {err}"
-                        )));
+            match_status_per_pairs_of_matches_idx
+                .par_iter_mut()
+                .for_each(|((id_index, secret_index), match_status)| {
+                    let match_id = &matches[*id_index].match_value;
+                    let match_secret = &matches[*secret_index].match_value;
+                    if match_secret.is_none() {
+                        *match_status =
+                            MatchStatus::Error("Missing match value for aws_secret".to_string());
+                        return;
                     }
-                };
-            });
+                    if match_id.is_none() {
+                        *match_status =
+                            MatchStatus::Error("Missing match value for aws_id".to_string());
+                        return;
+                    }
+                    let match_secret =
+                        extract_aws_secret_from_match(match_secret.as_ref().unwrap());
+                    let match_id = match_id.as_ref().unwrap();
+                    // Let's reqwest the HTTP API endpoint to validate the matches
+                    let mut datetime = chrono::Utc::now();
+                    if self.config.forced_datetime_utc.is_some() {
+                        datetime = self.config.forced_datetime_utc.unwrap()
+                    }
+                    let (body, headers) = generate_aws_headers_and_body(
+                        &datetime,
+                        &self.config.aws_sts_endpoint,
+                        match_id,
+                        &match_secret,
+                    );
+                    let res = AWS_BLOCKING_CLIENT
+                        .post(self.config.aws_sts_endpoint.as_str())
+                        .headers(headers)
+                        .body(body)
+                        .timeout(self.config.timeout)
+                        .send();
+
+                    match res {
+                        Ok(val) => handle_reqwest_response(match_status, &val),
+                        Err(err) => {
+                            *match_status = MatchStatus::Error(fmt::format(format_args!(
+                                "Error making HTTP request: {err}"
+                            )));
+                        }
+                    };
+                });
+        });
 
         merge_returned_match_status_with_better_status(
             matches,

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -2,11 +2,12 @@ use super::{
     config::{CustomHttpConfig, RequestHeader},
     match_validator::MatchValidator,
 };
+use crate::match_validation::match_validator::RAYON_THREAD_POOL;
 use crate::{match_validation::config::HttpMethod, MatchStatus, RuleMatch};
 use crate::{scanner::RootCompiledRule, HttpValidatorOption};
 use ahash::AHashMap;
 use lazy_static::lazy_static;
-use rayon::prelude::*;
+use rayon::iter::IntoParallelRefMutIterator;
 use reqwest::blocking::Response;
 use std::{fmt, ops::Range, time::Duration};
 
@@ -109,37 +110,41 @@ impl MatchValidator for HttpValidator {
             })
             .collect();
 
-        match_status_per_endpoint_and_match.par_iter_mut().for_each(
-            |((match_idx, endpoint), match_status)| {
-                let match_value = matches[*match_idx].match_value.as_ref().unwrap();
-                let mut request_builder = match self.config.method {
-                    HttpMethod::Get => BLOCKING_HTTP_CLIENT.get(*endpoint),
-                    HttpMethod::Post => BLOCKING_HTTP_CLIENT.post(*endpoint),
-                    HttpMethod::Put => BLOCKING_HTTP_CLIENT.put(*endpoint),
-                    HttpMethod::Delete => BLOCKING_HTTP_CLIENT.delete(*endpoint),
-                    HttpMethod::Patch => BLOCKING_HTTP_CLIENT.patch(*endpoint),
-                };
-                request_builder = request_builder.timeout(self.config.options.timeout);
+        RAYON_THREAD_POOL.install(|| {
+            use rayon::prelude::*;
 
-                // Add headers
-                for header in &self.config.request_header {
-                    request_builder = request_builder
-                        .header(&header.key, &header.get_value_with_match(match_value));
-                }
-                let res = request_builder.send();
-                match res {
-                    Ok(val) => {
-                        self.handle_reqwest_response(match_status, &val);
+            match_status_per_endpoint_and_match.par_iter_mut().for_each(
+                |((match_idx, endpoint), match_status)| {
+                    let match_value = matches[*match_idx].match_value.as_ref().unwrap();
+                    let mut request_builder = match self.config.method {
+                        HttpMethod::Get => BLOCKING_HTTP_CLIENT.get(*endpoint),
+                        HttpMethod::Post => BLOCKING_HTTP_CLIENT.post(*endpoint),
+                        HttpMethod::Put => BLOCKING_HTTP_CLIENT.put(*endpoint),
+                        HttpMethod::Delete => BLOCKING_HTTP_CLIENT.delete(*endpoint),
+                        HttpMethod::Patch => BLOCKING_HTTP_CLIENT.patch(*endpoint),
+                    };
+                    request_builder = request_builder.timeout(self.config.options.timeout);
+
+                    // Add headers
+                    for header in &self.config.request_header {
+                        request_builder = request_builder
+                            .header(&header.key, &header.get_value_with_match(match_value));
                     }
-                    Err(err) => {
-                        // TODO(trosenblatt) emit a metrics for this
-                        *match_status = MatchStatus::Error(fmt::format(format_args!(
-                            "Error making HTTP request: {err}"
-                        )));
+                    let res = request_builder.send();
+                    match res {
+                        Ok(val) => {
+                            self.handle_reqwest_response(match_status, &val);
+                        }
+                        Err(err) => {
+                            // TODO(trosenblatt) emit a metrics for this
+                            *match_status = MatchStatus::Error(fmt::format(format_args!(
+                                "Error making HTTP request: {err}"
+                            )));
+                        }
                     }
-                }
-            },
-        );
+                },
+            );
+        });
 
         // Update the match status with this highest priority returned
         for ((match_idx, _), status) in match_status_per_endpoint_and_match {

--- a/sds/src/match_validation/match_validator.rs
+++ b/sds/src/match_validation/match_validator.rs
@@ -1,6 +1,13 @@
 use crate::scanner::RootCompiledRule;
 use crate::RuleMatch;
+use rayon::{ThreadPool, ThreadPoolBuilder};
+use std::sync::LazyLock;
 use std::vec::Vec;
+
+/// A locally configured thread pool is used for Rayon to prevent conflicts with other libraries
+/// that might override the (default) global thread pool with different (potentially undesirable) settings
+pub const RAYON_THREAD_POOL: LazyLock<ThreadPool> =
+    LazyLock::new(|| ThreadPoolBuilder::new().build().unwrap());
 
 pub trait MatchValidator: Send + Sync {
     // Trait use to validate the matches and update the match status


### PR DESCRIPTION
By default `rayon` will use a global thread pool with configuration of whatever code configures it first, potentially causing conflicts (e.g. different number of workers threads than expected). To prevent issues, a local thread pool is created and used.