### PR TITLE
feat(scanner): group adjacent rule matches

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -106,9 +106,9 @@ pub use scanner::shared_pool::{SharedPool, SharedPoolGuard};
 pub use scanner::suppression::Suppressions;
 #[cfg(feature = "dd-sds")]
 pub use scanner::{
-    CompiledRule, MatchEmitter, Precedence, RootCompiledRule, RootRuleConfig, RuleResult,
-    RuleStatus, ScanOptionBuilder, Scanner, ScannerBuilder, SharedData, StringMatch,
-    StringMatchesCtx,
+    CompiledRule, MatchEmitter, MatchGroupingStrategy, Precedence, RootCompiledRule,
+    RootRuleConfig, RuleResult, RuleStatus, ScanOptionBuilder, Scanner, ScannerBuilder, SharedData,
+    StringMatch, StringMatchesCtx,
     config::RuleConfig,
     error::{CreateScannerError, ScannerError},
     regex_rule::config::{

--- a/sds/src/match_validation/http_validator_v2.rs
+++ b/sds/src/match_validation/http_validator_v2.rs
@@ -513,7 +513,8 @@ mod tests {
     use std::{collections::BTreeMap, time::Duration};
 
     use crate::{
-        CompiledRule, MatchAction, Path, Precedence, ReplacementType, RootCompiledRule, Scope,
+        CompiledRule, MatchAction, MatchGroupingStrategy, Path, Precedence, ReplacementType,
+        RootCompiledRule, Scope,
         match_validation::config_v2::{
             BodyMatcher, CustomHttpConfigV2, StatusCodeMatcher, TemplatedMatchString,
         },
@@ -556,6 +557,7 @@ mod tests {
             suppressions: None,
             precedence: Precedence::default(),
             is_supporting_rule: false,
+            match_grouping: MatchGroupingStrategy::default(),
         }
     }
 
@@ -1369,6 +1371,7 @@ calls:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                match_grouping: MatchGroupingStrategy::default(),
             },
             RootCompiledRule {
                 inner: Box::new(MockCompiledRule),
@@ -1387,6 +1390,7 @@ calls:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                match_grouping: MatchGroupingStrategy::default(),
             },
         ];
 
@@ -1496,6 +1500,7 @@ match_pairing:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                match_grouping: MatchGroupingStrategy::default(),
             },
             RootCompiledRule {
                 inner: Box::new(MockCompiledRule),
@@ -1514,6 +1519,7 @@ match_pairing:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                match_grouping: MatchGroupingStrategy::default(),
             },
         ];
 
@@ -1710,6 +1716,7 @@ match_pairing:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                match_grouping: MatchGroupingStrategy::default(),
             },
             RootCompiledRule {
                 inner: Box::new(MockCompiledRule),
@@ -1728,6 +1735,7 @@ match_pairing:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                match_grouping: MatchGroupingStrategy::default(),
             },
         ];
 

--- a/sds/src/scanner/config.rs
+++ b/sds/src/scanner/config.rs
@@ -1,5 +1,5 @@
 use crate::scanner::error::CreateScannerError;
-use crate::{CompiledRule, Labels, RegexRuleConfig};
+use crate::{CompiledRule, Labels, MatchGroupingStrategy, RegexRuleConfig};
 
 pub trait RuleConfig: Send + Sync {
     fn convert_to_compiled_rule(
@@ -10,5 +10,9 @@ pub trait RuleConfig: Send + Sync {
 
     fn as_regex_rule(&self) -> Option<&RegexRuleConfig> {
         None
+    }
+
+    fn default_match_grouping(&self) -> MatchGroupingStrategy {
+        MatchGroupingStrategy::Disabled
     }
 }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -90,6 +90,15 @@ pub enum Precedence {
     Specific,
 }
 
+/// Controls whether adjacent matches from the same rule should be merged into one span.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Copy, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MatchGroupingStrategy {
+    #[default]
+    Disabled,
+    AdjacentWhitespace,
+}
+
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct RootRuleConfig<T> {
@@ -198,6 +207,12 @@ impl<T> Deref for RootRuleConfig<T> {
         &self.inner
     }
 }
+
+impl RootRuleConfig<Arc<dyn RuleConfig>> {
+    fn resolved_match_grouping(&self) -> MatchGroupingStrategy {
+        self.inner.default_match_grouping()
+    }
+}
 pub struct RootCompiledRule {
     pub inner: Box<dyn CompiledRule>,
     pub scope: Scope,
@@ -206,6 +221,7 @@ pub struct RootCompiledRule {
     pub suppressions: Option<CompiledSuppressions>,
     pub precedence: Precedence,
     pub is_supporting_rule: bool,
+    pub match_grouping: MatchGroupingStrategy,
 }
 
 impl RootCompiledRule {
@@ -651,6 +667,8 @@ impl Scanner {
 
                     self.suppress_matches::<E::Encoding>(&mut rule_matches, content, regex_caches);
 
+                    self.group_adjacent_rule_matches::<E::Encoding>(&mut rule_matches, content);
+
                     self.sort_and_remove_overlapping_rules::<E::Encoding>(&mut rule_matches);
 
                     let will_mutate = rule_matches.iter().any(|rule_match| {
@@ -751,6 +769,40 @@ impl Scanner {
                 true
             }
         });
+    }
+
+    fn group_adjacent_rule_matches<E: Encoding>(
+        &self,
+        rule_matches: &mut Vec<InternalRuleMatch<E>>,
+        content: &str,
+    ) {
+        if rule_matches.len() <= 1 {
+            return;
+        }
+
+        let mut grouped: Vec<InternalRuleMatch<E>> = Vec::with_capacity(rule_matches.len());
+
+        for current in rule_matches.drain(..) {
+            if let Some(last) = grouped.last_mut()
+                && self.rules[last.rule_index].match_grouping
+                    == MatchGroupingStrategy::AdjacentWhitespace
+                && last.rule_index == current.rule_index
+                && last.utf8_end < current.utf8_start
+                && content[last.utf8_end..current.utf8_start]
+                    .chars()
+                    .all(|c| c.is_whitespace())
+            {
+                last.utf8_end = current.utf8_end;
+                last.custom_end = current.custom_end;
+                if last.keyword.is_none() {
+                    last.keyword = current.keyword;
+                }
+                continue;
+            }
+            grouped.push(current);
+        }
+
+        *rule_matches = grouped;
     }
 
     pub fn validate_matches(&self, rule_matches: &mut Vec<RuleMatch>) {
@@ -1119,6 +1171,7 @@ impl ScannerBuilder<'_> {
                     suppressions: compiled_suppressions,
                     precedence: config.precedence,
                     is_supporting_rule: config.is_supporting_rule,
+                    match_grouping: config.resolved_match_grouping(),
                 })
             })
             .collect::<Result<Vec<RootCompiledRule>, CreateScannerError>>()?;

