### PR TITLE
[SDS-1397] Add encoded_labels argument to create_scanner

### DIFF
--- a/sds-go/go/dd_sds.h
+++ b/sds-go/go/dd_sds.h
@@ -5,7 +5,7 @@
 
 long create_regex_rule(const char* json_config);
 
-long create_scanner(long rule_list, const char** error);
+long create_scanner(long rule_list, const char* encoded_labels, const char** error);
 void delete_scanner(long scanner_id);
 
 // event is a non-null terminated TODO

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -3,6 +3,7 @@ package dd_sds
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -66,8 +67,16 @@ func CreateScanner(ruleConfigs []RuleConfig) (*Scanner, error) {
 		rule.Delete()
 	}
 
+	labels := [][2]string{}
+	labelsMarshalled, err := json.Marshal(labels)
+	if err != nil {
+		return nil, err
+	}
+	encodedLabelsJson := C.CString(string(labelsMarshalled))
+	defer C.free(unsafe.Pointer(encodedLabelsJson))
+
 	var errorString *C.char
-	id := C.create_scanner(C.long(ruleList.nativePtr), &errorString)
+	id := C.create_scanner(C.long(ruleList.nativePtr), encodedLabelsJson, &errorString)
 
 	if id < 0 {
 		switch id {

--- a/sds-go/rust/src/native/create_scanner.rs
+++ b/sds-go/rust/src/native/create_scanner.rs
@@ -2,18 +2,24 @@ use std::ffi::c_char;
 use std::mem::ManuallyDrop;
 use std::sync::Arc;
 
-use crate::{handle_panic_ptr_return, RuleList};
+use crate::{handle_panic_ptr_return, read_json, RuleList};
 use dd_sds::Scanner;
 
 #[no_mangle]
-pub extern "C" fn create_scanner(rules: i64, error_out: *mut *const c_char) -> i64 {
+pub extern "C" fn create_scanner(
+    rules: i64,
+    encoded_labels: *const c_char,
+    error_out: *mut *const c_char,
+) -> i64 {
     handle_panic_ptr_return(Some(error_out), || {
         let rules_mutex =
             ManuallyDrop::new(unsafe { RuleList::from_raw(rules as usize as *const _) });
         let rules = rules_mutex.lock().unwrap();
 
+        let labels = unsafe { read_json(encoded_labels).unwrap() };
+
         // create the scanner
-        let scanner = match Scanner::builder(&rules).build() {
+        let scanner = match Scanner::builder(&rules).labels(labels).build() {
             Ok(s) => s,
             Err(err) => return err.into(),
         };

--- a/sds-go/rust/src/native/create_scanner.rs
+++ b/sds-go/rust/src/native/create_scanner.rs
@@ -5,6 +5,10 @@ use std::sync::Arc;
 use crate::{handle_panic_ptr_return, read_json, RuleList};
 use dd_sds::Scanner;
 
+/// # Safety
+///
+/// This function makes use of `read_json` which is unsafe as it dereferences a pointer to a c_char.
+/// The caller must ensure that the pointer is valid and points to a valid JSON string.
 #[no_mangle]
 pub unsafe extern "C" fn create_scanner(
     rules: i64,

--- a/sds-go/rust/src/native/create_scanner.rs
+++ b/sds-go/rust/src/native/create_scanner.rs
@@ -6,7 +6,7 @@ use crate::{handle_panic_ptr_return, read_json, RuleList};
 use dd_sds::Scanner;
 
 #[no_mangle]
-pub extern "C" fn create_scanner(
+pub unsafe extern "C" fn create_scanner(
     rules: i64,
     encoded_labels: *const c_char,
     error_out: *mut *const c_char,


### PR DESCRIPTION
## Description

Currently, go scanners cannot provide labels used for observability. 

It results in this kind of graphs: 
https://app.datadoghq.com/dashboard/sgc-h3v-m7x/sds-cloud-for-telemetries-overview?fromUser=true&refresh_mode=paused&from_ts=1754320382865&to_ts=1754322182865&live=false&tile_focus=7644895609508851

Where org id is `N/A`.

By adding the labels argument, we'll be able to have the org id set 👍 