### PR TITLE
Use hybrid data structure for `InternalRuleMatchSet`

### DIFF
--- a/sds/src/encoding.rs
+++ b/sds/src/encoding.rs
@@ -1,5 +1,5 @@
 /// Specifies how indices are calculated for rule matches
-pub trait Encoding: Sized {
+pub trait Encoding: Sized + 'static {
     type Index: Sized + 'static;
     type IndexShift: Sized;
 

--- a/sds/src/scanner/internal_rule_match_set.rs
+++ b/sds/src/scanner/internal_rule_match_set.rs
@@ -3,31 +3,52 @@ use crate::{Encoding, Path};
 use ahash::AHashMap;
 
 pub struct InternalRuleMatchSet<E: Encoding> {
+    sync_matches: Vec<(Path<'static>, Vec<InternalRuleMatch<E>>)>,
     // This is a maps of vecs, where each inner vec is a set of matches for a single path.
-    map: AHashMap<Path<'static>, Vec<InternalRuleMatch<E>>>,
+    async_matches: AHashMap<Path<'static>, Vec<InternalRuleMatch<E>>>,
 }
 
 impl<E: Encoding> InternalRuleMatchSet<E> {
     pub fn new() -> Self {
         Self {
-            map: AHashMap::new(),
+            sync_matches: Vec::new(),
+            async_matches: AHashMap::new(),
         }
     }
 
-    pub fn push_matches(
+    pub fn push_sync_matches(&mut self, path: &Path, matches: Vec<InternalRuleMatch<E>>) {
+        if matches.is_empty() {
+            return;
+        }
+        self.sync_matches.push((path.into_static(), matches));
+    }
+
+    pub fn push_async_matches(
         &mut self,
         path: &Path,
-        list: impl IntoIterator<Item = InternalRuleMatch<E>>,
+        matches: impl IntoIterator<Item = InternalRuleMatch<E>>,
     ) {
-        let mut list = list.into_iter().peekable();
-        if list.peek().is_none() {
+        let mut matches = matches.into_iter().peekable();
+        if matches.peek().is_none() {
             // An empty list should not push a new entry in the map
             return;
         }
-        self.map.entry(path.into_static()).or_default().extend(list);
+        self.async_matches
+            .entry(path.into_static())
+            .or_default()
+            .extend(matches);
     }
 
-    pub fn into_iter(self) -> impl Iterator<Item = (Path<'static>, Vec<InternalRuleMatch<E>>)> {
-        self.map.into_iter()
+    pub fn into_iter(mut self) -> impl Iterator<Item = (Path<'static>, Vec<InternalRuleMatch<E>>)> {
+        if !self.async_matches.is_empty() {
+            // merge async matches into sync matches if there are matches for the same path
+            for (path, matches) in &mut self.sync_matches {
+                if let Some(async_matches) = self.async_matches.remove(path) {
+                    matches.extend(async_matches)
+                }
+            }
+        }
+
+        self.sync_matches.into_iter().chain(self.async_matches)
     }
 }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -500,7 +500,7 @@ impl Scanner {
         // results just need to be collected
         for job in async_jobs {
             let rule_info = job.fut.await.unwrap()?;
-            rule_matches.push_matches(
+            rule_matches.push_async_matches(
                 &job.path,
                 rule_info
                     .rule_matches
@@ -1025,7 +1025,8 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
         // will be a match
         let needs_to_access_content = !path_rules_matches.is_empty() || !self.async_jobs.is_empty();
 
-        self.rule_matches.push_matches(path, path_rules_matches);
+        self.rule_matches
+            .push_sync_matches(path, path_rules_matches);
 
         Ok(needs_to_access_content)
     }


### PR DESCRIPTION
This should improve the performance a bit, especially if there are no async matches. This also guarantees the ordering of sync matches. Async matches will always be at the end.