### PR TITLE
Lock rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.89.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.89.0"
-components = ["rustfmt"]
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.89.0"
+components = ["rustfmt"]

--- a/sds/src/match_action.rs
+++ b/sds/src/match_action.rs
@@ -96,7 +96,7 @@ impl MatchAction {
         }
     }
 
-    pub fn get_replacement(&self, matched_content: &str) -> Option<Replacement> {
+    pub fn get_replacement(&self, matched_content: &str) -> Option<Replacement<'_>> {
         match self {
             MatchAction::None => None,
             MatchAction::Redact { replacement } => Some(Replacement {

--- a/sds/src/parser/regex_parser.rs
+++ b/sds/src/parser/regex_parser.rs
@@ -209,7 +209,7 @@ fn unicode_property_class(input: Input) -> ParseResult<UnicodePropertyClass> {
     ))(input)
 }
 
-fn unicode_property_name(input: Input) -> ParseResult<&str> {
+fn unicode_property_name(input: Input<'_>) -> ParseResult<'_, &str> {
     let (input, name) = recognize(many0(one_of(ASCII_LETTERS_WITH_UNDERSCORE)))(input)?;
     if UNICODE_PROPERTY_NAMES.contains(&name.value) {
         Ok((input, name.value))
@@ -530,7 +530,7 @@ fn integer(input: Input) -> ParseResult<u32> {
     Ok((input, value))
 }
 
-fn capture_group_name(input: Input) -> ParseResult<&str> {
+fn capture_group_name(input: Input<'_>) -> ParseResult<'_, &str> {
     let (input, value) = recognize(tuple((
         one_of(ASCII_LETTERS_WITH_UNDERSCORE),
         many0(one_of(ASCII_ALPHANUMERIC_WITH_UNDERSCORE)),

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -392,7 +392,7 @@ pub struct Scanner {
 }
 
 impl Scanner {
-    pub fn builder(rules: &[RootRuleConfig<Arc<dyn RuleConfig>>]) -> ScannerBuilder {
+    pub fn builder(rules: &[RootRuleConfig<Arc<dyn RuleConfig>>]) -> ScannerBuilder<'_> {
         ScannerBuilder::new(rules)
     }
 
@@ -808,7 +808,7 @@ pub struct ScannerBuilder<'a> {
 }
 
 impl ScannerBuilder<'_> {
-    pub fn new(rules: &[RootRuleConfig<Arc<dyn RuleConfig>>]) -> ScannerBuilder {
+    pub fn new(rules: &[RootRuleConfig<Arc<dyn RuleConfig>>]) -> ScannerBuilder<'_> {
         ScannerBuilder {
             rules,
             labels: Labels::empty(),


### PR DESCRIPTION
This locks the `rustc` version to 1.89. We will still keep updating the version, but this allows us to choose when it's updated and fix clippy / formatting errors at the same time, rather than whenever the releases comes out, which may make arbitrary PRs fail in CI.