### PR TITLE
Improve deserialization of JwtClaimsValidator

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -17,7 +17,7 @@ mod path;
 mod proximity_keywords;
 mod rule_match;
 mod scanner;
-mod scoped_ruleset;
+pub(crate) mod scoped_ruleset;
 mod secondary_validation;
 mod simple_event;
 mod stats;
@@ -43,18 +43,18 @@ pub use scanner::shared_pool::{SharedPool, SharedPoolGuard};
 
 pub use scanner::error::MatchValidationError;
 pub use scanner::{
-    config::RuleConfig,
-    error::{CreateScannerError, ScannerError},
-    regex_rule::config::{ProximityKeywordsConfig, RegexRuleConfig, SecondaryValidator},
-    regex_rule::RegexCaches,
-    scope::Scope,
     CompiledRule, MatchEmitter, RootCompiledRule, RootRuleConfig, RuleResult, RuleStatus,
     ScanOptionBuilder, Scanner, ScannerBuilder, SharedData, StringMatch, StringMatchesCtx,
+    config::RuleConfig,
+    error::{CreateScannerError, ScannerError},
+    regex_rule::RegexCaches,
+    regex_rule::config::{ProximityKeywordsConfig, RegexRuleConfig, SecondaryValidator},
+    scope::Scope,
 };
 pub use scoped_ruleset::ExclusionCheck;
 pub use tokio::TOKIO_RUNTIME;
 pub use validation::{
-    get_regex_complexity_estimate_very_slow, validate_regex, RegexValidationError,
+    RegexValidationError, get_regex_complexity_estimate_very_slow, validate_regex,
 };
 
 #[cfg(any(feature = "testing", feature = "bench"))]

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -304,34 +304,34 @@ mod test {
     }
 
     // TODO: Why does this need to be in order? The config should either be a Vec, or drop the order requirement
-    // #[test]
-    // fn test_jwt_claims_checker_config_serialization_order() {
-    //     use crate::secondary_validation::jwt_claims_checker::ClaimRequirement;
-    //     use std::collections::HashMap;
-    //
-    //     // Create a config with claims in non-alphabetical order
-    //     let mut required_claims = HashMap::new();
-    //     required_claims.insert("zzz".to_string(), ClaimRequirement::Present);
-    //     required_claims.insert(
-    //         "aaa".to_string(),
-    //         ClaimRequirement::ExactValue("test".to_string()),
-    //     );
-    //     required_claims.insert(
-    //         "mmm".to_string(),
-    //         ClaimRequirement::RegexMatch(r"^test.*".to_string()),
-    //     );
-    //
-    //     let config = JwtClaimsValidatorConfig { required_claims };
-    //
-    //     // Serialize multiple times to ensure stable order
-    //     let serialized1 = serde_json::to_string(&config).unwrap();
-    //     let serialized2 = serde_json::to_string(&config).unwrap();
-    //
-    //     // Both serializations should be identical
-    //     assert_eq!(serialized1, serialized2, "Serialization should be stable");
-    //
-    //     // Keys should be in alphabetical order
-    //     assert!(serialized1.find("aaa").unwrap() < serialized1.find("mmm").unwrap());
-    //     assert!(serialized1.find("mmm").unwrap() < serialized1.find("zzz").unwrap());
-    // }
+    #[test]
+    fn test_jwt_claims_validator_config_serialization_order() {
+        use crate::secondary_validation::jwt_claims_validator::ClaimRequirement;
+        use std::collections::BTreeMap;
+    
+        // Create a config with claims in non-alphabetical order
+        let mut required_claims = BTreeMap::new();
+        required_claims.insert("zzz".to_string(), ClaimRequirement::Present);
+        required_claims.insert(
+            "aaa".to_string(),
+            ClaimRequirement::ExactValue("test".to_string()),
+        );
+        required_claims.insert(
+            "mmm".to_string(),
+            ClaimRequirement::RegexMatch(r"^test.*".to_string()),
+        );
+    
+        let config = JwtClaimsValidatorConfig { required_claims };
+    
+        // Serialize multiple times to ensure stable order
+        let serialized1 = serde_json::to_string(&config).unwrap();
+        let serialized2 = serde_json::to_string(&config).unwrap();
+    
+        // Both serializations should be identical
+        assert_eq!(serialized1, serialized2, "Serialization should be stable");
+    
+        // Keys should be in alphabetical order
+        assert!(serialized1.find("aaa").unwrap() < serialized1.find("mmm").unwrap());
+        assert!(serialized1.find("mmm").unwrap() < serialized1.find("zzz").unwrap());
+    }
 }

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -129,6 +129,7 @@ pub struct ProximityKeywordsConfig {
     pub excluded_keywords: Vec<String>,
 }
 
