### PR TITLE
[DSEC-112] add opt-out feature for third-party active checkers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,14 @@ help:     ## Show this help.
 ##@ Build sds-go
 
 .PHONY: build-sds-go
-build-sds-go: ## Build the sds-go lib.
+build-sds-go: ## Build the sds-go lib (third-party active checkers included by default).
 	@echo "Building sds-go lib"
 	cargo build --manifest-path="sds/Cargo.toml" --release --features dd_sds_go
+
+.PHONY: build-sds-go-no-third-party-active-checkers
+build-sds-go-no-third-party-active-checkers: ## Build the sds-go lib without third-party active checkers (drops reqwest/aws-sign-v4).
+	@echo "Building sds-go lib without third-party active checkers"
+	cargo build --manifest-path="sds/Cargo.toml" --release --no-default-features --features dd-sds,dd_sds_go
 
 ##@ Formatting
 
@@ -45,6 +50,8 @@ test-rust: ## Test the rust lib.
 	@echo "Testing rust lib"
 	cargo test --manifest-path="sds/Cargo.toml"
 	cargo test --manifest-path="sds/Cargo.toml" --features dd_sds_go
+	@echo "Checking rust lib builds without third-party active checkers"
+	cargo check --manifest-path="sds/Cargo.toml" --no-default-features --features dd-sds,dd_sds_go
 
 .PHONY: test-all
 test-all: test-rust test-go ## Test the rust lib and golang libs.

--- a/scripts/generate_license_3rdparty.sh
+++ b/scripts/generate_license_3rdparty.sh
@@ -30,8 +30,8 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 contents = path.read_text()
-default_features = 'default = ["dd-sds"]'
-license_features = 'default = ["dd-sds", "sds-bindings-utils", "dd_sds_go", "sds-fuzz", "hyperscan", "manual_test"]'
+default_features = 'default = ["dd-sds", "third-party-active-checkers"]'
+license_features = 'default = ["dd-sds", "third-party-active-checkers", "sds-bindings-utils", "dd_sds_go", "sds-fuzz", "hyperscan", "manual_test"]'
 
 if default_features not in contents:
     raise SystemExit(f"Unable to find expected default feature line in {path}")

--- a/scripts/rust_checks.sh
+++ b/scripts/rust_checks.sh
@@ -4,6 +4,8 @@ cargo check --manifest-path="sds/Cargo.toml" --benches --features dd_sds_go
 cargo check --manifest-path="sds/Cargo.toml" --bin fuzz --features sds-fuzz
 cargo clippy --manifest-path="sds/Cargo.toml" --features dd_sds_go -- -D warnings
 cargo clippy --manifest-path="sds/Cargo.toml" --bin fuzz --features sds-fuzz -- -D warnings
+# Ensure the crate also builds cleanly without third-party active checkers (no reqwest/aws-sign-v4).
+cargo clippy --manifest-path="sds/Cargo.toml" --no-default-features --features dd-sds,dd_sds_go -- -D warnings
 
 DID_STASH=0
 

--- a/sds/Cargo.toml
+++ b/sds/Cargo.toml
@@ -12,8 +12,13 @@ name = "dd_sds"
 crate-type = ["staticlib", "cdylib", "lib"]
 
 [features]
-default = ["dd-sds"]
+default = ["dd-sds", "third-party-active-checkers"]
 dd-sds = []
+# Enables third-party active checkers (HTTP and AWS match validation) and their
+# associated network dependencies (reqwest, aws-sign-v4). Enabled by default.
+# Build with `--no-default-features` (plus the features you need) to produce a
+# scanner without these dependencies.
+third-party-active-checkers = ["dep:reqwest", "dep:aws-sign-v4", "dep:rayon"]
 sds-bindings-utils = ["dd-sds"]
 dd_sds_go = ["dd-sds", "sds-bindings-utils", "dep:serde_path_to_error"]
 sds-fuzz = ["dd-sds", "dep:afl", "dep:rand"]
@@ -46,13 +51,13 @@ iban_validate = "4"
 num_cpus = "1.16.0"
 
 lazy_static = "1.5.0"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "charset", "http2", "rustls-tls-native-roots"] }
