### PR TITLE
Update JWT Claim Checker to evaluate on the JWT header

### DIFF
--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -303,7 +303,7 @@ mod test {
         );
     }
 
-    // TODO: Why does this need to be in order? The config should either be a Vec, or drop the order requirement
+    // The order has to be stable to pass linter checks. Otherwise, each instantiation will change the file
     #[test]
     fn test_jwt_claims_validator_config_serialization_order() {
         use crate::secondary_validation::jwt_claims_validator::ClaimRequirement;
@@ -321,7 +321,10 @@ mod test {
             ClaimRequirement::RegexMatch(r"^test.*".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { required_claims };
+        let config = JwtClaimsValidatorConfig { 
+            required_claims, 
+            required_headers: std::collections::BTreeMap::new() 
+        };
 
         // Serialize multiple times to ensure stable order
         let serialized1 = serde_json::to_string(&config).unwrap();

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -321,9 +321,9 @@ mod test {
             ClaimRequirement::RegexMatch(r"^test.*".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
-            required_claims, 
-            required_headers: std::collections::BTreeMap::new() 
+        let config = JwtClaimsValidatorConfig {
+            required_claims,
+            required_headers: std::collections::BTreeMap::new(),
         };
 
         // Serialize multiple times to ensure stable order

--- a/sds/src/secondary_validation/jwt_claims_validator.rs
+++ b/sds/src/secondary_validation/jwt_claims_validator.rs
@@ -98,7 +98,6 @@ fn validate_required_claims(
     payload_required_claims: &[(String, ClaimRequirement)],
     patterns: &AHashMap<String, Regex>,
 ) -> bool {
-    let mut matched_anything = false;
     let mut checks_passed = true;
     if let Some(header_obj) = header.as_object() {
         checks_passed &= header_required_claims
@@ -112,9 +111,8 @@ fn validate_required_claims(
                     false
                 }
             });
-        matched_anything = true;
-    } else if header_required_claims.len() > 0 {
-        false;
+    } else if !header_required_claims.is_empty() {
+        return false;
     }
     if let Some(payload_obj) = payload.as_object() {
         checks_passed &= payload_required_claims
@@ -126,11 +124,10 @@ fn validate_required_claims(
                     false
                 }
             });
-        matched_anything = true;
-    } else if payload_required_claims.len() > 0 {
-        false;
+    } else if !payload_required_claims.is_empty() {
+        return false;
     }
-    matched_anything && checks_passed
+    checks_passed
 }
 
 fn validate_claim_requirement(

--- a/sds/src/secondary_validation/jwt_claims_validator.rs
+++ b/sds/src/secondary_validation/jwt_claims_validator.rs
@@ -41,7 +41,7 @@ impl JwtClaimsValidator {
                 payload_patterns.insert(claim_name.clone(), Regex::new(pattern).unwrap());
             }
         }
-        
+
         for (claim_name, requirement) in &config.required_headers {
             if let ClaimRequirement::RegexMatch(pattern) = requirement {
                 header_patterns.insert(claim_name.clone(), Regex::new(pattern).unwrap());
@@ -104,15 +104,13 @@ fn validate_required_claims(
     if required_claims.is_empty() {
         true
     } else if let Some(payload_obj) = payload.as_object() {
-        required_claims
-            .iter()
-            .all(|(claim_name, requirement)| {
-                if let Some(claim_value) = payload_obj.get(claim_name) {
-                    validate_claim_requirement(claim_value, requirement, patterns.get(claim_name))
-                } else {
-                    false
-                }
-            })
+        required_claims.iter().all(|(claim_name, requirement)| {
+            if let Some(claim_value) = payload_obj.get(claim_name) {
+                validate_claim_requirement(claim_value, requirement, patterns.get(claim_name))
+            } else {
+                false
+            }
+        })
     } else {
         false
     }
@@ -205,9 +203,9 @@ mod tests {
         required_claims.insert("sub".to_string(), ClaimRequirement::Present);
         required_claims.insert("name".to_string(), ClaimRequirement::Present);
 
-        let config = JwtClaimsValidatorConfig { 
-            required_claims, 
-            required_headers: BTreeMap::new() 
+        let config = JwtClaimsValidatorConfig {
+            required_claims,
+            required_headers: BTreeMap::new(),
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(checker.is_valid_match(&jwt));
@@ -228,9 +226,9 @@ mod tests {
             ClaimRequirement::ExactValue("my-service".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
-            required_claims, 
-            required_headers: BTreeMap::new() 
+        let config = JwtClaimsValidatorConfig {
+            required_claims,
+            required_headers: BTreeMap::new(),
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(checker.is_valid_match(&jwt));
@@ -250,9 +248,9 @@ mod tests {
             ClaimRequirement::RegexMatch(r"^[^@]+@[^@]+\.[^@]+$".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
-            required_claims, 
-            required_headers: BTreeMap::new() 
+        let config = JwtClaimsValidatorConfig {
+            required_claims,
+            required_headers: BTreeMap::new(),
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(checker.is_valid_match(&jwt));
@@ -265,9 +263,9 @@ mod tests {
         required_claims.insert("sub".to_string(), ClaimRequirement::Present);
         required_claims.insert("aud".to_string(), ClaimRequirement::Present); // aud is missing
 
-        let config = JwtClaimsValidatorConfig { 
-            required_claims, 
-            required_headers: BTreeMap::new() 
+        let config = JwtClaimsValidatorConfig {
+            required_claims,
+            required_headers: BTreeMap::new(),
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(!checker.is_valid_match(&jwt));
@@ -282,9 +280,9 @@ mod tests {
             ClaimRequirement::ExactValue("my-service".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
-            required_claims, 
-            required_headers: BTreeMap::new() 
+        let config = JwtClaimsValidatorConfig {
+            required_claims,
+            required_headers: BTreeMap::new(),
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(!checker.is_valid_match(&jwt));
@@ -303,9 +301,9 @@ mod tests {
             ClaimRequirement::RegexMatch(r"^[^@]+@[^@]+\.[^@]+$".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
-            required_claims, 
-            required_headers: BTreeMap::new() 
+        let config = JwtClaimsValidatorConfig {
+            required_claims,
+            required_headers: BTreeMap::new(),
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(!checker.is_valid_match(&jwt));
@@ -331,9 +329,9 @@ mod tests {
             ClaimRequirement::RegexMatch(r"^[^@]+@[^@]+\.[^@]+$".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
-            required_claims, 
-            required_headers: BTreeMap::new() 
+        let config = JwtClaimsValidatorConfig {
+            required_claims,
+            required_headers: BTreeMap::new(),
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(checker.is_valid_match(&jwt));
@@ -406,9 +404,9 @@ mod tests {
         let mut required_headers = BTreeMap::new();
         required_headers.insert("kid".to_string(), ClaimRequirement::Present);
 
-        let config = JwtClaimsValidatorConfig { 
+        let config = JwtClaimsValidatorConfig {
             required_claims: BTreeMap::new(),
-            required_headers 
+            required_headers,
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(checker.is_valid_match(&jwt));
@@ -432,9 +430,9 @@ mod tests {
             ClaimRequirement::ExactValue("production".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
+        let config = JwtClaimsValidatorConfig {
             required_claims: BTreeMap::new(),
-            required_headers 
+            required_headers,
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(checker.is_valid_match(&jwt));
@@ -468,9 +466,9 @@ mod tests {
             ClaimRequirement::ExactValue("1.0".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
-            required_claims, 
-            required_headers 
+        let config = JwtClaimsValidatorConfig {
+            required_claims,
+            required_headers,
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(checker.is_valid_match(&jwt));
@@ -487,9 +485,9 @@ mod tests {
         let mut required_headers = BTreeMap::new();
         required_headers.insert("kid".to_string(), ClaimRequirement::Present);
 
-        let config = JwtClaimsValidatorConfig { 
+        let config = JwtClaimsValidatorConfig {
             required_claims: BTreeMap::new(),
-            required_headers 
+            required_headers,
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(!checker.is_valid_match(&jwt));
@@ -509,9 +507,9 @@ mod tests {
             ClaimRequirement::ExactValue("key-123".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
+        let config = JwtClaimsValidatorConfig {
             required_claims: BTreeMap::new(),
-            required_headers 
+            required_headers,
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(!checker.is_valid_match(&jwt));
@@ -528,9 +526,9 @@ mod tests {
         let mut required_headers = BTreeMap::new();
         required_headers.insert("kid".to_string(), ClaimRequirement::Present);
 
-        let config = JwtClaimsValidatorConfig { 
+        let config = JwtClaimsValidatorConfig {
             required_claims: BTreeMap::new(),
-            required_headers 
+            required_headers,
         };
         let checker = JwtClaimsValidator::new(config);
         // Should fail because "kid" is in payload, not header
@@ -556,9 +554,9 @@ mod tests {
             ClaimRequirement::RegexMatch(r"^auth-.*".to_string()),
         );
 
-        let config = JwtClaimsValidatorConfig { 
+        let config = JwtClaimsValidatorConfig {
             required_claims: BTreeMap::new(),
-            required_headers 
+            required_headers,
         };
         let checker = JwtClaimsValidator::new(config);
         assert!(checker.is_valid_match(&jwt));


### PR DESCRIPTION
In order to support specific JWTs, we need to check for the presence of an attribute in the JWT header.
This PR extends the current syntax of the JwtClaimsChecker to be able to explicitly address the header. This was done this way in order to avoid updating the syntax of the file format