+#[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum ClaimRequirement {
     /// Just check that the claim exists

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -3,7 +3,7 @@ use crate::scanner::config::RuleConfig;
 use crate::scanner::metrics::RuleMetrics;
 use crate::scanner::regex_rule::compiled::RegexCompiledRule;
 use crate::scanner::regex_rule::regex_store::get_memoized_regex;
-use crate::secondary_validation::jwt_claims_checker::JwtClaimsCheckerConfig;
+use crate::secondary_validation::jwt_claims_validator::JwtClaimsValidatorConfig;
 use crate::validation::validate_and_create_regex;
 use crate::{CompiledRule, CreateScannerError, Labels};
 use serde::{Deserialize, Serialize};
@@ -156,7 +156,7 @@ pub enum SecondaryValidator {
     IbanChecker,
     IrishPpsChecksum,
     ItalianNationalIdChecksum,
-    JwtClaimsChecker { config: JwtClaimsCheckerConfig },
+    JwtClaimsValidator { config: JwtClaimsValidatorConfig },
     JwtExpirationChecker,
     LatviaNationalIdChecksum,
     LithuanianPersonalIdentificationNumberChecksum,
@@ -321,7 +321,7 @@ mod test {
     //         ClaimRequirement::RegexMatch(r"^test.*".to_string()),
     //     );
     //
-    //     let config = JwtClaimsCheckerConfig { required_claims };
+    //     let config = JwtClaimsValidatorConfig { required_claims };
     //
     //     // Serialize multiple times to ensure stable order
     //     let serialized1 = serde_json::to_string(&config).unwrap();

--- a/sds/src/secondary_validation/jwt_claims_validator.rs
+++ b/sds/src/secondary_validation/jwt_claims_validator.rs
@@ -19,7 +19,7 @@ pub enum ClaimRequirement {
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
 pub struct JwtClaimsValidatorConfig {
     #[serde(default)]
-    pub required_claims: std::collections::HashMap<String, ClaimRequirement>,
+    pub required_claims: std::collections::BTreeMap<String, ClaimRequirement>,
 }
 
 pub struct JwtClaimsValidator {
@@ -128,7 +128,7 @@ mod tests {
     use super::*;
     use crate::secondary_validation::jwt_claims_validator::ClaimRequirement::{Present, RegexMatch};
     use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     fn generate_jwt_with_claims(claims: &str) -> String {
         let header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"; // {"alg":"HS256","typ":"JWT"}
@@ -168,7 +168,7 @@ mod tests {
     fn test_valid_jwt_with_required_claims_present() {
         let jwt =
             generate_jwt_with_claims(r#"{"sub":"1234567890","name":"John Doe","iat":1516239022}"#);
-        let mut required_claims = HashMap::new();
+        let mut required_claims = BTreeMap::new();
         required_claims.insert("sub".to_string(), ClaimRequirement::Present);
         required_claims.insert("name".to_string(), ClaimRequirement::Present);
 
@@ -182,7 +182,7 @@ mod tests {
         let jwt = generate_jwt_with_claims(
             r#"{"sub":"1234567890","issuer":"my-service","role":"admin"}"#,
         );
-        let mut required_claims = HashMap::new();
+        let mut required_claims = BTreeMap::new();
         required_claims.insert(
             "sub".to_string(),
             ClaimRequirement::ExactValue("1234567890".to_string()),
@@ -201,7 +201,7 @@ mod tests {
     fn test_valid_jwt_with_regex_match() {
         let jwt =
             generate_jwt_with_claims(r#"{"sub":"user-1234567890","email":"john.doe@example.com"}"#);
-        let mut required_claims = HashMap::new();
+        let mut required_claims = BTreeMap::new();
         required_claims.insert(
             "sub".to_string(),
             ClaimRequirement::RegexMatch(r"^user-\d+$".to_string()),
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn test_invalid_jwt_missing_required_claims() {
         let jwt = generate_jwt_with_claims(r#"{"sub":"1234567890","name":"John Doe"}"#);
-        let mut required_claims = HashMap::new();
+        let mut required_claims = BTreeMap::new();
         required_claims.insert("sub".to_string(), ClaimRequirement::Present);
         required_claims.insert("aud".to_string(), ClaimRequirement::Present); // aud is missing
 
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn test_invalid_jwt_wrong_exact_value() {
         let jwt = generate_jwt_with_claims(r#"{"sub":"1234567890","issuer":"wrong-service"}"#);
-        let mut required_claims = HashMap::new();
+        let mut required_claims = BTreeMap::new();
         required_claims.insert(
             "issuer".to_string(),
             ClaimRequirement::ExactValue("my-service".to_string()),
@@ -245,7 +245,7 @@ mod tests {
     #[test]
     fn test_invalid_jwt_regex_no_match() {
         let jwt = generate_jwt_with_claims(r#"{"sub":"invalid-user","email":"invalid-email"}"#);
-        let mut required_claims = HashMap::new();
+        let mut required_claims = BTreeMap::new();
         required_claims.insert(
             "sub".to_string(),
             ClaimRequirement::RegexMatch(r"^user-\d+$".to_string()),
@@ -265,7 +265,7 @@ mod tests {
         let jwt = generate_jwt_with_claims(
             r#"{"sub":"user-123","issuer":"my-service","role":"admin","email":"user@example.com"}"#,
         );
-        let mut required_claims = HashMap::new();
+        let mut required_claims = BTreeMap::new();
         required_claims.insert(
             "sub".to_string(),
             ClaimRequirement::RegexMatch(r"^user-\d+$".to_string()),

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -21,7 +21,7 @@ mod iban_checker;
 mod irish_pps_checksum;
 mod iso_7064_checksum;
 mod italian_national_id_checksum;
-pub mod jwt_claims_checker;
+pub mod jwt_claims_validator;
 mod jwt_expiration_checker;
 mod latvia_national_id_checksum;
 mod lithuanian_personal_identification_number_checksum;
@@ -70,7 +70,7 @@ pub use crate::secondary_validation::iso_7064_checksum::{
     Mod97_10checksum, Mod661_26checksum, Mod1271_36Checksum,
 };
 pub use crate::secondary_validation::italian_national_id_checksum::ItalianNationalIdChecksum;
-pub use crate::secondary_validation::jwt_claims_checker::JwtClaimsChecker;
+pub use crate::secondary_validation::jwt_claims_validator::JwtClaimsValidator;
 pub use crate::secondary_validation::jwt_expiration_checker::JwtExpirationChecker;
 pub use crate::secondary_validation::latvia_national_id_checksum::LatviaNationalIdChecksum;
 use crate::secondary_validation::lithuanian_personal_identification_number_checksum::LithuanianPersonalIdentificationNumberChecksum;
@@ -156,8 +156,8 @@ impl SecondaryValidator {
             SecondaryValidator::IbanChecker => Arc::new(IbanChecker),
             SecondaryValidator::IrishPpsChecksum => Arc::new(IrishPpsChecksum),
             SecondaryValidator::ItalianNationalIdChecksum => Arc::new(ItalianNationalIdChecksum),
-            SecondaryValidator::JwtClaimsChecker { config } => {
-                Arc::new(JwtClaimsChecker::new(config.clone()))
+            SecondaryValidator::JwtClaimsValidator { config } => {
+                Arc::new(JwtClaimsValidator::new(config.clone()))
             }
             SecondaryValidator::JwtExpirationChecker => Arc::new(JwtExpirationChecker),
             SecondaryValidator::LatviaNationalIdChecksum => Arc::new(LatviaNationalIdChecksum),

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -21,7 +21,7 @@ mod iban_checker;
 mod irish_pps_checksum;
 mod iso_7064_checksum;
 mod italian_national_id_checksum;
-mod jwt_claims_checker;
+pub mod jwt_claims_checker;
 mod jwt_expiration_checker;
 mod latvia_national_id_checksum;
 mod lithuanian_personal_identification_number_checksum;
@@ -66,8 +66,8 @@ pub use crate::secondary_validation::hungarian_tin_checksum::HungarianTinChecksu
 pub use crate::secondary_validation::iban_checker::IbanChecker;
 pub use crate::secondary_validation::irish_pps_checksum::IrishPpsChecksum;
 pub use crate::secondary_validation::iso_7064_checksum::{
-    Mod11_10checksum, Mod11_2checksum, Mod1271_36Checksum, Mod27_26checksum, Mod37_2checksum,
-    Mod37_36checksum, Mod661_26checksum, Mod97_10checksum,
+    Mod11_2checksum, Mod11_10checksum, Mod27_26checksum, Mod37_2checksum, Mod37_36checksum,
+    Mod97_10checksum, Mod661_26checksum, Mod1271_36Checksum,
 };
 pub use crate::secondary_validation::italian_national_id_checksum::ItalianNationalIdChecksum;
 pub use crate::secondary_validation::jwt_claims_checker::JwtClaimsChecker;


### PR DESCRIPTION
Address deserialization issues in the format and rename `JwtClaimsChecker` into `JwtClaimsValidator`