### PR TITLE
[SDS-1326] Default hosts to empty list when deserializing

### DIFF
--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -100,7 +100,7 @@ pub struct HttpValidatorOption {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct CustomHttpConfig {
     pub endpoint: String,
-    #[serde(default = "default_hosts")]
+    #[serde(default)]
     pub hosts: Vec<String>,
     #[serde(default = "default_http_method")]
     pub http_method: HttpMethod,
@@ -220,10 +220,6 @@ impl CustomHttpConfig {
 
 fn default_timeout_seconds() -> u32 {
     DEFAULT_HTTPS_TIMEOUT_SEC as u32
-}
-
-fn default_hosts() -> Vec<String> {
-    vec![]
 }
 
 fn default_http_method() -> HttpMethod {


### PR DESCRIPTION
When deserializing the third party active checker config, make sure we default the hosts attribute to an empty list. 

Add some tests to validate the behaviour.