### PR TITLE
[SDSP-324] Add is_supporting_rule to RootRuleConfig and RootCompiledRule

### DIFF
--- a/sds-go/go/regex_rule.go
+++ b/sds-go/go/regex_rule.go
@@ -20,6 +20,7 @@ type RegexRuleConfig struct {
 	SecondaryValidator      *SecondaryValidator      `json:"validator,omitempty"`
 	ThirdPartyActiveChecker ThirdPartyActiveChecker  `json:"third_party_active_checker,omitempty"`
 	PatternCaptureGroups    []string                 `json:"pattern_capture_groups,omitempty"`
+	IsSupportingRule        bool                     `json:"is_supporting_rule,omitempty"`
 }
 
 // ThirdPartyActiveChecker is used to validate if a given match is still active or not. It applies well to tokens that have an expiration date for instance.
@@ -127,6 +128,7 @@ type ExtraConfig struct {
 	SecondaryValidator      *SecondaryValidator
 	ThirdPartyActiveChecker ThirdPartyActiveChecker
 	PatternCaptureGroups    []string
+	IsSupportingRule        bool
 }
 
 // CreateProximityKeywordsConfig creates a ProximityKeywordsConfig.
@@ -197,6 +199,7 @@ func NewMatchingRule(id string, pattern string, extraConfig ExtraConfig) RegexRu
 		SecondaryValidator:      extraConfig.SecondaryValidator,
 		ThirdPartyActiveChecker: extraConfig.ThirdPartyActiveChecker,
 		PatternCaptureGroups:    extraConfig.PatternCaptureGroups,
+		IsSupportingRule:        extraConfig.IsSupportingRule,
 	}
 }
 
@@ -230,6 +233,7 @@ func NewRedactingRule(id string, pattern string, redactionValue string, extraCon
 		SecondaryValidator:      extraConfig.SecondaryValidator,
 		ThirdPartyActiveChecker: extraConfig.ThirdPartyActiveChecker,
 		PatternCaptureGroups:    extraConfig.PatternCaptureGroups,
+		IsSupportingRule:        extraConfig.IsSupportingRule,
 	}
 }
 
@@ -245,6 +249,7 @@ func NewHashRule(id string, pattern string, extraConfig ExtraConfig) RegexRuleCo
 		SecondaryValidator:      extraConfig.SecondaryValidator,
 		ThirdPartyActiveChecker: extraConfig.ThirdPartyActiveChecker,
 		PatternCaptureGroups:    extraConfig.PatternCaptureGroups,
+		IsSupportingRule:        extraConfig.IsSupportingRule,
 	}
 }
 
@@ -261,6 +266,7 @@ func NewPartialRedactRule(id string, pattern string, characterCount uint32, dire
 		ProximityKeywords:       extraConfig.ProximityKeywords,
 		SecondaryValidator:      extraConfig.SecondaryValidator,
 		ThirdPartyActiveChecker: extraConfig.ThirdPartyActiveChecker,
+		IsSupportingRule:        extraConfig.IsSupportingRule,
 	}
 }
 

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -18,10 +18,11 @@ import (
 import "C"
 
 var (
-	ErrUnknown            error = fmt.Errorf("unknown error")
-	ErrInvalidRegex       error = fmt.Errorf("invalid regex")
-	ErrInvalidKeywords    error = fmt.Errorf("invalid keywords")
-	ErrInvalidMatchAction error = fmt.Errorf("invalid match action")
+	ErrUnknown                      error = fmt.Errorf("unknown error")
+	ErrInvalidRegex                 error = fmt.Errorf("invalid regex")
+	ErrInvalidKeywords              error = fmt.Errorf("invalid keywords")
+	ErrInvalidMatchAction           error = fmt.Errorf("invalid match action")
+	ErrInvalidSupportingRuleConfig  error = fmt.Errorf("supporting rules cannot have a match action other than None")
 )
 
 // Scanner wraps an SDS scanner.
@@ -114,6 +115,8 @@ func CreateScannerWithOptions(ruleConfigs []RuleConfig, options ScannerOptions) 
 			} else {
 				return nil, fmt.Errorf("internal panic")
 			}
