### PR TITLE
Remove should_keywords_match_event_paths bool

### DIFF
--- a/sds-go/go/dd_sds.h
+++ b/sds-go/go/dd_sds.h
@@ -5,7 +5,7 @@
 
 long create_regex_rule(const char* json_config);
 
-long create_scanner(long rule_list, const char** error, bool should_keywords_match_event_paths);
+long create_scanner(long rule_list, const char** error);
 void delete_scanner(long scanner_id);
 
 // event is a non-null terminated TODO

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -67,7 +67,7 @@ func CreateScanner(ruleConfigs []RuleConfig) (*Scanner, error) {
 	}
 
 	var errorString *C.char
-	id := C.create_scanner(C.long(ruleList.nativePtr), &errorString, C.bool(false) /* should_keywords_match_event_paths */)
+	id := C.create_scanner(C.long(ruleList.nativePtr), &errorString)
 
 	if id < 0 {
 		switch id {

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -687,10 +687,10 @@ func runTestMap(t *testing.T, scanner *Scanner, testData map[string]mapTestResul
 		}
 
 		sort.Slice(result.Matches, func(i, j int) bool {
-			return sortRulesMatch(result.Matches[i], result.Matches[i])
+			return sortRulesMatch(result.Matches[i], result.Matches[j])
 		})
 		sort.Slice(testResult.rules, func(i, j int) bool {
-			return sortRulesMatch(testResult.rules[i], testResult.rules[i])
+			return sortRulesMatch(testResult.rules[i], testResult.rules[j])
 		})
 
 		for i, expected := range testResult.rules {


### PR DESCRIPTION
## Description

There's more cleanup to do as I didn't see the boolean was still there in the go bindings.