### PR TITLE
[SDS-1412] Add optional proxy for 3rd party validation

### DIFF
--- a/sds/src/match_validation/aws_validator.rs
+++ b/sds/src/match_validation/aws_validator.rs
@@ -19,10 +19,8 @@ lazy_static! {
         let mut builder = reqwest::blocking::Client::builder();
 
         if let Ok(proxy_url) = std::env::var("DD_SDS_HTTP_PROXY") {
-            if !proxy_url.is_empty() {
-                if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
-                    builder = builder.proxy(proxy);
-                }
+            if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
+                builder = builder.proxy(proxy);
             }
         }
 

--- a/sds/src/match_validation/aws_validator.rs
+++ b/sds/src/match_validation/aws_validator.rs
@@ -18,10 +18,8 @@ lazy_static! {
     static ref AWS_BLOCKING_CLIENT: reqwest::blocking::Client = {
         let mut builder = reqwest::blocking::Client::builder();
 
-        if let Ok(proxy_url) = std::env::var("DD_SDS_HTTP_PROXY") {
-            if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
-                builder = builder.proxy(proxy);
-            }
+        if let Ok(proxy_url) = std::env::var("DD_SDS_HTTP_PROXY") && !proxy_url.is_empty() && let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
+            builder = builder.proxy(proxy);
         }
 
         builder

--- a/sds/src/match_validation/aws_validator.rs
+++ b/sds/src/match_validation/aws_validator.rs
@@ -18,7 +18,7 @@ lazy_static! {
     static ref AWS_BLOCKING_CLIENT: reqwest::blocking::Client = {
         let mut builder = reqwest::blocking::Client::builder();
 
-        if let Ok(proxy_url) = std::env::var("DD_SDS_HTTP_PROXY") && !proxy_url.is_empty() && let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
+        if let Ok(proxy_url) = std::env::var("HTTPS_PROXY") && !proxy_url.is_empty() && let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
             builder = builder.proxy(proxy);
         }
 

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -17,10 +17,8 @@ lazy_static! {
 
         // Prefer explicit SDS proxy, then fall back to standard env vars.
         if let Ok(proxy_url) = std::env::var("DD_SDS_HTTP_PROXY") {
-            if !proxy_url.is_empty() {
-                if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
-                    builder = builder.proxy(proxy);
-                }
+            if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
+                builder = builder.proxy(proxy);
             }
         }
 

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -16,10 +16,8 @@ lazy_static! {
         let mut builder = reqwest::blocking::Client::builder();
 
         // Prefer explicit SDS proxy, then fall back to standard env vars.
-        if let Ok(proxy_url) = std::env::var("DD_SDS_HTTP_PROXY") {
-            if let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
-                builder = builder.proxy(proxy);
-            }
+        if let Ok(proxy_url) = std::env::var("DD_SDS_HTTP_PROXY") && !proxy_url.is_empty() && let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
+            builder = builder.proxy(proxy);
         }
 
         builder

--- a/sds/src/match_validation/http_validator.rs
+++ b/sds/src/match_validation/http_validator.rs
@@ -16,7 +16,7 @@ lazy_static! {
         let mut builder = reqwest::blocking::Client::builder();
 
         // Prefer explicit SDS proxy, then fall back to standard env vars.
-        if let Ok(proxy_url) = std::env::var("DD_SDS_HTTP_PROXY") && !proxy_url.is_empty() && let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
+        if let Ok(proxy_url) = std::env::var("HTTPS_PROXY") && !proxy_url.is_empty() && let Ok(proxy) = reqwest::Proxy::all(&proxy_url) {
             builder = builder.proxy(proxy);
         }
 


### PR DESCRIPTION
We allow reqwest calls to be made by a proxy for packages that may use this and need a proxy. Supports https://github.com/DataDog/datadog-agentless-scanner/pull/800