### PR TITLE
Add scan metadata

### DIFF
--- a/sds/Cargo.lock
+++ b/sds/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]

--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -31,7 +31,7 @@ ahash = "0.8.7"
 afl = { version = "0.14.5", optional = true }
 nom = "7.1.3"
 regex = "1.9.5"
-regex-automata = "0.4.7"
+regex-automata = "0.4.13"
 regex-syntax = "0.7.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_path_to_error = { version = "0.1.17", optional = true }

--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -27,7 +27,7 @@ hyperscan = ["sds-fuzz", "dep:hyperscan"]
 manual_test = ["sds-fuzz"]
 
 [dependencies]
-ahash = "0.8.7"
+ahash = { version = "0.8.7", features = ["serde"] }
 afl = { version = "0.14.5", optional = true }
 nom = "7.1.3"
 regex = "1.9.5"

--- a/sds/src/native/scan.rs
+++ b/sds/src/native/scan.rs
@@ -3,6 +3,8 @@ use std::ffi::c_void;
 use std::slice;
 use std::sync::Arc;
 
+use ahash::AHashMap;
+
 use crate::bindings_utils::{BinaryEvent, encode_response};
 use crate::{ScanOptionBuilder, Scanner, Utf8Encoding};
 
@@ -67,6 +69,83 @@ pub unsafe extern "C" fn scan(
             let c_str = std::ffi::CString::new(error.message).unwrap_or(
                 // The error message contained null bytes, which shouldn't really happen,
                 // but just in case.
+                std::ffi::CString::new("Rust panicked. No more information is available.").unwrap(),
+            );
+            unsafe {
+                let raw = c_str.into_raw();
+                *error_out = raw;
+                *retsize = 0;
+                *retcapacity = 0;
+            }
+            std::ptr::null::<c_char>()
+        }
+    }
+}
+
+/// Like `scan`, but accepts an additional null-terminated JSON string of key-value scan metadata
+/// (e.g. `{"org_id":"123"}`). The metadata is forwarded to each rule via
+/// `StringMatchesCtx::scan_metadata`. Pass an empty JSON object (`{}`) when no metadata is needed.
+///
+/// # Safety
+///
+/// Same requirements as `scan`. Additionally, `scan_metadata_json` must be a valid null-terminated
+/// UTF-8 string containing a JSON object.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn scan_v2(
+    scanner_id: i64,
+    event: *const c_void,
+    event_size: i64,
+    retsize: *mut i64,
+    retcapacity: *mut i64,
+    error_out: *mut *const c_char,
+    with_validate_matching: i32,
+    scan_metadata_json: *const c_char,
+) -> *const c_char {
+    match convert_panic_to_go_error(|| {
+        let scanner =
+            std::mem::ManuallyDrop::new(unsafe { Arc::from_raw(scanner_id as *mut Scanner) });
+
+        let data = unsafe { slice::from_raw_parts(event.cast(), event_size as usize) }.to_vec();
+
+        let mut event = BinaryEvent::<Utf8Encoding>::new(data, false, None);
+
+        let scan_metadata: AHashMap<String, String> = if scan_metadata_json.is_null() {
+            AHashMap::new()
+        } else {
+            let cstr = unsafe { std::ffi::CStr::from_ptr(scan_metadata_json) };
+            serde_json::from_str(cstr.to_str().unwrap_or("{}")).unwrap_or_default()
+        };
+
+        let scan_options = ScanOptionBuilder::new()
+            .with_validate_matching(with_validate_matching != 0)
+            .with_scan_metadata(scan_metadata)
+            .build();
+        let matches = scanner.scan_with_options(&mut event, scan_options);
+
+        if let Some(encoded_response) =
+            encode_response(&event.storage, matches.as_deref(), false, false)
+        {
+            let mut str = std::mem::ManuallyDrop::new(encoded_response);
+            let len = str.len() as i64;
+            let cap = str.capacity() as i64;
+
+            unsafe {
+                *retsize = len;
+                *retcapacity = cap;
+            };
+
+            str.as_mut_ptr() as *const c_char
+        } else {
+            unsafe {
+                *retsize = 0;
+                *retcapacity = 0;
+            }
+            std::ptr::null::<c_char>()
+        }
+    }) {
+        Ok(ptr) => ptr,
+        Err(error) => {
+            let c_str = std::ffi::CString::new(error.message).unwrap_or(
                 std::ffi::CString::new("Rust panicked. No more information is available.").unwrap(),
             );
             unsafe {

--- a/sds/src/native/scan.rs
+++ b/sds/src/native/scan.rs
@@ -93,7 +93,6 @@ pub unsafe extern "C" fn scan(
     }
 }
 
-
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn free_vec(ptr: *const c_char, len: i64, cap: i64) {
     unsafe {

--- a/sds/src/native/scan.rs
+++ b/sds/src/native/scan.rs
@@ -15,6 +15,9 @@ use super::convert_panic_to_go_error;
 /// This function makes use of `slice::from_raw_parts` which is unsafe as it dereferences a pointer to a c_void.
 /// It also dereferences `retsize` and `retcapacity` which are pointers to i64.
 /// The caller must ensure that the pointers are valid.
+/// `scan_metadata_json` may be null (no metadata) or a null-terminated UTF-8 JSON object string
+/// (e.g. `{"org_id":"123"}`). The metadata is forwarded to each rule via
+/// `StringMatchesCtx::scan_metadata`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn scan(
     scanner_id: i64,
@@ -24,6 +27,7 @@ pub unsafe extern "C" fn scan(
     retcapacity: *mut i64,
     error_out: *mut *const c_char,
     with_validate_matching: i32,
+    scan_metadata_json: *const c_char,
 ) -> *const c_char {
     match convert_panic_to_go_error(|| {
         let scanner =
@@ -34,9 +38,16 @@ pub unsafe extern "C" fn scan(
 
         let mut event = BinaryEvent::<Utf8Encoding>::new(data, false, None);
 
-        // TODO: we might want to forward the error to go in the future
+        let scan_metadata: AHashMap<String, String> = if scan_metadata_json.is_null() {
+            AHashMap::new()
+        } else {
+            let cstr = unsafe { std::ffi::CStr::from_ptr(scan_metadata_json) };
+            serde_json::from_str(cstr.to_str().unwrap_or("{}")).unwrap_or_default()
+        };
+
         let scan_options = ScanOptionBuilder::new()
             .with_validate_matching(with_validate_matching != 0)
+            .with_scan_metadata(scan_metadata)
             .build();
         let matches = scanner.scan_with_options(&mut event, scan_options);
 
@@ -82,82 +93,6 @@ pub unsafe extern "C" fn scan(
     }
 }
 
-/// Like `scan`, but accepts an additional null-terminated JSON string of key-value scan metadata
-/// (e.g. `{"org_id":"123"}`). The metadata is forwarded to each rule via
-/// `StringMatchesCtx::scan_metadata`. Pass an empty JSON object (`{}`) when no metadata is needed.
-///
-/// # Safety
-///
-/// Same requirements as `scan`. Additionally, `scan_metadata_json` must be a valid null-terminated
-/// UTF-8 string containing a JSON object.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn scan_v2(
-    scanner_id: i64,
-    event: *const c_void,
-    event_size: i64,
-    retsize: *mut i64,
-    retcapacity: *mut i64,
-    error_out: *mut *const c_char,
-    with_validate_matching: i32,
-    scan_metadata_json: *const c_char,
-) -> *const c_char {
-    match convert_panic_to_go_error(|| {
-        let scanner =
-            std::mem::ManuallyDrop::new(unsafe { Arc::from_raw(scanner_id as *mut Scanner) });
-
-        let data = unsafe { slice::from_raw_parts(event.cast(), event_size as usize) }.to_vec();
-
-        let mut event = BinaryEvent::<Utf8Encoding>::new(data, false, None);
-
-        let scan_metadata: AHashMap<String, String> = if scan_metadata_json.is_null() {
-            AHashMap::new()
-        } else {
-            let cstr = unsafe { std::ffi::CStr::from_ptr(scan_metadata_json) };
-            serde_json::from_str(cstr.to_str().unwrap_or("{}")).unwrap_or_default()
-        };
-
-        let scan_options = ScanOptionBuilder::new()
-            .with_validate_matching(with_validate_matching != 0)
-            .with_scan_metadata(scan_metadata)
-            .build();
-        let matches = scanner.scan_with_options(&mut event, scan_options);
-
-        if let Some(encoded_response) =
-            encode_response(&event.storage, matches.as_deref(), false, false)
-        {
-            let mut str = std::mem::ManuallyDrop::new(encoded_response);
-            let len = str.len() as i64;
-            let cap = str.capacity() as i64;
-
-            unsafe {
-                *retsize = len;
-                *retcapacity = cap;
-            };
-
-            str.as_mut_ptr() as *const c_char
-        } else {
-            unsafe {
-                *retsize = 0;
-                *retcapacity = 0;
-            }
-            std::ptr::null::<c_char>()
-        }
-    }) {
-        Ok(ptr) => ptr,
-        Err(error) => {
-            let c_str = std::ffi::CString::new(error.message).unwrap_or(
-                std::ffi::CString::new("Rust panicked. No more information is available.").unwrap(),
-            );
-            unsafe {
-                let raw = c_str.into_raw();
-                *error_out = raw;
-                *retsize = 0;
-                *retcapacity = 0;
-            }
-            std::ptr::null::<c_char>()
-        }
-    }
-}
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn free_vec(ptr: *const c_char, len: i64, cap: i64) {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -238,6 +238,9 @@ pub struct StringMatchesCtx<'a> {
     pub per_scanner_data: &'a SharedData,
     pub per_event_data: &'a mut SharedData,
     pub event_id: Option<&'a str>,
+
+    // Per-scan metadata supplied by the caller via `ScanOptions::scan_metadata`.
+    pub scan_metadata: &'a AHashMap<String, String>,
 }
 
 impl StringMatchesCtx<'_> {
@@ -406,6 +409,10 @@ pub struct ScanOptions {
     // Whether to validate matches using third-party validators (e.g., checksum validation for credit cards).
     // When enabled, the scanner automatically collects match content needed for validation.
     pub validate_matches: bool,
+    // Arbitrary key-value metadata passed through to each rule's `get_string_matches` call via
+    // `StringMatchesCtx::scan_metadata`. Rules may use this to receive per-scan context (e.g.
+    // an org identifier) without requiring changes to the `CompiledRule` trait signature.
+    pub scan_metadata: AHashMap<String, String>,
 }
 
 impl Default for ScanOptions {
@@ -414,6 +421,7 @@ impl Default for ScanOptions {
             blocked_rules_idx: vec![],
             wildcarded_indices: AHashMap::new(),
             validate_matches: false,
+            scan_metadata: AHashMap::new(),
         }
     }
 }
@@ -422,6 +430,7 @@ pub struct ScanOptionBuilder {
     blocked_rules_idx: Vec<usize>,
     wildcarded_indices: AHashMap<Path<'static>, Vec<(usize, usize)>>,
     validate_matches: bool,
+    scan_metadata: AHashMap<String, String>,
 }
 
 impl ScanOptionBuilder {
@@ -430,6 +439,7 @@ impl ScanOptionBuilder {
             blocked_rules_idx: vec![],
             wildcarded_indices: AHashMap::new(),
             validate_matches: false,
+            scan_metadata: AHashMap::new(),
         }
     }
 
@@ -451,11 +461,17 @@ impl ScanOptionBuilder {
         self
     }
 
+    pub fn with_scan_metadata(mut self, scan_metadata: AHashMap<String, String>) -> Self {
+        self.scan_metadata = scan_metadata;
+        self
+    }
+
     pub fn build(self) -> ScanOptions {
         ScanOptions {
             blocked_rules_idx: self.blocked_rules_idx,
             wildcarded_indices: self.wildcarded_indices,
             validate_matches: self.validate_matches,
+            scan_metadata: self.scan_metadata,
         }
     }
 }
@@ -681,6 +697,7 @@ impl Scanner {
                     wildcarded_indexes: &options.wildcarded_indices,
                     async_jobs: &mut async_jobs,
                     event_id: event.get_id().map(|s| s.to_string()),
+                    scan_metadata: &options.scan_metadata,
                 },
             )
         })?;
@@ -1129,6 +1146,7 @@ struct ScannerContentVisitor<'a, E: Encoding> {
     wildcarded_indexes: &'a AHashMap<Path<'static>, Vec<(usize, usize)>>,
     async_jobs: &'a mut Vec<PendingRuleJob>,
     event_id: Option<String>,
+    scan_metadata: &'a AHashMap<String, String>,
 }
 
 impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
@@ -1189,6 +1207,7 @@ impl<'a, E: Encoding> ContentVisitor<'a> for ScannerContentVisitor<'a, E> {
                     per_scanner_data: &self.scanner.per_scanner_data,
                     per_event_data: &mut self.per_event_data,
                     event_id: self.event_id.as_deref(),
+                    scan_metadata: self.scan_metadata,
                 };
 
                 let async_status = rule.get_string_matches(content, path, &mut ctx)?;


### PR DESCRIPTION
[Jira](https://datadoghq.atlassian.net/browse/SDSP-363)

Allow setting arbitrary metadata during scans, which can be used by scanning rules. This is intentionally generic so new values can be added in the future with no library changes.