### PR TITLE
[SDSP] Add cargo-deny supply-chain checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,12 @@ jobs:
         run: cargo install dd-rust-license-tool
       - name: "Check LICENSE-3rdparty.csv"
         run: make check-licenses
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: "Install cargo-deny"
+        run: cargo install cargo-deny --version 0.19.8 --locked
+      - name: "Check dependency advisories, licenses and bans"
+        run: make check-deny

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,13 @@ check-rust: ## Check the rust lib.
 	@echo "Checking rust lib"
 	bash ./scripts/rust_checks.sh
 
+##@ Supply chain
+
+.PHONY: check-deny
+check-deny: ## Check dependencies for advisories, license and ban policy (cargo-deny).
+	@echo "Checking dependencies with cargo-deny"
+	cd sds && cargo deny --all-features check
+
 ##@ Licenses generation
 
 .PHONY: update-licenses

--- a/sds/Cargo.lock
+++ b/sds/Cargo.lock
@@ -680,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1895,9 +1895,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",

--- a/sds/deny.toml
+++ b/sds/deny.toml
@@ -1,0 +1,31 @@
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "warn"
+ignore = [
+  # async-std is only reachable through httpmock, a dev/test-only dependency,
+  # so it never ships in the library. RUSTSEC-2025-0052 has no safe upgrade.
+  { id = "RUSTSEC-2025-0052", reason = "async-std is unmaintained but only pulled in transitively by the httpmock dev-dependency" },
+]
+
+[bans]
+multiple-versions = "allow"  # Allow multiple versions of same crate
+
+[licenses]
+version = 2
+# Only licenses actually present in the dependency graph are allowed. All are
+# permissive and part of Datadog's standard allow policy (from Saluki).
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "ISC",
+  "MIT",
+  "MITNFA",
+  "Unicode-3.0",
+  "Zlib",
+]


### PR DESCRIPTION
## Motivation
`dd-sensitive-data-scanner` is consumed by many different repositories, including the Datadog Agent, which already gates it through cargo-deny (see [datadog-agent `rust/deny.toml`](https://github.com/DataDog/datadog-agent/blob/main/rust/deny.toml)). Running the same checks here catches license, security-advisory and dependency issues at the source, so every consumer benefits instead of each having to re-discover them downstream.

## What
- `sds/deny.toml`: advisories + license allow-list (only licenses present in the graph) + ban policy. We took inspiration from the Agent's config: [datadog-agent `rust/deny.toml`](https://github.com/DataDog/datadog-agent/blob/main/rust/deny.toml#L22).
- `make check-deny` target and a CI job running it.

## Cargo.lock bumps
- `crossbeam-epoch 0.9.18 → 0.9.20`: **required** — 0.9.18 is affected by [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference), which makes `cargo deny check advisories` fail. 0.9.20 is the patched release.
- `metrics 0.24.5 → 0.24.6`: **not strictly required** — 0.24.5 was yanked from crates.io, which cargo-deny only reports as a `warn` (non-failing). Bumping to the non-yanked 0.24.6 clears the warning and avoids depending on a pulled release.

## Test plan
- [x] [CI `cargo-deny` job passes](https://github.com/DataDog/dd-sensitive-data-scanner/actions/runs/30697617037/job/91363051805?pr=375)