### PR TITLE
[DSEC-134] Default omitted match_action to None on deserialization

### DIFF
--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -95,6 +95,7 @@ pub enum Precedence {
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct RootRuleConfig<T> {
+    #[serde(default)]
     pub match_action: MatchAction,
     #[serde(default)]
     pub scope: Scope,

--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -307,7 +307,7 @@ pub struct JwtClaimsValidatorConfig {
 
 #[cfg(test)]
 mod test {
-    use crate::{AwsType, CustomHttpConfig, MatchValidationType, RootRuleConfig};
+    use crate::{AwsType, CustomHttpConfig, MatchAction, MatchValidationType, RootRuleConfig};
     use std::collections::BTreeMap;
     use strum::IntoEnumIterator;
 
@@ -349,6 +349,13 @@ mod test {
                 pattern_capture_groups: Some(vec!["capture_group".to_string()]),
             }
         );
+    }
+
+    #[test]
+    fn match_action_should_default_to_none_on_deserialization() {
+        let config: RootRuleConfig<RegexRuleConfig> =
+            serde_json::from_str(r#"{"pattern":"hello"}"#).unwrap();
+        assert_eq!(config.match_action, MatchAction::None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Default `RootRuleConfig.match_action` to `None` when omitted from JSON/YAML.

## Test plan
- [x] `cargo test match_action_should_default_to_none_on_deserialization`


Made with [Cursor](https://cursor.com)