### PR TITLE
Add sds_excluded_namespace tag to multipass excluded match metric

### DIFF
--- a/sds/benches/bench.rs
+++ b/sds/benches/bench.rs
@@ -206,12 +206,121 @@ pub fn included_keywords_on_path(c: &mut Criterion) {
     });
 }
 
+pub fn multipass_excluded_scan(c: &mut Criterion) {
+    // Realistic event: deeply nested structure with many paths, simulating
+    // a structured log with metadata, user data, and request/response bodies.
+    let mut root = BTreeMap::new();
+
+    // Top-level flat fields (50)
+    for i in 0..50 {
+        root.insert(
+            format!("attr-{}", i),
+            SimpleEvent::String(format!("token-abc-{}", i)),
+        );
+    }
+
+    // Nested "user" object with 20 fields
+    let mut user = BTreeMap::new();
+    for i in 0..20 {
+        user.insert(
+            format!("field-{}", i),
+            SimpleEvent::String("secret-key-99".to_string()),
+        );
+    }
+    root.insert("user".to_string(), SimpleEvent::Map(user));
+
+    // Nested "request" -> "headers" with 30 fields
+    let mut headers = BTreeMap::new();
+    for i in 0..30 {
+        headers.insert(
+            format!("x-header-{}", i),
+            SimpleEvent::String("bearer-tok-123".to_string()),
+        );
+    }
+    let mut request = BTreeMap::new();
+    request.insert("headers".to_string(), SimpleEvent::Map(headers));
+    // "request" -> "body" with 40 fields
+    let mut body = BTreeMap::new();
+    for i in 0..40 {
+        body.insert(
+            format!("param-{}", i),
+            SimpleEvent::String(format!("val-xyz-{}", i % 5)),
+        );
+    }
+    request.insert("body".to_string(), SimpleEvent::Map(body));
+    root.insert("request".to_string(), SimpleEvent::Map(request));
+
+    // Nested "response" -> "body" with 30 fields
+    let mut resp_body = BTreeMap::new();
+    for i in 0..30 {
+        resp_body.insert(
+            format!("field-{}", i),
+            SimpleEvent::String("secret-key-99".to_string()),
+        );
+    }
+    let mut response = BTreeMap::new();
+    response.insert("body".to_string(), SimpleEvent::Map(resp_body));
+    root.insert("response".to_string(), SimpleEvent::Map(response));
+
+    // Array of 20 items
+    let items: Vec<SimpleEvent> = (0..20)
+        .map(|i| {
+            let mut m = BTreeMap::new();
+            m.insert(
+                "id".to_string(),
+                SimpleEvent::String(format!("item-id-{}", i)),
+            );
+            m.insert(
+                "value".to_string(),
+                SimpleEvent::String("secret-key-99".to_string()),
+            );
+            SimpleEvent::Map(m)
+        })
+        .collect();
+    root.insert("items".to_string(), SimpleEvent::List(items));
+
+    // Excluded scope fields that share content with scanned fields
+    let mut excluded = BTreeMap::new();
+    for i in 0..10 {
+        excluded.insert(
+            format!("internal-{}", i),
+            SimpleEvent::String("secret-key-99".to_string()),
+        );
+    }
+    root.insert("_metadata".to_string(), SimpleEvent::Map(excluded));
+
+    let mut event = SimpleEvent::Map(root);
+
+    // Exclude _metadata.* paths
+    let excluded_paths: Vec<Path> = (0..10)
+        .map(|i| {
+            Path::from(vec![
+                PathSegment::Field("_metadata".into()),
+                PathSegment::Field(format!("internal-{}", i).into()),
+            ])
+        })
+        .collect();
+
+    let rule = RootRuleConfig::new(RegexRuleConfig::new("[a-z]+-[a-z]+-\\d+").build())
+        .scope(Scope::exclude(excluded_paths))
+        .match_action(dd_sds::MatchAction::None);
+
+    let scanner = Scanner::builder(&[rule]).build().unwrap();
+
+    c.bench_function("multipass_excluded_scan", |b| {
+        b.iter(|| {
+            let _result = scanner.scan(&mut event).unwrap();
+        })
+    });
+}
+
 criterion::criterion_group!(
     benches,
     scoped_ruleset,
     luhn_checksum,
     included_keywords,
-    included_keywords_on_path
+    included_keywords_on_path,
+    multipass_excluded_scan
 );
 
 criterion::criterion_main!(benches);

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -25,7 +25,7 @@ pub use crate::secondary_validation::Validator;
 use crate::stats::GLOBAL_STATS;
 use crate::tokio::TOKIO_RUNTIME;
 use crate::{CreateScannerError, EncodeIndices, MatchAction, Path, ScannerError};
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashMap;
 use futures::executor::block_on;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -218,9 +218,10 @@ pub struct StringMatchesCtx<'a> {
     rule_index: usize,
     pub regex_caches: &'a mut RegexCaches,
     pub exclusion_check: &'a ExclusionCheck<'a>,