+		case -8: // rust: CreateScannerError::InvalidSupportingRuleConfig
+			return nil, ErrInvalidSupportingRuleConfig
 		}
 
 		return nil, ErrUnknown

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -18,10 +18,10 @@ import (
 import "C"
 
 var (
-	ErrUnknown                     error = fmt.Errorf("unknown error")
-	ErrInvalidRegex                error = fmt.Errorf("invalid regex")
-	ErrInvalidKeywords             error = fmt.Errorf("invalid keywords")
-	ErrInvalidMatchAction          error = fmt.Errorf("invalid match action")
+	ErrUnknown                      error = fmt.Errorf("unknown error")
+	ErrInvalidRegex                 error = fmt.Errorf("invalid regex")
+	ErrInvalidKeywords              error = fmt.Errorf("invalid keywords")
+	ErrInvalidMatchAction           error = fmt.Errorf("invalid match action")
 	ErrSupportingRuleHasMatchAction error = fmt.Errorf("supporting rules cannot have a match action other than None")
 )
 

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -18,11 +18,11 @@ import (
 import "C"
 
 var (
-	ErrUnknown                      error = fmt.Errorf("unknown error")
-	ErrInvalidRegex                 error = fmt.Errorf("invalid regex")
-	ErrInvalidKeywords              error = fmt.Errorf("invalid keywords")
-	ErrInvalidMatchAction           error = fmt.Errorf("invalid match action")
-	ErrInvalidSupportingRuleConfig  error = fmt.Errorf("supporting rules cannot have a match action other than None")
+	ErrUnknown                     error = fmt.Errorf("unknown error")
+	ErrInvalidRegex                error = fmt.Errorf("invalid regex")
+	ErrInvalidKeywords             error = fmt.Errorf("invalid keywords")
+	ErrInvalidMatchAction          error = fmt.Errorf("invalid match action")
+	ErrInvalidSupportingRuleConfig error = fmt.Errorf("supporting rules cannot have a match action other than None")
 )
 
 // Scanner wraps an SDS scanner.

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -115,7 +115,7 @@ func CreateScannerWithOptions(ruleConfigs []RuleConfig, options ScannerOptions) 
 			} else {
 				return nil, fmt.Errorf("internal panic")
 			}
-		case -8: // rust: CreateScannerError::InvalidSupportingRuleConfig
+		case -8: // rust: CreateScannerError::SupportingRuleHasMatchAction
 			return nil, ErrSupportingRuleHasMatchAction
 		}
 

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -22,7 +22,7 @@ var (
 	ErrInvalidRegex                error = fmt.Errorf("invalid regex")
 	ErrInvalidKeywords             error = fmt.Errorf("invalid keywords")
 	ErrInvalidMatchAction          error = fmt.Errorf("invalid match action")
-	ErrInvalidSupportingRuleConfig error = fmt.Errorf("supporting rules cannot have a match action other than None")
+	ErrSupportingRuleHasMatchAction error = fmt.Errorf("supporting rules cannot have a match action other than None")
 )
 
 // Scanner wraps an SDS scanner.
@@ -116,7 +116,7 @@ func CreateScannerWithOptions(ruleConfigs []RuleConfig, options ScannerOptions) 
 				return nil, fmt.Errorf("internal panic")
 			}
 		case -8: // rust: CreateScannerError::InvalidSupportingRuleConfig
-			return nil, ErrInvalidSupportingRuleConfig
+			return nil, ErrSupportingRuleHasMatchAction
 		}
 
 		return nil, ErrUnknown

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -1040,3 +1040,46 @@ func TestCreateScannerFailsOnEmptySdsMatchCaptureGroup(t *testing.T) {
 		t.Fatal("on failed creation, the returned scanner should be nil")
 	}
 }
