### PR TITLE
Change SecondaryValidator type to struct to allow building complex co…

### DIFF
--- a/sds-go/go/jwt_claims_validator.go
+++ b/sds-go/go/jwt_claims_validator.go
@@ -1,0 +1,116 @@
+package dd_sds
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// JwtClaimsValidatorConfig represents the configuration for JWT claims validation
+type JwtClaimsValidatorConfig struct {
+	RequiredClaims  map[string]ClaimRequirement `json:"required_claims"`
+	RequiredHeaders map[string]ClaimRequirement `json:"required_headers"`
+}
+
+// UnmarshalJSON handles custom deserialization of JwtClaimsValidatorConfig
+func (j *JwtClaimsValidatorConfig) UnmarshalJSON(data []byte) error {
+	var rawConfig struct {
+		RequiredClaims  map[string]json.RawMessage `json:"required_claims"`
+		RequiredHeaders map[string]json.RawMessage `json:"required_headers"`
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&rawConfig); err != nil {
+		return err
+	}
+
+	j.RequiredClaims = make(map[string]ClaimRequirement)
+	for claimName, rawRequirement := range rawConfig.RequiredClaims {
+		requirement, err := UnmarshalClaimRequirement(rawRequirement)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal claim requirement for '%s': %v", claimName, err)
+		}
+		j.RequiredClaims[claimName] = requirement
+	}
+
+	j.RequiredHeaders = make(map[string]ClaimRequirement)
+	for headerName, rawRequirement := range rawConfig.RequiredHeaders {
+		requirement, err := UnmarshalClaimRequirement(rawRequirement)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal header requirement for '%s': %v", headerName, err)
+		}
+		j.RequiredHeaders[headerName] = requirement
+	}
+
+	return nil
+}
+
+// ClaimRequirement represents a requirement for a JWT claim
+type ClaimRequirement interface {
+	claimRequirementType() string
+}
+
+// ClaimRequirementPresent represents a claim that must be present (not null)
+type ClaimRequirementPresent struct{}
+
+func (c ClaimRequirementPresent) claimRequirementType() string { return "Present" }
+
+func (c ClaimRequirementPresent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"type": "Present",
+	})
+}
+
+// ClaimRequirementExactValue represents a claim that must have an exact string value
+type ClaimRequirementExactValue struct {
+	Value string
+}
+
+func (c ClaimRequirementExactValue) claimRequirementType() string { return "ExactValue" }
+
+func (c ClaimRequirementExactValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"type":   "ExactValue",
+		"config": c.Value,
+	})
+}
+
+// ClaimRequirementRegexMatch represents a claim that must match a regex pattern
+type ClaimRequirementRegexMatch struct {
+	Pattern string
+}
+
+func (c ClaimRequirementRegexMatch) claimRequirementType() string { return "RegexMatch" }
+
+func (c ClaimRequirementRegexMatch) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"type":   "RegexMatch",
+		"config": c.Pattern,
+	})
+}
+
+// UnmarshalClaimRequirement handles deserialization of ClaimRequirement from the tagged union format
+func UnmarshalClaimRequirement(data []byte) (ClaimRequirement, error) {
+	// Use a local struct to ensure type property is always expected
+	var rawRequirement struct {
+		Type   string `json:"type"`
+		Config string `json:"config"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&rawRequirement); err != nil {
+		return nil, fmt.Errorf("claim requirement must be a JSON object: %v", err)
+	}
+
+	switch rawRequirement.Type {
+	case "Present":
+		return ClaimRequirementPresent{}, nil
+	case "ExactValue":
+		return ClaimRequirementExactValue{Value: rawRequirement.Config}, nil
+	case "RegexMatch":
+		return ClaimRequirementRegexMatch{Pattern: rawRequirement.Config}, nil
+	default:
+		return nil, fmt.Errorf("unknown claim requirement type: %s", rawRequirement.Type)
+	}
+}

--- a/sds-go/go/jwt_claims_validator_test.go
+++ b/sds-go/go/jwt_claims_validator_test.go
@@ -1,0 +1,224 @@
+package dd_sds
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestJwtClaimsValidatorConfig_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData string
+		expected JwtClaimsValidatorConfig
+		wantErr  bool
+	}{
+		{
+			name:     "empty config",
+			jsonData: `{"required_claims": {}, "required_headers": {}}`,
+			expected: JwtClaimsValidatorConfig{
+				RequiredClaims:  map[string]ClaimRequirement{},
+				RequiredHeaders: map[string]ClaimRequirement{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "config with claims only",
+			jsonData: `{
+				"required_claims": {
+					"sub": {"type": "Present"},
+					"aud": {"type": "ExactValue", "config": "my-audience"}
+				},
+				"required_headers": {}
+			}`,
+			expected: JwtClaimsValidatorConfig{
+				RequiredClaims: map[string]ClaimRequirement{
+					"sub": ClaimRequirementPresent{},
+					"aud": ClaimRequirementExactValue{Value: "my-audience"},
+				},
+				RequiredHeaders: map[string]ClaimRequirement{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "config with headers only",
+			jsonData: `{
+				"required_claims": {},
+				"required_headers": {
+					"kid": {"type": "ExactValue", "config": "key-123"},
+					"alg": {"type": "RegexMatch", "config": "^HS\\d+$"}
+				}
+			}`,
+			expected: JwtClaimsValidatorConfig{
+				RequiredClaims: map[string]ClaimRequirement{},
+				RequiredHeaders: map[string]ClaimRequirement{
+					"kid": ClaimRequirementExactValue{Value: "key-123"},
+					"alg": ClaimRequirementRegexMatch{Pattern: "^HS\\d+$"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "config with both claims and headers",
+			jsonData: `{
+				"required_claims": {
+					"sub": {"type": "Present"},
+					"iss": {"type": "ExactValue", "config": "my-issuer"}
+				},
+				"required_headers": {
+					"kid": {"type": "ExactValue", "config": "key-456"},
+					"typ": {"type": "RegexMatch", "config": "^JWT$"}
+				}
+			}`,
+			expected: JwtClaimsValidatorConfig{
+				RequiredClaims: map[string]ClaimRequirement{
+					"sub": ClaimRequirementPresent{},
+					"iss": ClaimRequirementExactValue{Value: "my-issuer"},
+				},
+				RequiredHeaders: map[string]ClaimRequirement{
+					"kid": ClaimRequirementExactValue{Value: "key-456"},
+					"typ": ClaimRequirementRegexMatch{Pattern: "^JWT$"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "backwards compatibility - missing required_headers field",
+			jsonData: `{
+				"required_claims": {
+					"sub": {"type": "Present"}
+				}
+			}`,
+			expected: JwtClaimsValidatorConfig{
+				RequiredClaims: map[string]ClaimRequirement{
+					"sub": ClaimRequirementPresent{},
+				},
+				RequiredHeaders: map[string]ClaimRequirement{},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config JwtClaimsValidatorConfig
+			err := json.Unmarshal([]byte(tt.jsonData), &config)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JwtClaimsValidatorConfig.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil {
+				return
+			}
+
+			// Check required claims
+			if len(config.RequiredClaims) != len(tt.expected.RequiredClaims) {
+				t.Errorf("RequiredClaims length = %v, want %v", len(config.RequiredClaims), len(tt.expected.RequiredClaims))
+			}
+
+			for key, expectedReq := range tt.expected.RequiredClaims {
+				actualReq, exists := config.RequiredClaims[key]
+				if !exists {
+					t.Errorf("Missing required claim: %v", key)
+					continue
+				}
+				if actualReq.claimRequirementType() != expectedReq.claimRequirementType() {
+					t.Errorf("RequiredClaims[%v] type = %v, want %v", key, actualReq.claimRequirementType(), expectedReq.claimRequirementType())
+				}
+			}
+
+			// Check required headers
+			if len(config.RequiredHeaders) != len(tt.expected.RequiredHeaders) {
+				t.Errorf("RequiredHeaders length = %v, want %v", len(config.RequiredHeaders), len(tt.expected.RequiredHeaders))
+			}
+
+			for key, expectedReq := range tt.expected.RequiredHeaders {
+				actualReq, exists := config.RequiredHeaders[key]
+				if !exists {
+					t.Errorf("Missing required header: %v", key)
+					continue
+				}
+				if actualReq.claimRequirementType() != expectedReq.claimRequirementType() {
+					t.Errorf("RequiredHeaders[%v] type = %v, want %v", key, actualReq.claimRequirementType(), expectedReq.claimRequirementType())
+				}
+			}
+		})
+	}
+}
+
+func TestJwtClaimsValidatorConfig_MarshalJSON(t *testing.T) {
+	config := JwtClaimsValidatorConfig{
+		RequiredClaims: map[string]ClaimRequirement{
+			"sub": ClaimRequirementPresent{},
+			"iss": ClaimRequirementExactValue{Value: "my-issuer"},
+		},
+		RequiredHeaders: map[string]ClaimRequirement{
+			"kid": ClaimRequirementExactValue{Value: "key-123"},
+			"alg": ClaimRequirementRegexMatch{Pattern: "^HS\\d+$"},
+		},
+	}
+
+	jsonData, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("Failed to marshal config: %v", err)
+	}
+
+	// Unmarshal to verify round-trip
+	var unmarshaledConfig JwtClaimsValidatorConfig
+	err = json.Unmarshal(jsonData, &unmarshaledConfig)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal config: %v", err)
+	}
+
+	// Verify the round-trip preserved the data
+	if len(unmarshaledConfig.RequiredClaims) != len(config.RequiredClaims) {
+		t.Errorf("RequiredClaims length after round-trip = %v, want %v", len(unmarshaledConfig.RequiredClaims), len(config.RequiredClaims))
+	}
+
+	if len(unmarshaledConfig.RequiredHeaders) != len(config.RequiredHeaders) {
+		t.Errorf("RequiredHeaders length after round-trip = %v, want %v", len(unmarshaledConfig.RequiredHeaders), len(config.RequiredHeaders))
+	}
+}
+
+func TestJwtClaimsValidatorConfig_UnmarshalJSON_with_unknown_field(t *testing.T) {
+	valid := `{"required_claims": {"sub":{"type":"Present"}}, "required_headers": {}}`
+	withUnknown := `{"required_claims": {"sub":{"type":"Present"}}, "required_headers": {}, "unknown_field":"unknown_value"}`
+
+	tests := []struct {
+		name          string
+		jsonInput     string
+		expectedError error
+	}{
+		{
+			name:          "unmarshal valid config",
+			jsonInput:     valid,
+			expectedError: nil,
+		},
+		{
+			name:          "unmarshal with unknown field",
+			jsonInput:     withUnknown,
+			expectedError: errors.New("json: unknown field \"unknown_field\""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg JwtClaimsValidatorConfig
+			err := json.Unmarshal([]byte(tt.jsonInput), &cfg)
+			if tt.expectedError == nil {
+				if err != nil {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Expected error: %v, got: nil", tt.expectedError)
+			}
+			if err.Error() != tt.expectedError.Error() {
+				t.Fatalf("Expected error: %q, got: %q", tt.expectedError.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/sds-go/go/regex_rule.go
+++ b/sds-go/go/regex_rule.go
@@ -92,6 +92,7 @@ type SecondaryValidatorType string
 const (
 	LuhnChecksum      = SecondaryValidatorType("LuhnChecksum")
 	ChineseIdChecksum = SecondaryValidatorType("ChineseIdChecksum")
+	JwtValidatorType  = SecondaryValidatorType("JwtClaimsValidator")
 )
 
 // SecondaryValidator represents a secondary validator that can optionally have configuration
@@ -103,6 +104,14 @@ type SecondaryValidator struct {
 // NewSecondaryValidator creates a simple validator without configuration
 func NewSecondaryValidator(validatorType string) *SecondaryValidator {
 	return &SecondaryValidator{Type: SecondaryValidatorType(validatorType)}
+}
+
+// NewJwtClaimsValidator creates a JWT claims checker validator with configuration
+func NewJwtClaimsValidator(config JwtClaimsValidatorConfig) *SecondaryValidator {
+	return &SecondaryValidator{
+		Type:   JwtValidatorType,
+		Config: config,
+	}
 }
 
 type PartialRedactionDirection string

--- a/sds-go/go/regex_rule.go
+++ b/sds-go/go/regex_rule.go
@@ -17,7 +17,7 @@ type RegexRuleConfig struct {
 	Pattern                 string                   `json:"pattern"`
 	MatchAction             MatchAction              `json:"match_action"`
 	ProximityKeywords       *ProximityKeywordsConfig `json:"proximity_keywords,omitempty"`
-	SecondaryValidator      SecondaryValidator       `json:"validator,omitempty"`
+	SecondaryValidator      *SecondaryValidator      `json:"validator,omitempty"`
 	ThirdPartyActiveChecker ThirdPartyActiveChecker  `json:"third_party_active_checker,omitempty"`
 	PatternCaptureGroups    []string                 `json:"pattern_capture_groups,omitempty"`
 }
@@ -87,12 +87,23 @@ const (
 	ReplacementTypePartialEnd   = ReplacementType("partial_end")
 )
 
-type SecondaryValidator string
+type SecondaryValidatorType string
 
 const (
-	LuhnChecksum      = SecondaryValidator("LuhnChecksum")
-	ChineseIdChecksum = SecondaryValidator("ChineseIdChecksum")
+	LuhnChecksum      = SecondaryValidatorType("LuhnChecksum")
+	ChineseIdChecksum = SecondaryValidatorType("ChineseIdChecksum")
 )
+
+// SecondaryValidator represents a secondary validator that can optionally have configuration
+type SecondaryValidator struct {
+	Type   SecondaryValidatorType `json:"type"`
+	Config interface{}            `json:"config,omitempty"`
+}
+
+// NewSecondaryValidator creates a simple validator without configuration
+func NewSecondaryValidator(validatorType string) *SecondaryValidator {
+	return &SecondaryValidator{Type: SecondaryValidatorType(validatorType)}
+}
 
 type PartialRedactionDirection string
 
@@ -104,7 +115,7 @@ const (
 // ExtraConfig is used to provide more configuration while creating the rules.
 type ExtraConfig struct {
 	ProximityKeywords       *ProximityKeywordsConfig
-	SecondaryValidator      SecondaryValidator
+	SecondaryValidator      *SecondaryValidator
 	ThirdPartyActiveChecker ThirdPartyActiveChecker
 	PatternCaptureGroups    []string
 }
@@ -242,13 +253,6 @@ func NewPartialRedactRule(id string, pattern string, characterCount uint32, dire
 		SecondaryValidator:      extraConfig.SecondaryValidator,
 		ThirdPartyActiveChecker: extraConfig.ThirdPartyActiveChecker,
 	}
-}
-
-// MarshalJSON marshales the SecondaryValidator.
-func (s SecondaryValidator) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]string{
-		"type": string(s),
-	})
 }
 
 // MarshalJSON marshals the MatchAction in a format understood by the serde rust

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -458,7 +458,7 @@ func TestSecondaryValidator(t *testing.T) {
 	scannerWithChecksum, err := CreateScanner([]RuleConfig{
 		NewRedactingRule("rule_card",
 			"\\b4\\d{3}(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:\\d{9}(?:\\d{3}(?:\\d{3})?)?))\\b",
-			"[redacted]", ExtraConfig{SecondaryValidator: LuhnChecksum}),
+			"[redacted]", ExtraConfig{SecondaryValidator: NewSecondaryValidator("LuhnChecksum")}),
 	})
 	if err != nil {
 		t.Fatal("failed to create the scanner with checksum:", err.Error())

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -504,6 +504,87 @@ func TestSecondaryValidator(t *testing.T) {
 	runTest(t, scannerWithChecksum, testData, false)
 }
 
+func TestJWTSecondaryValidator(t *testing.T) {
+	scannerWithoutChecksum, err := CreateScanner([]RuleConfig{
+		NewRedactingRule("rule_oauth_test",
+			`ey[\w=-]+\.ey[\w=-]+\.[\w-]+`,
+			"[redacted]", ExtraConfig{}),
+	})
+	if err != nil {
+		t.Fatal("failed to create the scanner wo checksum:", err.Error())
+	}
+	defer scannerWithoutChecksum.Delete()
+	scannerWithChecksum, err := CreateScanner([]RuleConfig{
+		NewRedactingRule("rule_oauth_test",
+			`ey[\w=-]+\.ey[\w=-]+\.[\w-]+`,
+			"[redacted]", ExtraConfig{
+				SecondaryValidator: NewJwtClaimsValidator(JwtClaimsValidatorConfig{
+					RequiredHeaders: map[string]ClaimRequirement{
+						"alg": ClaimRequirementExactValue{
+							Value: "HS256",
+						},
+						"typ": ClaimRequirementPresent{},
+					},
+					RequiredClaims: map[string]ClaimRequirement{
+						"app": ClaimRequirementRegexMatch{
+							Pattern: `test_\w`,
+						},
+						"version": ClaimRequirementExactValue{
+							Value: "2",
+						},
+						"scope": ClaimRequirementPresent{},
+					},
+				}),
+			},
+		),
+	})
+	if err != nil {
+		t.Fatal("failed to create the scanner with checksum:", err.Error())
+	}
+	defer scannerWithChecksum.Delete()
+
+	testData := map[string]testResult{
+		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHAiOiJ0ZXN0X2FwcCIsInZlcnNpb24iOiIyIiwiaXNzIjoidGVzdCIsImV4cCI6MTUxNjIzOTAyMn0.2V6y840xin2_bPfoaUa1odbKJ1DoA6EerZIvAeK7AvI non_jwt_token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHAiOiJ0ZXN0X2FwcCIsInZlcnNpb24iOiIyIiwic2NvcGUiOiJwdWJsaWMiLCJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.caby0bMSrvwzcQH_DVuPmDP2JTqgOdje7G9RPU_JToE": {
+			mutated: true,
+			str:     "[redacted] non_jwt_token [redacted]",
+			rules: []RuleMatch{
+				{
+					RuleIdx:           0,
+					StartIndex:        0,
+					ReplacementType:   ReplacementTypePlaceholder,
+					EndIndexExclusive: 10,
+					ShiftOffset:       -154,
+				},
+				{
+					RuleIdx:           0,
+					StartIndex:        25,
+					ReplacementType:   ReplacementTypePlaceholder,
+					EndIndexExclusive: 35,
+					ShiftOffset:       -331,
+				},
+			},
+		},
+	}
+	runTest(t, scannerWithoutChecksum, testData, false)
+
+	testData = map[string]testResult{
+		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHAiOiJ0ZXN0X2FwcCIsInZlcnNpb24iOiIyIiwiaXNzIjoidGVzdCIsImV4cCI6MTUxNjIzOTAyMn0.2V6y840xin2_bPfoaUa1odbKJ1DoA6EerZIvAeK7AvI non_jwt_token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHAiOiJ0ZXN0X2FwcCIsInZlcnNpb24iOiIyIiwic2NvcGUiOiJwdWJsaWMiLCJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.caby0bMSrvwzcQH_DVuPmDP2JTqgOdje7G9RPU_JToE": {
+			mutated: true,
+			str:     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHAiOiJ0ZXN0X2FwcCIsInZlcnNpb24iOiIyIiwiaXNzIjoidGVzdCIsImV4cCI6MTUxNjIzOTAyMn0.2V6y840xin2_bPfoaUa1odbKJ1DoA6EerZIvAeK7AvI non_jwt_token [redacted]",
+			rules: []RuleMatch{
+				{
+					RuleIdx:           0,
+					StartIndex:        179,
+					ReplacementType:   ReplacementTypePlaceholder,
+					EndIndexExclusive: 189,
+					ShiftOffset:       -177,
+				},
+			},
+		},
+	}
+	runTest(t, scannerWithChecksum, testData, false)
+}
+
 func TestThirdPartyActiveChecker(t *testing.T) {
 	// Test rule without third party validation
 	scannerWithoutValidation, err := CreateScanner([]RuleConfig{


### PR DESCRIPTION
## Description

This PR updates SecondaryValidator type from string to structure to allow building more complex and configurable validators. This may breaks the code usage.

**Related JIRA:** [SDS-2036](https://datadoghq.atlassian.net/browse/SDS-2036)

## Changes

### Core Changes in dd-sds

1. **New `SecondaryValidator` struct** - replaces SecondaryValidator old type (string):
   - `type`: The string referring to the secondary validator type (the same used for the old one)
   - `config`: The validator config (non mandatory)

### Breaking Changes

- `SecondaryValidator` is now a structure rather than a string. For instance, if a string variable `s` contains the secondary validator type (like "LuhnChecksum"), please change

```go
var s string = "LuhnChecksum" // Example 
SecondaryValidator(s)
```
to
```go
var s string = "LuhnChecksum" // Example 
NewSecondaryValidator(s)
```

This creates a struct that contains the type.


[SDS-2036]: https://datadoghq.atlassian.net/browse/SDS-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