### PR TITLE
[SDS] Put id of the rule in the error

### DIFF
--- a/sds-go/go/regex_rule.go
+++ b/sds-go/go/regex_rule.go
@@ -124,7 +124,7 @@ func (c RegexRuleConfig) CreateRule() (*Rule, error) {
 
 	ptr := C.create_regex_rule(cdata)
 	if ptr < 0 {
-		return nil, fmt.Errorf("Failed to create regex rule")
+		return nil, fmt.Errorf("Failed to create regex rule with id %s", c.Id)
 	} else {
 		return &Rule{nativeRulePtr: int64(ptr)}, nil
 	}


### PR DESCRIPTION
I want to be able to debug errors more easily --> https://app.datadoghq.com/logs?query=service%3Asds-context-provider%20status%3Awarn%20%22correctness%20checks%20are%20disabled%20the%20context%20will%20be%20published%20with%20the%20following%20errors%20cannot%20create%20scanner%20from%20group%20llm%20observability%20span%20scanning%20failed%20to%20create%20regex%20rule%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZfzrTntNEXojQAAABhBWmZ6clRwWkFBQ1c1RVRkVGh3SmVBTnoAAAAkMDE5N2YzYWQtNGZlYi00ZWI0LThhMWItY2YwYTI0OTU1MDZlAAD0KA&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1752120795875&to_ts=1752135195875&live=true