+
+func TestSupportingRuleMatchExcludedFromOutput(t *testing.T) {
+	rules := []RuleConfig{
+		NewMatchingRule("supporting", `\bprefix_\w+\b`, ExtraConfig{IsSupportingRule: true}),
+		NewMatchingRule("main", `\bmain_\w+\b`, ExtraConfig{}),
+	}
+
+	scanner, err := CreateScanner(rules)
+	if err != nil {
+		t.Fatal("failed to create scanner:", err.Error())
+	}
+	defer scanner.Delete()
+
+	result, err := scanner.Scan([]byte("prefix_abc and main_token"))
+	if err != nil {
+		t.Fatal("failed to scan:", err.Error())
+	}
+
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(result.Matches))
+	}
+	// rule index 1 is the main rule
+	if result.Matches[0].RuleIdx != 1 {
+		t.Fatalf("expected match from rule index 1 (main), got rule index %d", result.Matches[0].RuleIdx)
+	}
+}
+
+func TestCreateScannerFailsOnSupportingRuleWithMatchAction(t *testing.T) {
+	rules := []RuleConfig{
+		NewRedactingRule("supporting", `\bsecret_\w+\b`, "[REDACTED]", ExtraConfig{IsSupportingRule: true}),
+	}
+
+	scanner, err := CreateScanner(rules)
+	if err == nil {
+		t.Fatal("creating scanner should fail when a supporting rule has a non-None match action")
+	}
+	if scanner != nil {
+		t.Fatal("on failed creation, the returned scanner should be nil")
+	}
+	if err != ErrInvalidSupportingRuleConfig {
+		t.Fatalf("expected ErrInvalidSupportingRuleConfig, got: %v", err)
+	}
+}

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -1079,7 +1079,7 @@ func TestCreateScannerFailsOnSupportingRuleWithMatchAction(t *testing.T) {
 	if scanner != nil {
 		t.Fatal("on failed creation, the returned scanner should be nil")
 	}
-	if err != ErrInvalidSupportingRuleConfig {
-		t.Fatalf("expected ErrInvalidSupportingRuleConfig, got: %v", err)
+	if err != ErrSupportingRuleHasMatchAction {
+		t.Fatalf("expected ErrSupportingRuleHasMatchAction, got: %v", err)
 	}
 }

--- a/sds/src/match_validation/http_validator_v2.rs
+++ b/sds/src/match_validation/http_validator_v2.rs
@@ -555,6 +555,7 @@ mod tests {
             match_validation_type: Some(MatchValidationType::CustomHttpV2(config)),
             suppressions: None,
             precedence: Precedence::default(),
+            is_supporting_rule: false,
         }
     }
 
@@ -1367,6 +1368,7 @@ calls:
                 match_validation_type: Some(MatchValidationType::CustomHttpV2(provider_config)),
                 suppressions: None,
                 precedence: Precedence::default(),
+                is_supporting_rule: false,
             },
             RootCompiledRule {
                 inner: Box::new(MockCompiledRule),
@@ -1384,6 +1386,7 @@ calls:
                 )),
                 suppressions: None,
                 precedence: Precedence::default(),
+                is_supporting_rule: false,
             },
         ];
 
@@ -1492,6 +1495,7 @@ match_pairing:
                 match_validation_type: Some(MatchValidationType::CustomHttpV2(config.clone())),
                 suppressions: None,
                 precedence: Precedence::default(),
+                is_supporting_rule: false,
             },
             RootCompiledRule {
                 inner: Box::new(MockCompiledRule),
@@ -1509,6 +1513,7 @@ match_pairing:
                 )),
                 suppressions: None,
                 precedence: Precedence::default(),
+                is_supporting_rule: false,
             },
         ];
 
@@ -1704,6 +1709,7 @@ match_pairing:
                 match_validation_type: Some(MatchValidationType::CustomHttpV2(config.clone())),
                 suppressions: None,
                 precedence: Precedence::default(),
+                is_supporting_rule: false,
             },
             RootCompiledRule {
                 inner: Box::new(MockCompiledRule),
@@ -1721,6 +1727,7 @@ match_pairing:
                 )),
                 suppressions: None,
                 precedence: Precedence::default(),
+                is_supporting_rule: false,
             },
         ];
 

--- a/sds/src/scanner/error.rs
+++ b/sds/src/scanner/error.rs
@@ -16,6 +16,7 @@ impl From<CreateScannerError> for i64 {
             CreateScannerError::InvalidMatchValidator(_) => -5,
             CreateScannerError::InvalidSuppressions(_) => -6,
             CreateScannerError::InvalidPatternCaptureGroups(_) => -7,
+            CreateScannerError::InvalidSupportingRuleConfig => -8,
         }
     }
 }