--- a/sds/src/scanner/test/match_grouping.rs
+++ b/sds/src/scanner/test/match_grouping.rs
@@ -1,0 +1,95 @@
+use crate::{
+    CompiledRule, CreateScannerError, Labels, MatchAction, MatchGroupingStrategy, Path,
+    RootRuleConfig, RuleConfig, RuleResult, RuleStatus, ScannerBuilder, StringMatch,
+    StringMatchesCtx,
+};
+use std::sync::Arc;
+
+struct NameLikeRuleConfig {
+    match_grouping: MatchGroupingStrategy,
+}
+
+struct NameLikeCompiledRule;
+
+impl CompiledRule for NameLikeCompiledRule {
+    fn get_string_matches(
+        &self,
+        content: &str,
+        _path: &Path,
+        ctx: &mut StringMatchesCtx,
+    ) -> RuleResult {
+        for word in ["John", "Smith"] {
+            if let Some(start) = content.find(word) {
+                ctx.match_emitter.emit(StringMatch {
+                    start,
+                    end: start + word.len(),
+                    keyword: None,
+                });
+            }
+        }
+        Ok(RuleStatus::Done)
+    }
+}
+
+impl RuleConfig for NameLikeRuleConfig {
+    fn convert_to_compiled_rule(
+        &self,
+        _rule_index: usize,
+        _labels: Labels,
+    ) -> Result<Box<dyn CompiledRule>, CreateScannerError> {
+        Ok(Box::new(NameLikeCompiledRule))
+    }
+
+    fn default_match_grouping(&self) -> MatchGroupingStrategy {
+        self.match_grouping
+    }
+}
+
+fn build_scanner(match_grouping: MatchGroupingStrategy) -> crate::Scanner {
+    let rule_config =
+        RootRuleConfig::new(Arc::new(NameLikeRuleConfig { match_grouping }) as Arc<dyn RuleConfig>)
+            .match_action(MatchAction::Redact {
+                replacement: "[REDACTED]".to_string(),
+            });
+
+    ScannerBuilder::new(&[rule_config])
+        .with_return_matches(true)
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn groups_whitespace_separated_matches_when_rule_opts_in() {
+    let scanner = build_scanner(MatchGroupingStrategy::AdjacentWhitespace);
+    let mut content = "John Smith".to_string();
+
+    let matches = scanner.scan(&mut content).unwrap();
+
+    assert_eq!(content, "[REDACTED]");
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].start_index, 0);
+    assert_eq!(matches[0].end_index_exclusive, 10);
+    assert_eq!(matches[0].match_value, Some("John Smith".to_string()));
+}
+
+#[test]
+fn leaves_whitespace_separated_matches_split_by_default() {
+    let scanner = build_scanner(MatchGroupingStrategy::Disabled);
+    let mut content = "John Smith".to_string();
+
+    let matches = scanner.scan(&mut content).unwrap();
+
+    assert_eq!(content, "[REDACTED] [REDACTED]");
+    assert_eq!(matches.len(), 2);
+}
+
+#[test]
+fn does_not_group_non_whitespace_separated_matches() {
+    let scanner = build_scanner(MatchGroupingStrategy::AdjacentWhitespace);
+    let mut content = "John, Smith".to_string();
+
+    let matches = scanner.scan(&mut content).unwrap();
+
+    assert_eq!(content, "[REDACTED], [REDACTED]");
+    assert_eq!(matches.len(), 2);
+}

--- a/sds/src/scanner/test/mod.rs
+++ b/sds/src/scanner/test/mod.rs
@@ -1,5 +1,6 @@
 mod async_rule;
 mod included_keywords;
+mod match_grouping;
 mod match_validation;
 mod metrics;
 mod overlapping_matches;


### PR DESCRIPTION
## Summary
- Add an opt-in match grouping strategy for merging whitespace-separated matches from the same rule.
- Apply grouping before overlap handling and mutation so grouped spans redact as a single match.
- Add scanner tests covering opted-in grouping, default disabled behavior, and non-whitespace separation.

## Test plan
- cargo test --manifest-path "sds/Cargo.toml" scanner::test::match_grouping

## Notes
- Human Name Scanner enablement lives in the separate sds-shared-library repo and is not included in this PR.