### PR TITLE
Add a JWT checker

### DIFF
--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -144,19 +144,11 @@ pub enum ClaimRequirement {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
 pub struct JwtClaimsCheckerConfig {
     #[serde_as(deserialize_as = "DefaultOnNull")]
     #[serde(default)]
     pub required_claims: std::collections::HashMap<String, ClaimRequirement>,
-}
-
-impl Default for JwtClaimsCheckerConfig {
-    fn default() -> Self {
-        Self {
-            required_claims: std::collections::HashMap::new(),
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, EnumIter, AsRefStr)]

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -133,6 +133,32 @@ pub struct ProximityKeywordsConfig {
     pub excluded_keywords: Vec<String>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum ClaimRequirement {
+    /// Just check that the claim exists
+    Present,
+    /// Check that the claim exists and has an exact value
+    ExactValue(String),
+    /// Check that the claim exists and matches a regex pattern
+    RegexMatch(String),
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct JwtClaimsCheckerConfig {
+    #[serde_as(deserialize_as = "DefaultOnNull")]
+    #[serde(default)]
+    pub required_claims: std::collections::HashMap<String, ClaimRequirement>,
+}
+
+impl Default for JwtClaimsCheckerConfig {
+    fn default() -> Self {
+        Self {
+            required_claims: std::collections::HashMap::new(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, EnumIter, AsRefStr)]
 #[serde(tag = "type")]
 pub enum SecondaryValidator {
@@ -159,6 +185,7 @@ pub enum SecondaryValidator {
     IbanChecker,
     IrishPpsChecksum,
     ItalianNationalIdChecksum,
+    JwtClaimsChecker { config: JwtClaimsCheckerConfig },
     JwtExpirationChecker,
     LatviaNationalIdChecksum,
     LithuanianPersonalIdentificationNumberChecksum,

--- a/sds/src/secondary_validation/jwt_claims_checker.rs
+++ b/sds/src/secondary_validation/jwt_claims_checker.rs
@@ -59,21 +59,13 @@ fn validate_required_claims(payload: &JsonValue, required_claims: &HashMap<Strin
     let payload_obj = payload.as_object().unwrap();
     
     // Check each required claim
-    for (claim_name, requirement) in required_claims {
-        match payload_obj.get(claim_name) {
-            Some(claim_value) => {
-                if !validate_claim_requirement(claim_value, requirement) {
-                    return false;
-                }
-            }
-            None => {
-                // Claim is missing
-                return false;
-            }
+    required_claims.iter().all(|(claim_name, requirement)| {
+        if let Some(claim_value) = payload_obj.get(claim_name) {
+            validate_claim_requirement(claim_value, requirement)
+        } else {
+            false
         }
-    }
-    
-    true
+    })
 }
 
 fn validate_claim_requirement(claim_value: &JsonValue, requirement: &ClaimRequirement) -> bool {

--- a/sds/src/secondary_validation/jwt_claims_checker.rs
+++ b/sds/src/secondary_validation/jwt_claims_checker.rs
@@ -54,10 +54,10 @@ fn decode_segments(encoded_token: &str) -> Option<(JsonValue, JsonValue)> {
 }
 
 fn decode_segment(segment: &str) -> Option<JsonValue> {
-    URL_SAFE_NO_PAD
+    let decoded = URL_SAFE_NO_PAD
         .decode(segment)
-        .ok()
-        .and_then(|decoded| serde_json::from_slice(&decoded).ok())
+        .ok()?;
+    serde_json::from_slice(&decoded).ok()
 }
 
 fn validate_required_claims(payload: &JsonValue, required_claims: &Vec<(String, ClaimRequirement)>, patterns: &AHashMap<String, Regex>) -> bool {

--- a/sds/src/secondary_validation/jwt_claims_checker.rs
+++ b/sds/src/secondary_validation/jwt_claims_checker.rs
@@ -221,14 +221,6 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_jwt_empty_payload() {
-        let jwt = generate_jwt_with_claims("{}");
-        let config = JwtClaimsCheckerConfig::default();
-        let checker = JwtClaimsChecker::new(config);
-        assert!(!checker.is_valid_match(&jwt));
-    }
-
-    #[test]
     fn test_invalid_jwt_malformed() {
         let config = JwtClaimsCheckerConfig::default();
         let checker = JwtClaimsChecker::new(config);

--- a/sds/src/secondary_validation/jwt_claims_checker.rs
+++ b/sds/src/secondary_validation/jwt_claims_checker.rs
@@ -22,8 +22,6 @@ impl JwtClaimsChecker {
     }
 }
 
-const SEGMENTS_COUNT: usize = 3;
-
 impl Validator for JwtClaimsChecker {
     fn is_valid_match(&self, regex_match: &str) -> bool {
         if let Some((_, payload)) = decode_segments(regex_match) {
@@ -38,14 +36,16 @@ impl Validator for JwtClaimsChecker {
 // This function is an extraction of the decoding part from jwt_expiration_checker
 // Reusing the JWT decoding logic to avoid duplication
 fn decode_segments(encoded_token: &str) -> Option<(JsonValue, JsonValue)> {
-    let raw_segments: Vec<&str> = encoded_token.split('.').collect();
-    if raw_segments.len() != SEGMENTS_COUNT {
+    let mut raw_segments: std::str::Split<&str> = encoded_token.split(".");
+
+    let header_segment = raw_segments.next()?;
+    let payload_segment = raw_segments.next()?;
+
+    if raw_segments.next().is_none() {
         // Invalid JWT header + payload + signature
         return None;
     }
 
-    let header_segment = raw_segments[0];
-    let payload_segment = raw_segments[1];
     let header_json = decode_segment(header_segment)?;
     let payload_json = decode_segment(payload_segment)?;
     Some((header_json, payload_json))

--- a/sds/src/secondary_validation/jwt_claims_checker.rs
+++ b/sds/src/secondary_validation/jwt_claims_checker.rs
@@ -79,7 +79,7 @@ fn validate_claim_requirement(claim_value: &JsonValue, requirement: &ClaimRequir
     match requirement {
         ClaimRequirement::Present => {
             // Just check that the claim exists (we already know it does if we're here)
-            true
+            claim_value != &JsonValue::Null
         }
         ClaimRequirement::ExactValue(expected) => {
             // Check for exact string match

--- a/sds/src/secondary_validation/jwt_claims_checker.rs
+++ b/sds/src/secondary_validation/jwt_claims_checker.rs
@@ -59,20 +59,18 @@ fn decode_segment(segment: &str) -> Option<JsonValue> {
 }
 
 fn validate_required_claims(payload: &JsonValue, required_claims: &HashMap<String, ClaimRequirement>, patterns: &HashMap<String, Regex>) -> bool {
-    if !payload.is_object() {
-        return false;
+    if let Some(payload_obj) = payload.as_object() {
+        // Check each required claim
+        required_claims.iter().all(|(claim_name, requirement)| {
+            if let Some(claim_value) = payload_obj.get(claim_name) {
+                validate_claim_requirement(claim_value, requirement, patterns.get(claim_name))
+            } else {
+                false
+            }
+        })
+    } else {
+        false
     }
-    
-    let payload_obj = payload.as_object().unwrap();
-    
-    // Check each required claim
-    required_claims.iter().all(|(claim_name, requirement)| {
-        if let Some(claim_value) = payload_obj.get(claim_name) {
-            validate_claim_requirement(claim_value, requirement, patterns.get(claim_name))
-        } else {
-            false
-        }
-    })
 }
 
 fn validate_claim_requirement(claim_value: &JsonValue, requirement: &ClaimRequirement, cached_pattern: Option<&Regex>) -> bool {

--- a/sds/src/secondary_validation/jwt_claims_checker.rs
+++ b/sds/src/secondary_validation/jwt_claims_checker.rs
@@ -1,0 +1,244 @@
+use crate::secondary_validation::Validator;
+use crate::scanner::regex_rule::config::{ClaimRequirement, JwtClaimsCheckerConfig};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use regex::Regex;
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+
+pub struct JwtClaimsChecker {
+    pub config: JwtClaimsCheckerConfig,
+}
+
+impl JwtClaimsChecker {
+    pub fn new(config: JwtClaimsCheckerConfig) -> Self {
+        Self { config }
+    }
+}
+
+const SEGMENTS_COUNT: usize = 3;
+
+impl Validator for JwtClaimsChecker {
+    fn is_valid_match(&self, regex_match: &str) -> bool {
+        if let Some((_, payload)) = decode_segments(regex_match) {
+            validate_required_claims(&payload, &self.config.required_claims)
+        } else {
+            // If JWT segments cannot be decoded, the JWT is not well formatted
+            false
+        }
+    }
+}
+
+// This function is an extraction of the decoding part from jwt_expiration_checker
+// Reusing the JWT decoding logic to avoid duplication
+fn decode_segments(encoded_token: &str) -> Option<(JsonValue, JsonValue)> {
+    let raw_segments: Vec<&str> = encoded_token.split('.').collect();
+    if raw_segments.len() != SEGMENTS_COUNT {
+        // Invalid JWT header + payload + signature
+        return None;
+    }
+
+    let header_segment = raw_segments[0];
+    let payload_segment = raw_segments[1];
+    let header_json = decode_segment(header_segment)?;
+    let payload_json = decode_segment(payload_segment)?;
+    Some((header_json, payload_json))
+}
+
+fn decode_segment(segment: &str) -> Option<JsonValue> {
+    URL_SAFE_NO_PAD
+        .decode(segment)
+        .ok()
+        .and_then(|decoded| serde_json::from_slice(&decoded).ok())
+}
+
+fn validate_required_claims(payload: &JsonValue, required_claims: &HashMap<String, ClaimRequirement>) -> bool {
+    if !payload.is_object() {
+        return false;
+    }
+    
+    let payload_obj = payload.as_object().unwrap();
+    
+    // Check each required claim
+    for (claim_name, requirement) in required_claims {
+        match payload_obj.get(claim_name) {
+            Some(claim_value) => {
+                if !validate_claim_requirement(claim_value, requirement) {
+                    return false;
+                }
+            }
+            None => {
+                // Claim is missing
+                return false;
+            }
+        }
+    }
+    
+    true
+}
+
+fn validate_claim_requirement(claim_value: &JsonValue, requirement: &ClaimRequirement) -> bool {
+    match requirement {
+        ClaimRequirement::Present => {
+            // Just check that the claim exists (we already know it does if we're here)
+            true
+        }
+        ClaimRequirement::ExactValue(expected) => {
+            // Check for exact string match
+            if let Some(actual) = claim_value.as_str() {
+                actual == expected
+            } else {
+                false // We only match string values
+            }
+        }
+        ClaimRequirement::RegexMatch(pattern) => {
+            // Check if the claim value matches the regex pattern
+            if let Some(actual) = claim_value.as_str() {
+                match Regex::new(pattern) {
+                    Ok(regex) => regex.is_match(actual),
+                    Err(_) => false, // Invalid regex pattern
+                }
+            } else {
+                false // Can only regex match string values
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+
+    fn generate_jwt_with_claims(claims: &str) -> String {
+        let header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"; // {"alg":"HS256","typ":"JWT"}
+        let payload_encoded = URL_SAFE_NO_PAD.encode(claims.as_bytes());
+        let signature = "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        format!("{header}.{payload_encoded}.{signature}")
+    }
+
+    #[test]
+    fn test_decode_segments() {
+        let jwt = generate_jwt_with_claims(r#"{"sub":"1234567890","name":"John Doe","iat":1516239022}"#);
+        let result = decode_segments(&jwt);
+        assert!(result.is_some());
+        
+        let (header, payload) = result.unwrap();
+        assert_eq!(header.get("alg"), Some(&JsonValue::String("HS256".to_string())));
+        assert_eq!(payload.get("sub"), Some(&JsonValue::String("1234567890".to_string())));
+    }
+
+    #[test]
+    fn test_valid_jwt_with_claims_no_requirements() {
+        let jwt = generate_jwt_with_claims(r#"{"sub":"1234567890","name":"John Doe","iat":1516239022}"#);
+        let config = JwtClaimsCheckerConfig::default();
+        let checker = JwtClaimsChecker::new(config);
+        assert!(checker.is_valid_match(&jwt));
+    }
+
+    #[test]
+    fn test_valid_jwt_with_required_claims_present() {
+        let jwt = generate_jwt_with_claims(r#"{"sub":"1234567890","name":"John Doe","iat":1516239022}"#);
+        let mut required_claims = HashMap::new();
+        required_claims.insert("sub".to_string(), ClaimRequirement::Present);
+        required_claims.insert("name".to_string(), ClaimRequirement::Present);
+        
+        let config = JwtClaimsCheckerConfig { required_claims };
+        let checker = JwtClaimsChecker::new(config);
+        assert!(checker.is_valid_match(&jwt));
+    }
+
+    #[test]
+    fn test_valid_jwt_with_exact_value_match() {
+        let jwt = generate_jwt_with_claims(r#"{"sub":"1234567890","issuer":"my-service","role":"admin"}"#);
+        let mut required_claims = HashMap::new();
+        required_claims.insert("sub".to_string(), ClaimRequirement::ExactValue("1234567890".to_string()));
+        required_claims.insert("issuer".to_string(), ClaimRequirement::ExactValue("my-service".to_string()));
+        
+        let config = JwtClaimsCheckerConfig { required_claims };
+        let checker = JwtClaimsChecker::new(config);
+        assert!(checker.is_valid_match(&jwt));
+    }
+
+    #[test]
+    fn test_valid_jwt_with_regex_match() {
+        let jwt = generate_jwt_with_claims(r#"{"sub":"user-1234567890","email":"john.doe@example.com"}"#);
+        let mut required_claims = HashMap::new();
+        required_claims.insert("sub".to_string(), ClaimRequirement::RegexMatch(r"^user-\d+$".to_string()));
+        required_claims.insert("email".to_string(), ClaimRequirement::RegexMatch(r"^[^@]+@[^@]+\.[^@]+$".to_string()));
+        
+        let config = JwtClaimsCheckerConfig { required_claims };
+        let checker = JwtClaimsChecker::new(config);
+        assert!(checker.is_valid_match(&jwt));
+    }
+
+    #[test]
+    fn test_invalid_jwt_missing_required_claims() {
+        let jwt = generate_jwt_with_claims(r#"{"sub":"1234567890","name":"John Doe"}"#);
+        let mut required_claims = HashMap::new();
+        required_claims.insert("sub".to_string(), ClaimRequirement::Present);
+        required_claims.insert("aud".to_string(), ClaimRequirement::Present); // aud is missing
+        
+        let config = JwtClaimsCheckerConfig { required_claims };
+        let checker = JwtClaimsChecker::new(config);
+        assert!(!checker.is_valid_match(&jwt));
+    }
+
+    #[test]
+    fn test_invalid_jwt_wrong_exact_value() {
+        let jwt = generate_jwt_with_claims(r#"{"sub":"1234567890","issuer":"wrong-service"}"#);
+        let mut required_claims = HashMap::new();
+        required_claims.insert("issuer".to_string(), ClaimRequirement::ExactValue("my-service".to_string()));
+        
+        let config = JwtClaimsCheckerConfig { required_claims };
+        let checker = JwtClaimsChecker::new(config);
+        assert!(!checker.is_valid_match(&jwt));
+    }
+
+    #[test]
+    fn test_invalid_jwt_regex_no_match() {
+        let jwt = generate_jwt_with_claims(r#"{"sub":"invalid-user","email":"invalid-email"}"#);
+        let mut required_claims = HashMap::new();
+        required_claims.insert("sub".to_string(), ClaimRequirement::RegexMatch(r"^user-\d+$".to_string()));
+        required_claims.insert("email".to_string(), ClaimRequirement::RegexMatch(r"^[^@]+@[^@]+\.[^@]+$".to_string()));
+        
+        let config = JwtClaimsCheckerConfig { required_claims };
+        let checker = JwtClaimsChecker::new(config);
+        assert!(!checker.is_valid_match(&jwt));
+    }
+
+    #[test]
+    fn test_mixed_claim_requirements() {
+        let jwt = generate_jwt_with_claims(r#"{"sub":"user-123","issuer":"my-service","role":"admin","email":"user@example.com"}"#);
+        let mut required_claims = HashMap::new();
+        required_claims.insert("sub".to_string(), ClaimRequirement::RegexMatch(r"^user-\d+$".to_string()));
+        required_claims.insert("issuer".to_string(), ClaimRequirement::ExactValue("my-service".to_string()));
+        required_claims.insert("role".to_string(), ClaimRequirement::Present);
+        required_claims.insert("email".to_string(), ClaimRequirement::RegexMatch(r"^[^@]+@[^@]+\.[^@]+$".to_string()));
+        
+        let config = JwtClaimsCheckerConfig { required_claims };
+        let checker = JwtClaimsChecker::new(config);
+        assert!(checker.is_valid_match(&jwt));
+    }
+
+    #[test]
+    fn test_invalid_jwt_empty_payload() {
+        let jwt = generate_jwt_with_claims("{}");
+        let config = JwtClaimsCheckerConfig::default();
+        let checker = JwtClaimsChecker::new(config);
+        assert!(!checker.is_valid_match(&jwt));
+    }
+
+    #[test]
+    fn test_invalid_jwt_malformed() {
+        let config = JwtClaimsCheckerConfig::default();
+        let checker = JwtClaimsChecker::new(config);
+        assert!(!checker.is_valid_match("invalid_jwt"));
+    }
+
+    #[test]
+    fn test_invalid_jwt_wrong_segments() {
+        let config = JwtClaimsCheckerConfig::default();
+        let checker = JwtClaimsChecker::new(config);
+        assert!(!checker.is_valid_match("header.payload")); // Missing signature
+    }
+}

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -21,6 +21,7 @@ mod iban_checker;
 mod irish_pps_checksum;
 mod iso_7064_checksum;
 mod italian_national_id_checksum;
+mod jwt_claims_checker;
 mod jwt_expiration_checker;
 mod latvia_national_id_checksum;
 mod lithuanian_personal_identification_number_checksum;
@@ -69,6 +70,7 @@ pub use crate::secondary_validation::iso_7064_checksum::{
     Mod37_36checksum, Mod661_26checksum, Mod97_10checksum,
 };
 pub use crate::secondary_validation::italian_national_id_checksum::ItalianNationalIdChecksum;
+pub use crate::secondary_validation::jwt_claims_checker::JwtClaimsChecker;
 pub use crate::secondary_validation::jwt_expiration_checker::JwtExpirationChecker;
 pub use crate::secondary_validation::latvia_national_id_checksum::LatviaNationalIdChecksum;
 use crate::secondary_validation::lithuanian_personal_identification_number_checksum::LithuanianPersonalIdentificationNumberChecksum;
@@ -172,6 +174,9 @@ impl Validator for SecondaryValidator {
             SecondaryValidator::IrishPpsChecksum => IrishPpsChecksum.is_valid_match(regex_match),
             SecondaryValidator::ItalianNationalIdChecksum => {
                 ItalianNationalIdChecksum.is_valid_match(regex_match)
+            }
+            SecondaryValidator::JwtClaimsChecker { config } => {
+                JwtClaimsChecker::new(config.clone()).is_valid_match(regex_match)
             }
             SecondaryValidator::JwtExpirationChecker => {
                 JwtExpirationChecker.is_valid_match(regex_match)

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -157,7 +157,7 @@ impl SecondaryValidator {
             SecondaryValidator::IrishPpsChecksum => Arc::new(IrishPpsChecksum),
             SecondaryValidator::ItalianNationalIdChecksum => Arc::new(ItalianNationalIdChecksum),
             SecondaryValidator::JwtClaimsChecker { config } => {
-                JwtClaimsChecker::new(config.clone()).is_valid_match(regex_match)
+                Arc::new(JwtClaimsChecker::new(config.clone()))
             }
             SecondaryValidator::JwtExpirationChecker => Arc::new(JwtExpirationChecker),
             SecondaryValidator::LatviaNationalIdChecksum => Arc::new(LatviaNationalIdChecksum),


### PR DESCRIPTION
The checker can be configured to check whether claims match specific values or regexes.
That's because we need to check two different JWTs and this avoid having to introduce too many different checkers