### PR TITLE
Increase default async scan timeout

### DIFF
--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -861,7 +861,7 @@ impl ScannerBuilder<'_> {
             rules,
             labels: Labels::empty(),
             scanner_features: ScannerFeatures::default(),
-            async_scan_timeout: Duration::from_secs(60),
+            async_scan_timeout: Duration::from_secs(60 * 5),
         }
     }
 


### PR DESCRIPTION
[Jira](https://datadoghq.atlassian.net/browse/SDS-1454)

Increasing the default async timeout from 1 minute to 5 minutes. Accounting for async http requests + timeouts + retries, 1 minute is too easy to hit.