### PR TITLE
fix(scanner): prevent stack overflow when validating on a Rayon worker

### DIFF
--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -791,7 +791,7 @@ impl Scanner {
                 );
             };
 
-            // TODO(validation): move validation onto the async TOKIO_RUNTIME. It is I/O-bound
+            // TODO(SDSP-450): move validation onto the async TOKIO_RUNTIME. It is I/O-bound
             // (blocking HTTP to third-party checkers), so a Rayon (CPU-bound) pool is a poor
             // fit and forces the workaround below. Async validation would remove it entirely.
             //

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -773,20 +773,42 @@ impl Scanner {
             }
         }
 
-        RAYON_THREAD_POOL.install(|| {
-            use rayon::prelude::*;
+        // Skip the pool hop when there's nothing to validate.
+        if !match_validator_rule_match_per_type.is_empty() {
+            let run_validation = || {
+                use rayon::prelude::*;
 
-            match_validator_rule_match_per_type.par_iter_mut().for_each(
-                |(match_validation_type, matches_per_type)| {
-                    let match_validator = self.match_validators_per_type.get(match_validation_type);
-                    if let Some(match_validator) = match_validator {
-                        match_validator
-                            .as_ref()
-                            .validate(matches_per_type, &self.rules)
-                    }
-                },
-            );
-        });
+                match_validator_rule_match_per_type.par_iter_mut().for_each(
+                    |(match_validation_type, matches_per_type)| {
+                        let match_validator =
+                            self.match_validators_per_type.get(match_validation_type);
+                        if let Some(match_validator) = match_validator {
+                            match_validator
+                                .as_ref()
+                                .validate(matches_per_type, &self.rules)
+                        }
+                    },
+                );
+            };
+
+            // TODO(validation): move validation onto the async TOKIO_RUNTIME. It is I/O-bound
+            // (blocking HTTP to third-party checkers), so a Rayon (CPU-bound) pool is a poor
+            // fit and forces the workaround below. Async validation would remove it entirely.
+            //
+            // If we're already on a Rayon worker (e.g. the caller scans from its own parallel
+            // iterator), calling `install` here blocks the worker, and Rayon keeps it busy by
+            // stealing more of the caller's jobs — which scan and validate and steal again,
+            // recursing until the stack overflows. Running `install` on a separate OS thread
+            // parks this worker instead, breaking the recursion; validation still runs in
+            // parallel on RAYON_THREAD_POOL.
+            if rayon::current_thread_index().is_some() {
+                std::thread::scope(|s| {
+                    s.spawn(|| RAYON_THREAD_POOL.install(run_validation));
+                });
+            } else {
+                RAYON_THREAD_POOL.install(run_validation);
+            }
+        }
 
         // Refill the rule_matches with the validated matches
         for (_, mut matches) in match_validator_rule_match_per_type {

--- a/sds/src/scanner/test/parallel_scan.rs
+++ b/sds/src/scanner/test/parallel_scan.rs
@@ -40,3 +40,99 @@ fn test_parallel_scan_with_validate_does_not_panic() {
         }
     });
 }
