### PR TITLE
cleanup get_string_matches function

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -48,7 +48,7 @@ pub use scanner::{
     regex_rule::RegexCaches,
     scope::Scope,
     CompiledRule, MatchEmitter, RootCompiledRule, RootRuleConfig, ScanOptionBuilder, Scanner,
-    ScannerBuilder, SharedData, StringMatch,
+    ScannerBuilder, SharedData, StringMatch, StringMatchesCtx,
 };
 pub use scoped_ruleset::ExclusionCheck;
 pub use validation::{

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -29,14 +29,6 @@ impl CompiledRule for RegexCompiledRule {
         content: &str,
         path: &Path,
         ctx: &mut StringMatchesCtx,
-        // regex_caches: &mut RegexCaches,
-        // _per_string_data: &mut SharedData,
-        // _per_scanner_data: &SharedData,
-        // _per_event_data: &mut SharedData,
-        // exclusion_check: &ExclusionCheck<'_>,
-        // excluded_matches: &mut AHashSet<String>,
-        // match_emitter: &mut dyn MatchEmitter,
-        // _: Option<&Vec<(usize, usize)>>,
     ) -> Result<(), ScannerError> {
         match self.included_keywords {
             Some(ref included_keywords) => {

--- a/sds/src/scanner/test/mod.rs
+++ b/sds/src/scanner/test/mod.rs
@@ -5,7 +5,7 @@ mod overlapping_matches;
 mod validators;
 
 use super::*;
-use super::{MatchEmitter, ScannerBuilder, StringMatch};
+use super::{ScannerBuilder, StringMatch};
 use crate::match_action::{MatchAction, MatchActionValidationError};
 
 use crate::observability::labels::Labels;
@@ -14,12 +14,10 @@ use crate::scanner::regex_rule::config::{
 };
 use crate::scanner::scope::Scope;
 use crate::scanner::{get_next_regex_start, CreateScannerError, Scanner};
-use crate::scoped_ruleset::ExclusionCheck;
 use crate::validation::RegexValidationError;
 
 use crate::{simple_event::SimpleEvent, PartialRedactDirection, Path, PathSegment, RuleMatch};
 use crate::{Encoding, Utf8Encoding};
-use ahash::AHashSet;
 
 use regex_automata::Match;
 use std::collections::BTreeMap;
@@ -36,16 +34,9 @@ impl CompiledRule for DumbCompiledRule {
         &self,
         _content: &str,
         _path: &Path,
-        _regex_caches: &mut RegexCaches,
-        _per_string_data: &mut SharedData,
-        _per_scanner_data: &SharedData,
-        _per_event_data: &mut SharedData,
-        _exclusion_check: &ExclusionCheck<'_>,
-        _excluded_matches: &mut AHashSet<String>,
-        match_emitter: &mut dyn MatchEmitter,
-        _: Option<&Vec<(usize, usize)>>,
+        ctx: &mut StringMatchesCtx,
     ) -> Result<(), ScannerError> {
-        match_emitter.emit(StringMatch { start: 10, end: 16 });
+        ctx.match_emitter.emit(StringMatch { start: 10, end: 16 });
         Ok(())
     }
 }


### PR DESCRIPTION
This replaces 8 of the `get_string_matches` arguments with a struct to clean up things a bit in preparation for some new `async` versions of these functions.