@@ -46,6 +47,9 @@ pub enum CreateScannerError {
     /// The pattern capture groups are invalid (too many capture groups, capture group not present, etc.)
     #[error(transparent)]
     InvalidPatternCaptureGroups(#[from] RegexPatternCaptureGroupsValidationError),
+    /// A supporting rule has a non-None match action, which is not allowed
+    #[error("Supporting rules cannot have a match action other than None")]
+    InvalidSupportingRuleConfig,
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]

--- a/sds/src/scanner/error.rs
+++ b/sds/src/scanner/error.rs
@@ -16,7 +16,7 @@ impl From<CreateScannerError> for i64 {
             CreateScannerError::InvalidMatchValidator(_) => -5,
             CreateScannerError::InvalidSuppressions(_) => -6,
             CreateScannerError::InvalidPatternCaptureGroups(_) => -7,
-            CreateScannerError::InvalidSupportingRuleConfig => -8,
+            CreateScannerError::SupportingRuleHasMatchAction => -8,
         }
     }
 }
@@ -49,7 +49,7 @@ pub enum CreateScannerError {
     InvalidPatternCaptureGroups(#[from] RegexPatternCaptureGroupsValidationError),
     /// A supporting rule has a non-None match action, which is not allowed
     #[error("Supporting rules cannot have a match action other than None")]
-    InvalidSupportingRuleConfig,
+    SupportingRuleHasMatchAction,
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -102,6 +102,8 @@ pub struct RootRuleConfig<T> {
     suppressions: Option<Suppressions>,
     #[serde(default)]
     precedence: Precedence,
+    #[serde(default)]
+    pub is_supporting_rule: bool,
     #[serde(flatten)]
     pub inner: T,
 }
@@ -129,6 +131,7 @@ impl<T> RootRuleConfig<T> {
             third_party_active_checker: None,
             suppressions: None,
             precedence: Precedence::default(),
+            is_supporting_rule: false,
             inner,
         }
     }
@@ -142,6 +145,7 @@ impl<T> RootRuleConfig<T> {
             third_party_active_checker: self.third_party_active_checker,
             suppressions: self.suppressions,
             precedence: self.precedence,
+            is_supporting_rule: self.is_supporting_rule,
             inner: func(self.inner),
         }
     }
@@ -174,6 +178,11 @@ impl<T> RootRuleConfig<T> {
         self
     }
 