-aws-sign-v4 = "0.3.0"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "charset", "http2", "rustls-tls-native-roots"], optional = true }
+aws-sign-v4 = { version = "0.3.0", optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 slotmap = "1.0.7"
 base64 = "0.22.1"
 serde_json = "1.0.114"
-rayon = "1.10.0"
+rayon = { version = "1.10.0", optional = true }
 bitcoin = "0.32.6"
 iso_iec_7064 = "0.1.1"
 ethaddr = "0.2.2"

--- a/sds/src/match_validation/config.rs
+++ b/sds/src/match_validation/config.rs
@@ -4,10 +4,13 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::{hash::Hash, time::Duration};
 
+#[cfg(feature = "third-party-active-checkers")]
 use crate::match_validation::http_validator_v2::HttpValidatorV2;
 
+#[cfg(feature = "third-party-active-checkers")]
 use super::aws_validator::AwsValidator;
 use super::config_v2::CustomHttpConfigV2;
+#[cfg(feature = "third-party-active-checkers")]
 use super::http_validator::HttpValidator;
 use super::match_validator::MatchValidator;
 
@@ -276,6 +279,7 @@ impl MatchValidationType {
             MatchValidationType::CustomHttpV2(_) => InternalMatchValidationType::CustomHttpV2,
         }
     }
+    #[cfg(feature = "third-party-active-checkers")]
     pub fn into_match_validator(&self) -> Result<Box<dyn MatchValidator>, String> {
         match self {
             MatchValidationType::Aws(aws_type) => match aws_type {
@@ -289,6 +293,14 @@ impl MatchValidationType {
             )),
             MatchValidationType::CustomHttpV2(_) => Ok(Box::new(HttpValidatorV2)),
         }
+    }
+
+    /// When the `third-party-active-checkers` feature is disabled, no network-backed
+    /// validators can be created. Callers should gate validator creation on the same
+    /// feature; this stub exists only so the type keeps a stable public API.
+    #[cfg(not(feature = "third-party-active-checkers"))]
+    pub fn into_match_validator(&self) -> Result<Box<dyn MatchValidator>, String> {
+        Err("Third-party active checkers are not enabled in this build".to_string())
     }
 }
 

--- a/sds/src/match_validation/match_status.rs
+++ b/sds/src/match_validation/match_status.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "third-party-active-checkers")]
 use reqwest::blocking::Response;
 use serde::{Deserialize, Serialize};
 
@@ -49,6 +50,7 @@ impl UnknownResponseTypeInfo {
     }
 }
 
