### PR TITLE
Fix`libsds.scanner.total_regex_cache_size` metric

### DIFF
--- a/sds/src/scanner/regex_rule/regex_store.rs
+++ b/sds/src/scanner/regex_rule/regex_store.rs
@@ -127,10 +127,12 @@ impl RegexStore {
                 let shared_regex = Arc::new(regex);
 
                 let regex_cache = shared_regex.create_cache();
+                let cache_size = regex_cache.memory_usage() + std::mem::size_of::<Cache>();
                 let cache_key = self.key_map.insert(WeakSharedRegex {
                     regex: Arc::downgrade(&shared_regex),
-                    cache_size: regex_cache.memory_usage() + std::mem::size_of::<Cache>(),
+                    cache_size,
                 });
+                GLOBAL_STATS.add_total_regex_cache(cache_size as i64);
                 if let Some(old_cache_key) =
                     self.pattern_index.insert(pattern.to_owned(), cache_key)
                 {


### PR DESCRIPTION
[Jira](https://datadoghq.atlassian.net/browse/SDSP-177)

The `libsds.scanner.total_regex_cache_size` metric was sometimes showing invalid values (e.g. negative) due to not incrementing it correctly. This is now fixed. This did not impact the actual regex cache itself, only the metrics.