+    pub fn is_supporting_rule(mut self, value: bool) -> Self {
+        self.is_supporting_rule = value;
+        self
+    }
+
     fn get_third_party_active_checker(&self) -> Option<&MatchValidationType> {
         #[allow(deprecated)]
         self.third_party_active_checker
@@ -196,6 +205,7 @@ pub struct RootCompiledRule {
     pub match_validation_type: Option<MatchValidationType>,
     pub suppressions: Option<CompiledSuppressions>,
     pub precedence: Precedence,
+    pub is_supporting_rule: bool,
 }
 
 impl RootCompiledRule {
@@ -694,6 +704,12 @@ impl Scanner {
             self.validate_matches(&mut output_rule_matches);
         }
 
+        // Supporting rules exist only to provide template variables to CustomHttpV2 validators of
+        // other rules. Their matches must not appear in the final output. They are retained above
+        // until after validate_matches so that match pairing can reference their match values.
+        output_rule_matches
+            .retain(|rule_match| !self.rules[rule_match.rule_index].is_supporting_rule);
+
         Ok((output_rule_matches, total_io_duration))
     }
 
@@ -1046,6 +1062,7 @@ impl ScannerBuilder<'_> {
                     match_validation_type: config.get_third_party_active_checker().cloned(),
                     suppressions: compiled_suppressions,
                     precedence: config.precedence,
+                    is_supporting_rule: config.is_supporting_rule,
                 })
             })
             .collect::<Result<Vec<RootCompiledRule>, CreateScannerError>>()?;

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -1050,7 +1050,7 @@ impl ScannerBuilder<'_> {
             .enumerate()
             .map(|(rule_index, config)| {
                 if config.is_supporting_rule && config.match_action != MatchAction::None {
-                    return Err(CreateScannerError::InvalidSupportingRuleConfig);
+                    return Err(CreateScannerError::SupportingRuleHasMatchAction);
                 }
                 let inner = config.convert_to_compiled_rule(rule_index, self.labels.clone())?;
                 config.match_action.validate()?;

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -1049,6 +1049,9 @@ impl ScannerBuilder<'_> {
             .iter()
             .enumerate()
             .map(|(rule_index, config)| {
+                if config.is_supporting_rule && config.match_action != MatchAction::None {
+                    return Err(CreateScannerError::InvalidSupportingRuleConfig);
+                }
                 let inner = config.convert_to_compiled_rule(rule_index, self.labels.clone())?;
                 config.match_action.validate()?;
                 let compiled_suppressions = match &config.suppressions {

--- a/sds/src/scanner/test/mod.rs
+++ b/sds/src/scanner/test/mod.rs
@@ -3,6 +3,7 @@ mod included_keywords;
 mod match_validation;
 mod metrics;
 mod overlapping_matches;
+mod supporting_rule;
 mod validators;
 
 use super::*;

--- a/sds/src/scanner/test/supporting_rule.rs
+++ b/sds/src/scanner/test/supporting_rule.rs
@@ -183,14 +183,16 @@ fn test_only_supporting_rule_matches_produces_empty_output() {
 /// Building a scanner with a supporting rule that has a non-None match action must fail.
 #[test]
 fn test_supporting_rule_with_match_action_is_rejected_at_build_time() {
-    let supporting_rule =
-        RootRuleConfig::new(RegexRuleConfig::new("\\bsecret_\\w+\\b").build())
-            .match_action(MatchAction::Redact {
-                replacement: "[REDACTED]".to_string(),
-            })
-            .is_supporting_rule(true);
+    let supporting_rule = RootRuleConfig::new(RegexRuleConfig::new("\\bsecret_\\w+\\b").build())
+        .match_action(MatchAction::Redact {
+            replacement: "[REDACTED]".to_string(),
+        })
+        .is_supporting_rule(true);
 
     let result = ScannerBuilder::new(&[supporting_rule]).build();
 
-    assert_eq!(result.err().unwrap(), CreateScannerError::InvalidSupportingRuleConfig);
+    assert_eq!(
+        result.err().unwrap(),
+        CreateScannerError::InvalidSupportingRuleConfig
+    );
 }

--- a/sds/src/scanner/test/supporting_rule.rs
+++ b/sds/src/scanner/test/supporting_rule.rs
@@ -1,5 +1,5 @@
 use crate::match_validation::config_v2::TemplatedMatchString;
-use crate::scanner::{RootRuleConfig, ScanOptionBuilder};
+use crate::scanner::{CreateScannerError, RootRuleConfig, ScanOptionBuilder};
 use crate::{
     CustomHttpConfigV2, HttpCallConfig, HttpMethod, HttpRequestConfig, HttpResponseConfig,
     MatchAction, MatchPairingConfig, MatchValidationType, PairedValidatorConfig, RegexRuleConfig,
@@ -159,4 +159,38 @@ fn test_is_supporting_rule_serialization_round_trip() {
     let json = serde_json::to_string(&config).unwrap();
     let deserialized: RootRuleConfig<RegexRuleConfig> = serde_json::from_str(&json).unwrap();
     assert!(deserialized.is_supporting_rule);
+}
+
+/// When only supporting rules match (no main rules match), the output must be empty.
+#[test]
+fn test_only_supporting_rule_matches_produces_empty_output() {
+    let supporting_rule =
+        RootRuleConfig::new(RegexRuleConfig::new("\\bsupporting_\\w+\\b").build())
+            .match_action(MatchAction::None)
+            .is_supporting_rule(true);
+
+    let scanner = ScannerBuilder::new(&[supporting_rule])
+        .with_return_matches(true)
+        .build()
+        .unwrap();
+
+    let mut content = "supporting_value".to_string();
+    let matches = scanner.scan(&mut content).unwrap();
+
+    assert!(matches.is_empty());
+}
+
+/// Building a scanner with a supporting rule that has a non-None match action must fail.
+#[test]
+fn test_supporting_rule_with_match_action_is_rejected_at_build_time() {
+    let supporting_rule =
+        RootRuleConfig::new(RegexRuleConfig::new("\\bsecret_\\w+\\b").build())
+            .match_action(MatchAction::Redact {
+                replacement: "[REDACTED]".to_string(),
+            })
+            .is_supporting_rule(true);
+
+    let result = ScannerBuilder::new(&[supporting_rule]).build();
+
+    assert_eq!(result.err().unwrap(), CreateScannerError::InvalidSupportingRuleConfig);
 }

--- a/sds/src/scanner/test/supporting_rule.rs
+++ b/sds/src/scanner/test/supporting_rule.rs
@@ -193,6 +193,6 @@ fn test_supporting_rule_with_match_action_is_rejected_at_build_time() {
 
     assert_eq!(
         result.err().unwrap(),
-        CreateScannerError::InvalidSupportingRuleConfig
+        CreateScannerError::SupportingRuleHasMatchAction
     );
 }

--- a/sds/src/scanner/test/supporting_rule.rs
+++ b/sds/src/scanner/test/supporting_rule.rs
@@ -12,9 +12,10 @@ use std::collections::BTreeMap;
 /// Supporting rules must not appear in scan output during a plain scan.
 #[test]
 fn test_supporting_rule_match_excluded_from_scan_output() {
-    let supporting_rule = RootRuleConfig::new(RegexRuleConfig::new("\\bsecret_prefix_\\w+\\b").build())
-        .match_action(MatchAction::None)
-        .is_supporting_rule(true);
+    let supporting_rule =
+        RootRuleConfig::new(RegexRuleConfig::new("\\bsecret_prefix_\\w+\\b").build())
+            .match_action(MatchAction::None)
+            .is_supporting_rule(true);
 
     let main_rule = RootRuleConfig::new(RegexRuleConfig::new("\\bmain_\\w+\\b").build())
         .match_action(MatchAction::None);
@@ -29,10 +30,7 @@ fn test_supporting_rule_match_excluded_from_scan_output() {
 
     // Only the main rule match should appear
     assert_eq!(matches.len(), 1);
-    assert_eq!(
-        matches[0].match_value,
-        Some("main_token".to_string())
-    );
+    assert_eq!(matches[0].match_value, Some("main_token".to_string()));
 }
 
 /// Supporting rules must not appear in scan output even when validate_matches is used.
@@ -50,53 +48,51 @@ fn test_supporting_rule_excluded_from_output_but_used_for_match_pairing() {
         then.status(200);
     });
 
-    let supporting_rule =
-        RootRuleConfig::new(RegexRuleConfig::new("\\b[a-z_]+_corp\\b").build())
-            .match_action(MatchAction::None)
-            .is_supporting_rule(true)
-            .third_party_active_checker(MatchValidationType::CustomHttpV2(CustomHttpConfigV2 {
-                provides: Some(vec![PairedValidatorConfig {
-                    kind: "vendor_xyz".to_string(),
-                    name: "client_subdomain".to_string(),
-                }]),
-                calls: vec![],
-                match_pairing: None,
-            }));
+    let supporting_rule = RootRuleConfig::new(RegexRuleConfig::new("\\b[a-z_]+_corp\\b").build())
+        .match_action(MatchAction::None)
+        .is_supporting_rule(true)
+        .third_party_active_checker(MatchValidationType::CustomHttpV2(CustomHttpConfigV2 {
+            provides: Some(vec![PairedValidatorConfig {
+                kind: "vendor_xyz".to_string(),
+                name: "client_subdomain".to_string(),
+            }]),
+            calls: vec![],
+            match_pairing: None,
+        }));
 
     let mut parameters = BTreeMap::new();
     parameters.insert("client_subdomain".to_string(), "$SUBDOMAIN".to_string());
 
-    let main_rule =
-        RootRuleConfig::new(RegexRuleConfig::new("\\bapi_key_[a-z0-9]+\\b").build())
-            .match_action(MatchAction::None)
-            .third_party_active_checker(MatchValidationType::CustomHttpV2(CustomHttpConfigV2 {
-                match_pairing: Some(MatchPairingConfig {
-                    kind: "vendor_xyz".to_string(),
-                    parameters,
-                }),
-                provides: None,
-                calls: vec![HttpCallConfig {
-                    request: HttpRequestConfig {
-                        endpoint: TemplatedMatchString(format!(
-                            "{}/validate?secret=$MATCH&subdomain=$SUBDOMAIN",
-                            server.base_url()
-                        )),
-                        method: HttpMethod::Get,
-                        hosts: vec![],
-                        headers: BTreeMap::new(),
+    let main_rule = RootRuleConfig::new(RegexRuleConfig::new("\\bapi_key_[a-z0-9]+\\b").build())
+        .match_action(MatchAction::None)
+        .third_party_active_checker(MatchValidationType::CustomHttpV2(CustomHttpConfigV2 {
+            match_pairing: Some(MatchPairingConfig {
+                kind: "vendor_xyz".to_string(),
+                parameters,
+            }),
+            provides: None,
+            calls: vec![HttpCallConfig {
+                request: HttpRequestConfig {
+                    endpoint: TemplatedMatchString(format!(
+                        "{}/validate?secret=$MATCH&subdomain=$SUBDOMAIN",
+                        server.base_url()
+                    )),
+                    method: HttpMethod::Get,
+                    hosts: vec![],
+                    headers: BTreeMap::new(),
+                    body: None,
+                    timeout: std::time::Duration::from_secs(3),
+                },
+                response: HttpResponseConfig {
+                    conditions: vec![ResponseCondition {
+                        condition_type: ResponseConditionType::Valid,
+                        status_code: Some(StatusCodeMatcher::Single(200)),
+                        raw_body: None,
                         body: None,
-                        timeout: std::time::Duration::from_secs(3),
-                    },
-                    response: HttpResponseConfig {
-                        conditions: vec![ResponseCondition {
-                            condition_type: ResponseConditionType::Valid,
-                            status_code: Some(StatusCodeMatcher::Single(200)),
-                            raw_body: None,
-                            body: None,
-                        }],
-                    },
-                }],
-            }));
+                    }],
+                },
+            }],
+        }));
 
     let scanner = ScannerBuilder::new(&[supporting_rule, main_rule])
         .with_return_matches(true)
@@ -159,8 +155,7 @@ fn test_is_supporting_rule_defaults_to_false_on_deserialization() {
 /// is_supporting_rule is correctly round-tripped through JSON serialization.
 #[test]
 fn test_is_supporting_rule_serialization_round_trip() {
-    let config = RootRuleConfig::new(RegexRuleConfig::new("hello"))
-        .is_supporting_rule(true);
+    let config = RootRuleConfig::new(RegexRuleConfig::new("hello")).is_supporting_rule(true);
     let json = serde_json::to_string(&config).unwrap();
     let deserialized: RootRuleConfig<RegexRuleConfig> = serde_json::from_str(&json).unwrap();
     assert!(deserialized.is_supporting_rule);

--- a/sds/src/scanner/test/supporting_rule.rs
+++ b/sds/src/scanner/test/supporting_rule.rs
@@ -1,0 +1,167 @@
+use crate::match_validation::config_v2::TemplatedMatchString;
+use crate::scanner::{RootRuleConfig, ScanOptionBuilder};
+use crate::{
+    CustomHttpConfigV2, HttpCallConfig, HttpMethod, HttpRequestConfig, HttpResponseConfig,
+    MatchAction, MatchPairingConfig, MatchValidationType, PairedValidatorConfig, RegexRuleConfig,
+    ResponseCondition, ResponseConditionType, ScannerBuilder, StatusCodeMatcher,
+};
+use httpmock::Method::GET;
+use httpmock::MockServer;
+use std::collections::BTreeMap;
+
+/// Supporting rules must not appear in scan output during a plain scan.
+#[test]
+fn test_supporting_rule_match_excluded_from_scan_output() {
+    let supporting_rule = RootRuleConfig::new(RegexRuleConfig::new("\\bsecret_prefix_\\w+\\b").build())
+        .match_action(MatchAction::None)
+        .is_supporting_rule(true);
+
+    let main_rule = RootRuleConfig::new(RegexRuleConfig::new("\\bmain_\\w+\\b").build())
+        .match_action(MatchAction::None);
+
+    let scanner = ScannerBuilder::new(&[supporting_rule, main_rule])
+        .with_return_matches(true)
+        .build()
+        .unwrap();
+
+    let mut content = "secret_prefix_abc and main_token".to_string();
+    let matches = scanner.scan(&mut content).unwrap();
+
+    // Only the main rule match should appear
+    assert_eq!(matches.len(), 1);
+    assert_eq!(
+        matches[0].match_value,
+        Some("main_token".to_string())
+    );
+}
+
+/// Supporting rules must not appear in scan output even when validate_matches is used.
+/// The supporting rule's match value must still be used to populate template variables
+/// for the main rule's HTTP call.
+#[test]
+fn test_supporting_rule_excluded_from_output_but_used_for_match_pairing() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/validate")
+            .query_param("secret", "api_key_abc123")
+            .query_param("subdomain", "acme_corp");
+        then.status(200);
+    });
+
+    let supporting_rule =
+        RootRuleConfig::new(RegexRuleConfig::new("\\b[a-z_]+_corp\\b").build())
+            .match_action(MatchAction::None)
+            .is_supporting_rule(true)
+            .third_party_active_checker(MatchValidationType::CustomHttpV2(CustomHttpConfigV2 {
+                provides: Some(vec![PairedValidatorConfig {
+                    kind: "vendor_xyz".to_string(),
+                    name: "client_subdomain".to_string(),
+                }]),
+                calls: vec![],
+                match_pairing: None,
+            }));
+
+    let mut parameters = BTreeMap::new();
+    parameters.insert("client_subdomain".to_string(), "$SUBDOMAIN".to_string());
+
+    let main_rule =
+        RootRuleConfig::new(RegexRuleConfig::new("\\bapi_key_[a-z0-9]+\\b").build())
+            .match_action(MatchAction::None)
+            .third_party_active_checker(MatchValidationType::CustomHttpV2(CustomHttpConfigV2 {
+                match_pairing: Some(MatchPairingConfig {
+                    kind: "vendor_xyz".to_string(),
+                    parameters,
+                }),
+                provides: None,
+                calls: vec![HttpCallConfig {
+                    request: HttpRequestConfig {
+                        endpoint: TemplatedMatchString(format!(
+                            "{}/validate?secret=$MATCH&subdomain=$SUBDOMAIN",
+                            server.base_url()
+                        )),
+                        method: HttpMethod::Get,
+                        hosts: vec![],
+                        headers: BTreeMap::new(),
+                        body: None,
+                        timeout: std::time::Duration::from_secs(3),
+                    },
+                    response: HttpResponseConfig {
+                        conditions: vec![ResponseCondition {
+                            condition_type: ResponseConditionType::Valid,
+                            status_code: Some(StatusCodeMatcher::Single(200)),
+                            raw_body: None,
+                            body: None,
+                        }],
+                    },
+                }],
+            }));
+
+    let scanner = ScannerBuilder::new(&[supporting_rule, main_rule])
+        .with_return_matches(true)
+        .build()
+        .unwrap();
+
+    let mut content = "subdomain: acme_corp, key: api_key_abc123".to_string();
+    let matches = scanner
+        .scan_with_options(
+            &mut content,
+            ScanOptionBuilder::new()
+                .with_validate_matching(true)
+                .build(),
+        )
+        .unwrap();
+
+    // The supporting rule match must not appear in output
+    assert!(
+        matches
+            .iter()
+            .all(|m| m.match_value.as_deref() != Some("acme_corp")),
+        "supporting rule match should not appear in output"
+    );
+
+    // The main rule match must appear
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].match_value, Some("api_key_abc123".to_string()));
+
+    // The HTTP mock was called, proving the template variable was resolved from the
+    // supporting rule's match even though that match is not in the output
+    mock.assert();
+}
+
+/// Non-supporting rules are unaffected and always appear in output.
+#[test]
+fn test_non_supporting_rule_always_in_output() {
+    let rule = RootRuleConfig::new(RegexRuleConfig::new("\\btoken_\\w+\\b").build())
+        .match_action(MatchAction::None);
+
+    let scanner = ScannerBuilder::new(&[rule])
+        .with_return_matches(true)
+        .build()
+        .unwrap();
+
+    let mut content = "token_abc123".to_string();
+    let matches = scanner.scan(&mut content).unwrap();
+
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].match_value, Some("token_abc123".to_string()));
+}
+
+/// is_supporting_rule must default to false when deserializing from JSON (Go FFI path).
+#[test]
+fn test_is_supporting_rule_defaults_to_false_on_deserialization() {
+    let json = r#"{"match_action":{"type":"None"},"pattern":"hello"}"#;
+    let config: RootRuleConfig<RegexRuleConfig> = serde_json::from_str(json).unwrap();
+    assert!(!config.is_supporting_rule);
+}
+
+/// is_supporting_rule is correctly round-tripped through JSON serialization.
+#[test]
+fn test_is_supporting_rule_serialization_round_trip() {
+    let config = RootRuleConfig::new(RegexRuleConfig::new("hello"))
+        .is_supporting_rule(true);
+    let json = serde_json::to_string(&config).unwrap();
+    let deserialized: RootRuleConfig<RegexRuleConfig> = serde_json::from_str(&json).unwrap();
+    assert!(deserialized.is_supporting_rule);
+}


### PR DESCRIPTION
Supporting rules exist solely to provide template variables to `CustomHttpV2` match validators of other rules via `match_pairing`. Their matches are retained during `validate_matches` so HTTP pairing can reference their values, then stripped from the final output.