+#[cfg(feature = "third-party-active-checkers")]
 impl From<Response> for UnknownResponseTypeInfo {
     fn from(response: Response) -> Self {
         let status_code = response.status().as_u16();

--- a/sds/src/match_validation/match_validator.rs
+++ b/sds/src/match_validation/match_validator.rs
@@ -1,11 +1,14 @@
 use crate::RuleMatch;
 use crate::scanner::RootCompiledRule;
+#[cfg(feature = "third-party-active-checkers")]
 use rayon::{ThreadPool, ThreadPoolBuilder};
+#[cfg(feature = "third-party-active-checkers")]
 use std::sync::LazyLock;
 use std::vec::Vec;
 
 /// A locally configured thread pool is used for Rayon to prevent conflicts with other libraries
 /// that might override the (default) global thread pool with different (potentially undesirable) settings
+#[cfg(feature = "third-party-active-checkers")]
 pub static RAYON_THREAD_POOL: LazyLock<ThreadPool> =
     LazyLock::new(|| ThreadPoolBuilder::new().build().unwrap());
 

--- a/sds/src/match_validation/mod.rs
+++ b/sds/src/match_validation/mod.rs
@@ -1,9 +1,13 @@
+#[cfg(feature = "third-party-active-checkers")]
 mod aws_validator;
 pub(crate) mod config;
 pub(crate) mod config_v2;
 pub(crate) mod helpers;
+#[cfg(feature = "third-party-active-checkers")]
 pub(crate) mod http_validator;
+#[cfg(feature = "third-party-active-checkers")]
 pub(crate) mod http_validator_v2;
 pub(crate) mod match_status;
 pub(crate) mod match_validator;
+#[cfg(feature = "third-party-active-checkers")]
 pub(crate) mod validator_utils;

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -7,9 +7,11 @@ use crate::match_validation::{
     match_validator::MatchValidator,
 };
 
+#[cfg(feature = "third-party-active-checkers")]
 use error::MatchValidatorCreationError;
 
 use self::metrics::ScannerMetrics;
+#[cfg(feature = "third-party-active-checkers")]
 use crate::match_validation::match_validator::RAYON_THREAD_POOL;
 use crate::observability::labels::Labels;
 use crate::rule_match::{InternalRuleMatch, RuleMatch};
@@ -482,6 +484,9 @@ pub struct Scanner {
     scanner_features: ScannerFeatures,
     metrics: ScannerMetrics,
     labels: Labels,
+    // Without third-party active checkers this map is always empty and never read, but it is kept
+    // in the struct so the type stays identical across build configurations.
+    #[cfg_attr(not(feature = "third-party-active-checkers"), allow(dead_code))]
     match_validators_per_type: AHashMap<InternalMatchValidationType, Box<dyn MatchValidator>>,
     per_scanner_data: SharedData,
     async_scan_timeout: Duration,
@@ -753,6 +758,7 @@ impl Scanner {
         });
     }
 
+    #[cfg(feature = "third-party-active-checkers")]
     pub fn validate_matches(&self, rule_matches: &mut Vec<RuleMatch>) {
         // Create MatchValidatorRuleMatch per match_validator_type to pass it to each match_validator
         let mut match_validator_rule_match_per_type = AHashMap::new();
@@ -825,9 +831,12 @@ impl Scanner {
     // uses RAYON_THREAD_POOL internally; running rayon inside block_on causes an EnterError panic
     // when the calling thread re-enters the LocalPool executor context.
     fn finalize_matches(&self, rule_matches: &mut Vec<RuleMatch>, validate: bool) {
+        #[cfg(feature = "third-party-active-checkers")]
         if validate {
             self.validate_matches(rule_matches);
         }
+        #[cfg(not(feature = "third-party-active-checkers"))]
+        let _ = validate;
         // Supporting rules exist only to provide template variables to CustomHttpV2 validators of
         // other rules. Their matches must not appear in the final output. They are retained until
         // after validate_matches so that match pairing can reference their match values.
@@ -1077,8 +1086,15 @@ impl ScannerBuilder<'_> {
     }
 
     pub fn build(self) -> Result<Scanner, CreateScannerError> {
+        // When third-party active checkers are compiled out, no validators are ever
+        // created; the map stays empty and `mut` would be unused.
+        #[cfg_attr(
+            not(feature = "third-party-active-checkers"),
+            allow(unused_mut)
+        )]
         let mut match_validators_per_type = AHashMap::new();
 
+        #[cfg(feature = "third-party-active-checkers")]
         for rule in self.rules.iter() {
             if let Some(match_validation_type) = &rule.get_third_party_active_checker()
                 && match_validation_type.can_create_match_validator()

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -1088,10 +1088,7 @@ impl ScannerBuilder<'_> {
     pub fn build(self) -> Result<Scanner, CreateScannerError> {
         // When third-party active checkers are compiled out, no validators are ever
         // created; the map stays empty and `mut` would be unused.
-        #[cfg_attr(
-            not(feature = "third-party-active-checkers"),
-            allow(unused_mut)
-        )]
+        #[cfg_attr(not(feature = "third-party-active-checkers"), allow(unused_mut))]
         let mut match_validators_per_type = AHashMap::new();
 
         #[cfg(feature = "third-party-active-checkers")]


### PR DESCRIPTION
## Motivation

The Datadog Agent will ship the SDS scanner by **importing `dd-sds` directly as a Rust crate dependency**. In that use case the third-party active checkers are **not** used, so we want to avoid pulling in the large dependency set they require (HTTP client, full TLS stack, AWS request signing, rayon) when it isn't needed. This PR adds a way to compile the scanner without those checkers and their dependencies, while keeping them enabled by default for everyone else.

## Summary

Adds a default-on `third-party-active-checkers` Cargo feature so the scanner can optionally be built **without** third-party active checkers (HTTP/AWS match validation) and their exclusive dependencies. Behavior is unchanged by default.

The three dependencies used *exclusively* by third-party checkers are made optional and gated behind the feature:
- `reqwest` (+ its HTTP/TLS stack)
- `aws-sign-v4`
- `rayon` (only used to parallelize match validation)

Shared deps (`tokio`, `futures`, `num_cpus`, `moka`, `chrono`) are untouched since they're needed by the core scanning/async paths.

Config/status types (`MatchValidationType`, `MatchStatus`, etc.) and the scanner integration stay always-compiled, so the **public API and Go bindings are identical** in both configurations — only the network-backed validator code and its deps are gated.

## How to import without third-party checkers (Rust consumers, e.g. the Agent)

```toml
[dependencies]
dd-sensitive-data-scanner = { git = "https://github.com/DataDog/dd-sensitive-data-scanner", default-features = false, features = ["dd-sds"] }
```

(`default-features = false` drops the checkers; `dd-sds` is required since the whole public API is gated behind it.)

Build commands:

```bash
# Rust core only
cargo build --manifest-path=sds/Cargo.toml --release --no-default-features --features dd-sds
# Go bindings without checkers
make build-sds-go-no-third-party-active-checkers
```

## Impact

The Agent imports `dd-sds` as a Rust crate and links the `rlib`, so the relevant metric is the compiled Rust footprint. Disabling the checkers removes ~79 transitive crates (215 → 136 in `cargo tree`; 201 → 127 built `rlib`s), dropping the reqwest/hyper/rustls/ring/aws-sign/rayon stack and linking no outbound-network/TLS code.

### rlib

| Artifact (release) | With checkers (default) | Without checkers | Delta |
|---|---|---|---|
| `libdd_sds.rlib` (dd-sds's own code) | 5.77 MiB | 5.14 MiB | −0.63 MiB |
| Total compiled `rlib`s (dd-sds + all deps) | 204.6 MiB | 142.1 MiB | −62.5 MiB (−31%) |

dd-sds's own `rlib` barely changes (only the validator code is gated out); the real win is the **~62 MiB / 31% reduction in transitive dependency code**, plus lower compile time and supply-chain/audit surface. (Final linked-binary savings are smaller after dead-code elimination, but the dependency graph and build cost drop substantially.)

### dylib / staticlib (Go bindings artifacts, for reference)

| Build | Third-party checkers | `libdd_sds.dylib` |
|---|---|---|
| with `dd_sds_go` (Go bindings) | on (default) | 9.12 MiB |
| with `dd_sds_go` (Go bindings) | off | 4.52 MiB |
| without `dd_sds_go` (`dd-sds` core only) | on (default) | 0.40 MiB |
| without `dd_sds_go` (`dd-sds` core only) | off | 0.35 MiB |

For the Go bindings the `dylib` is roughly **halved (~4.6 MiB saved)**. (The non-Go `dd-sds` cdylib is tiny in both cases because it exports no C symbols without the Go bindings, so the linker dead-strips almost everything — it isn't a meaningful deliverable on its own; a Rust consumer links the `rlib`.)

## Changes
- `Cargo.toml`: make `reqwest`/`aws-sign-v4`/`rayon` optional; add default-on `third-party-active-checkers` feature.
- Gate validator modules, the `reqwest`-based code, `RAYON_THREAD_POOL`, `validate_matches`, and validator creation behind the feature.
- `Makefile`/`rust_checks.sh`: add feature-off build + clippy checks; new no-checkers Go build target.
- `generate_license_3rdparty.sh`: update hardcoded default-feature line.

## Test plan
- [x] `cargo clippy -- -D warnings` passes with feature on (`dd_sds_go`) and off (`--no-default-features --features dd-sds,dd_sds_go`)
- [x] `cargo tree` confirms `reqwest`/`aws-sign-v4`/`rayon` dropped when the feature is off
- [x] All 94 match-validation tests pass on the default build
- [x] `make check-rust` passes
- [x] CI green