### PR TITLE
Expose ClaimRequirement & JwtClaimsValidatorConfig publicly

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -48,7 +48,10 @@ pub use scanner::{
     config::RuleConfig,
     error::{CreateScannerError, ScannerError},
     regex_rule::RegexCaches,
-    regex_rule::config::{ProximityKeywordsConfig, RegexRuleConfig, SecondaryValidator},
+    regex_rule::config::{
+        ClaimRequirement, JwtClaimsValidatorConfig, ProximityKeywordsConfig, RegexRuleConfig,
+        SecondaryValidator,
+    },
     scope::Scope,
 };
 pub use scoped_ruleset::ExclusionCheck;


### PR DESCRIPTION
Follow-up of https://github.com/DataDog/dd-sensitive-data-scanner/pull/272, expose `ClaimRequirement` & `JwtClaimsValidatorConfig` outside of the crate.