### PR TITLE
Bump async timeout to 1min

### DIFF
--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -811,7 +811,7 @@ impl ScannerBuilder<'_> {
             rules,
             labels: Labels::empty(),
             scanner_features: ScannerFeatures::default(),
-            async_scan_timeout: Duration::from_secs(1),
+            async_scan_timeout: Duration::from_secs(60),
         }
     }
 


### PR DESCRIPTION
Otherwise event ends up in [DLT](https://ddstaging.datadoghq.com/logs?query=status%3Aerror%20%22Failed%20to%20scan%20message%22%20service%3Alogs-processing&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZhkzW9PyMWZ5gAAABhBWmhrelhxS0FBREkyUGszTG1UMXl3QWcAAAAkZjE5ODY0Y2UtNTJkZi00ZjI0LWFmMTEtMDA5NTU5NTRiNWNjAAqwLg&messageDisplay=inline&refresh_mode=sliding&storage=flex_tier&stream_sort=desc&viz=stream&from_ts=1753952083882&to_ts=1754038483882&live=true) after that 1sec.