+
+/// Regression test for the stack overflow fixed in `Scanner::validate_matches`.
+///
+/// When a validated scan runs on a Rayon worker (e.g. the caller scans via `into_par_iter`),
+/// `validate_matches` blocks the worker on `install`, and Rayon keeps it busy by stealing the
+/// next scan job and running it on the same stack — recursing until the stack overflows.
+///
+/// Forcing an actual overflow needs thousands of frames (flaky in a unit test), so we assert
+/// the invariant instead: a validated scan on a Rayon worker must never re-enter another scan
+/// on the same thread. The validator delay keeps the worker blocked long enough to steal a
+/// sibling job if the fix regresses.
+#[test]
+fn test_rayon_parallel_scan_with_validate_does_not_reenter_on_same_thread() {
+    use crate::match_validation::config::HttpStatusCodeRange;
+    use crate::{CustomHttpConfig, MatchValidationType};
+    use httpmock::Method::GET;
+    use httpmock::MockServer;
+    use rayon::prelude::*;
+    use std::cell::Cell;
+    use std::collections::BTreeMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    let server = MockServer::start();
+    // Delay the response so the calling worker stays blocked long enough to steal a sibling job
+    // if the recursion regresses.
+    let _mock = server.mock(|when, then| {
+        when.method(GET).path("/");
+        then.status(200).delay(Duration::from_millis(25));
+    });
+
+    let http_config = CustomHttpConfig::default()
+        .with_endpoint(server.url("/").to_string())
+        .with_request_headers(BTreeMap::from([(
+            "authorization".to_string(),
+            "Bearer $MATCH".to_string(),
+        )]))
+        .with_valid_http_status_code(vec![HttpStatusCodeRange {
+            start: 200,
+            end: 300,
+        }]);
+
+    let scanner = std::sync::Arc::new(
+        ScannerBuilder::new(&[RootRuleConfig::new(
+            RegexRuleConfig::new("\\bsecret_match\\b").build(),
+        )
+        .match_action(MatchAction::None)
+        .third_party_active_checker(MatchValidationType::CustomHttp(http_config))])
+        .with_return_matches(true)
+        .build()
+        .unwrap(),
+    );
+
+    thread_local! {
+        // Set while this thread is inside a scan below; a stolen scan re-enters with it set.
+        static IN_SCAN: Cell<bool> = const { Cell::new(false) };
+    }
+    static REENTRANCIES: AtomicUsize = AtomicUsize::new(0);
+
+    let inputs: Vec<String> = (0..128)
+        .map(|i| format!("event {i} has a secret_match in it"))
+        .collect();
+
+    // par_iter runs each scan on a Rayon worker — the context that triggered the recursion.
+    let oks = inputs
+        .par_iter()
+        .map(|input| {
+            let already_scanning = IN_SCAN.with(|f| f.replace(true));
+            if already_scanning {
+                REENTRANCIES.fetch_add(1, Ordering::Relaxed);
+            }
+
+            let mut event = input.clone();
+            let ok = scanner
+                .scan_with_options(
+                    &mut event,
+                    ScanOptionBuilder::new()
+                        .with_validate_matching(true)
+                        .build(),
+                )
+                .is_ok();
+
+            IN_SCAN.with(|f| f.set(already_scanning));
+            ok
+        })
+        .filter(|ok| *ok)
+        .count();
+
+    assert_eq!(oks, inputs.len(), "every validated scan should complete");
+    assert_eq!(
+        REENTRANCIES.load(Ordering::Relaxed),
+        0,
+        "a validated scan re-entered another scan on the same Rayon worker — the \
+         validate_matches work-stealing recursion has regressed"
+    );
+}


### PR DESCRIPTION
## What

Fixes a stack overflow in `Scanner::validate_matches` when a validated scan is driven from a Rayon worker thread ([#incident-56036](https://dd.enterprise.slack.com/archives/C0B9WNU89J6)).

## Why

When a caller scans many inputs from its own Rayon parallel iterator (e.g. `datadog-static-analyzer` scanning files via `into_par_iter`) with validation enabled, each scan calls `validate_matches`, which blocks the worker on `RAYON_THREAD_POOL.install`. A blocked Rayon worker does not idle — it keeps busy by **stealing more jobs from the caller's pool**. Those stolen jobs are themselves scans that validate, block, and steal again, so `scan -> validate` re-enters on the **same stack** once per queued item. The nesting grows with the number of queued inputs, and overflows the stack.

This was reproduced scanning a large monorepo with secrets validation enabled; an `lldb` backtrace showed the repeating `find_secrets -> scan_with_options -> validate_matches -> install -> (stolen) find_secrets -> …` cycle.

## How

- When already running on a Rayon worker (`rayon::current_thread_index().is_some()`), run the validation `install` on a separate OS thread and join it. Joining **parks** the worker instead of letting it steal, breaking the recursion. Validation still runs in parallel on `RAYON_THREAD_POOL`.
- Skip the pool hop entirely when there are no matches to validate (also avoids a needless `install` per scan on the common zero-match path).

## Tests

Adds `test_rayon_parallel_scan_with_validate_does_not_reenter_on_same_thread`, which drives validated scans through a Rayon parallel iterator and asserts a scan never re-enters another scan on the same thread (the re-entrancy that the overflow is a consequence of). A small validator delay keeps the worker blocked long enough to steal a sibling job if the fix regresses.

Verified the test **fails** on the pre-fix path (112 re-entrancies detected) and **passes** with the fix (0).

Additionally, rebuilt `datadog-static-analyzer` against this branch and re-ran scanning a large monorepo with secrets validation enabled which now completes successfully with no stack overflow.

## Reviewer notes

A `TODO` documents the proper long-term fix: move validation onto the async `TOKIO_RUNTIME`, since validation is I/O-bound (blocking HTTP to third-party checkers)