-    pub excluded_matches: &'a mut AHashSet<String>,
+    pub excluded_matches: &'a mut AHashMap<String, String>,
     pub match_emitter: &'a mut dyn MatchEmitter,
     pub wildcard_indices: Option<&'a Vec<(usize, usize)>>,
+    pub enable_debug_observability: bool,
 
     // Shared Data
     pub per_string_data: &'a mut SharedData,
@@ -332,7 +333,12 @@ pub trait CompiledRule: Send + Sync {
         false
     }
 
-    fn on_excluded_match_multipass_v0(&self, _path: &Path, _enable_debug_observability: bool) {
+    fn on_excluded_match_multipass_v0(
+        &self,
+        _path: &Path,
+        _excluded_path: &str,
+        _enable_debug_observability: bool,
+    ) {
         // default is to do nothing
     }
 
@@ -555,7 +561,7 @@ impl Scanner {
         &self,
         event: &mut E,
         rule_matches: InternalRuleMatchSet<E::Encoding>,
-        excluded_matches: AHashSet<String>,
+        excluded_matches: AHashMap<String, String>,
         output_rule_matches: &mut Vec<RuleMatch>,
         need_match_content: bool,
     ) {
@@ -589,16 +595,18 @@ impl Scanner {
                                 .inner
                                 .should_exclude_multipass_v0()
                             {
-                                let is_false_positive = excluded_matches
-                                    .contains(&content[rule_match.utf8_start..rule_match.utf8_end]);
-                                if is_false_positive && self.scanner_features.multipass_v0_enabled {
+                                let match_content =
+                                    &content[rule_match.utf8_start..rule_match.utf8_end];
+                                let excluded_path = excluded_matches.get(match_content);
+                                if let Some(excluded_path) = excluded_path {
                                     self.rules[rule_match.rule_index]
                                         .on_excluded_match_multipass_v0(
                                             &path,
+                                            excluded_path,
                                             self.scanner_features.enable_debug_observability,
                                         );
                                 }
-                                !is_false_positive
+                                excluded_path.is_none()
                             } else {
                                 true
                             }
@@ -637,7 +645,7 @@ impl Scanner {
         let need_match_content = self.scanner_features.return_matches || options.validate_matches;
         // All matches, after some (but not all) false-positives have been removed.
         let mut rule_matches = InternalRuleMatchSet::new();
-        let mut excluded_matches = AHashSet::new();
+        let mut excluded_matches = AHashMap::new();
         let mut async_jobs = vec![];
 
         access_regex_caches(|regex_caches| {
@@ -1082,7 +1090,7 @@ struct ScannerContentVisitor<'a, E: Encoding> {
     // Rules that shall be skipped for this scan
     // This list shall be small (<10), so a linear search is acceptable
     blocked_rules: &'a Vec<usize>,
-    excluded_matches: &'a mut AHashSet<String>,
+    excluded_matches: &'a mut AHashMap<String, String>,
     per_event_data: SharedData,
     wildcarded_indexes: &'a AHashMap<Path<'static>, Vec<(usize, usize)>>,
     async_jobs: &'a mut Vec<PendingRuleJob>,
@@ -1139,6 +1147,10 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
                     excluded_matches: self.excluded_matches,
                     match_emitter: &mut emitter,
                     wildcard_indices: wildcard_indices_per_path,
+                    enable_debug_observability: self
+                        .scanner
+                        .scanner_features
+                        .enable_debug_observability,
                     per_string_data: &mut per_string_data,
                     per_scanner_data: &self.scanner.per_scanner_data,
                     per_event_data: &mut self.per_event_data,

--- a/sds/src/scanner/regex_rule/compiled.rs
+++ b/sds/src/scanner/regex_rule/compiled.rs
@@ -10,7 +10,7 @@ use crate::scanner::{
 };
 use crate::secondary_validation::Validator;
 use crate::{CompiledRule, ExclusionCheck, Labels, Path, StringMatch};
-use ahash::AHashSet;
+use ahash::AHashMap;
 use metrics::counter;
 use regex_automata::Input;
 use regex_automata::meta::Cache;
@@ -50,6 +50,7 @@ impl CompiledRule for RegexCompiledRule {
                 );
             }
             None => {
+                let enable_debug = ctx.enable_debug_observability;
                 let cache_value = ctx.regex_caches.get(&self.regex);
                 let true_positive_search = self.true_positive_matches(
                     content,
@@ -58,6 +59,8 @@ impl CompiledRule for RegexCompiledRule {
                     true,
                     ctx.exclusion_check,
                     ctx.excluded_matches,
+                    path,
+                    enable_debug,
                 );
                 for string_match in true_positive_search {
                     ctx.match_emitter.emit(string_match);
@@ -71,12 +74,17 @@ impl CompiledRule for RegexCompiledRule {
         true
     }
 
-    fn on_excluded_match_multipass_v0(&self, path: &Path, enable_debug_observability: bool) {
+    fn on_excluded_match_multipass_v0(
+        &self,
+        path: &Path,
+        excluded_path: &str,
+        enable_debug_observability: bool,
+    ) {
         if enable_debug_observability {
-            let labels = self
-                .metrics
-                .base_labels
-                .clone_with_labels(Labels::new(&[("sds_namespace", path.to_string())]));
+            let labels = self.metrics.base_labels.clone_with_labels(Labels::new(&[
+                ("sds_namespace", path.to_string()),
+                ("sds_excluded_namespace", excluded_path.to_string()),
+            ]));
             counter!("false_positive.multipass.excluded_match", labels).increment(1);
         } else {
             self.metrics.false_positive_excluded_attributes.increment(1);
@@ -101,6 +109,7 @@ impl RegexCompiledRule {
         ctx: &mut StringMatchesCtx,
         included_keywords: &CompiledIncludedProximityKeywords,
     ) {
+        let enable_debug = ctx.enable_debug_observability;
         let mut included_keyword_matches = included_keywords.keyword_matches(content);
 
         'included_keyword_search: while let Some(included_keyword_match) =
@@ -114,6 +123,8 @@ impl RegexCompiledRule {
                 false,
                 ctx.exclusion_check,
                 ctx.excluded_matches,
+                path,
+                enable_debug,
             );
 
             for true_positive_match in true_positive_search {
@@ -183,6 +194,8 @@ impl RegexCompiledRule {
             false,
             ctx.exclusion_check,
             ctx.excluded_matches,
+            path,
+            enable_debug,
         );
 
         for string_match in true_positive_search {
@@ -190,6 +203,7 @@ impl RegexCompiledRule {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn true_positive_matches<'a>(
         &'a self,
         content: &'a str,
@@ -197,7 +211,9 @@ impl RegexCompiledRule {
         cache: &'a mut RegexCacheValue,
         check_excluded_keywords: bool,
         exclusion_check: &'a ExclusionCheck<'a>,
-        excluded_matches: &'a mut AHashSet<String>,
+        excluded_matches: &'a mut AHashMap<String, String>,
+        scan_path: &'a Path<'a>,
+        enable_debug_observability: bool,
     ) -> TruePositiveSearch<'a> {
         TruePositiveSearch {
             rule: self,
@@ -208,6 +224,8 @@ impl RegexCompiledRule {
             check_excluded_keywords,
             exclusion_check,
             excluded_matches,
+            scan_path,
+            enable_debug_observability,
         }
     }
 }
@@ -219,8 +237,10 @@ pub struct TruePositiveSearch<'a> {
     cache: &'a mut Cache,
     check_excluded_keywords: bool,
     exclusion_check: &'a ExclusionCheck<'a>,
-    excluded_matches: &'a mut AHashSet<String>,
+    excluded_matches: &'a mut AHashMap<String, String>,
     captures: &'a mut Captures,
+    scan_path: &'a Path<'a>,
+    enable_debug_observability: bool,
 }
 
 impl TruePositiveSearch<'_> {
@@ -283,8 +303,15 @@ impl Iterator for TruePositiveSearch<'_> {
                 if self.exclusion_check.is_excluded(self.rule.rule_index) {
                     // Matches from excluded paths are saved and used to treat additional equal matches as false positives.
                     // Matches are checked against this `excluded_matches` set after all scanning has been done.
-                    self.excluded_matches
-                        .insert(self.content[regex_match_range.0..regex_match_range.1].to_string());
+                    let match_str = &self.content[regex_match_range.0..regex_match_range.1];
+                    if !self.excluded_matches.contains_key(match_str) {
+                        let path = if self.enable_debug_observability {
+                            self.scan_path.to_string()
+                        } else {
+                            String::new()
+                        };
+                        self.excluded_matches.insert(match_str.to_string(), path);
+                    }
                 } else {
                     return Some(StringMatch {
                         start: regex_match_range.0,

--- a/sds/src/scanner/test/metrics.rs
+++ b/sds/src/scanner/test/metrics.rs
@@ -126,7 +126,10 @@ fn should_submit_excluded_match_metric_with_debug_observability() {
     let snapshot = snapshotter.snapshot().into_hashmap();
 
     let metric_name = "false_positive.multipass.excluded_match";
-    let labels = vec![Label::new("sds_namespace", "z-match")];
+    let labels = vec![
+        Label::new("sds_namespace", "z-match"),
+        Label::new("sds_excluded_namespace", "test"),
+    ];
     let metric_value = snapshot
         .get(&CompositeKey::new(
             Counter,


### PR DESCRIPTION
[SDS-2471](https://datadoghq.atlassian.net/browse/SDS-2471)

Adds `sds_excluded_namespace` tag to `false_positive.multipass.excluded_match` metric when `enable_debug_observability` is enabled. Zero-cost when disabled.

Benchmark (`multipass_excluded_scan`, ~260 paths):

| Stage | Time | vs baseline |
|---|---|---|
| main (no changes) | 69.3 µs | — |
| [Regression](https://github.com/DataDog/dd-sensitive-data-scanner/pull/347) (`into_static()` every call) | 80.2 µs | +15.7% |
| This PR (reference + conditional) | 70.1 µs | +1.2% (noise) |

[SDS-2471]: https://datadoghq.atlassian.net/browse/SDS-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