### PR TITLE
docs(agents): require simple fake regex patterns in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Key files:
 - Test edge cases, error conditions, and happy paths
 - Ensure tests are maintainable and clearly named
 - Each test should validate one specific behavior
+- **Always use simple, fake regex patterns in tests** (e.g. `"secret"`, `"foo"`, `"[0-9]+"`) — never real production regexes. A reader should understand what a test asserts without decoding a complex pattern. It is always possible to construct a simple regex that exercises any edge case.
 
 ## Maintenance
 


### PR DESCRIPTION
What does this PR do?
---------------------

Adds a testing guideline to AGENTS.md requiring that all tests use simple, fake regex patterns (e.g. `"secret"`, `"foo"`, `"[0-9]+"`) rather than real production regexes. This improves test readability by ensuring a reader can immediately understand what a test is asserting without having to decode a complex pattern.

---

This guidance applies to all agent-assisted (and human-written!) tests in the repository.