### PR TITLE
[DSEC-232] Provide reset_regex_caches

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -110,7 +110,10 @@ pub use scanner::{
         ClaimRequirement, JwtClaimsValidatorConfig, ProximityKeywordsConfig, RegexRuleConfig,
         SecondaryValidator,
     },
-    regex_rule::{RegexCacheKey, RegexCacheValue, RegexCaches, SharedRegex, get_memoized_regex},
+    regex_rule::{
+        RegexCacheKey, RegexCacheValue, RegexCaches, SharedRegex, get_memoized_regex,
+        reset_regex_caches,
+    },
     scope::Scope,
 };
 #[cfg(feature = "dd-sds")]

--- a/sds/src/scanner/regex_rule/mod.rs
+++ b/sds/src/scanner/regex_rule/mod.rs
@@ -3,5 +3,7 @@ pub mod config;
 mod regex_cache_store;
 mod regex_store;
 
-pub use regex_cache_store::{RegexCacheValue, RegexCaches, access_regex_caches};
+pub use regex_cache_store::{
+    RegexCacheValue, RegexCaches, access_regex_caches, reset_regex_caches,
+};
 pub use regex_store::{RegexCacheKey, SharedRegex, get_memoized_regex};

--- a/sds/src/scanner/regex_rule/regex_cache_store.rs
+++ b/sds/src/scanner/regex_rule/regex_cache_store.rs
@@ -3,21 +3,34 @@ use crate::scanner::regex_rule::regex_store::{RegexCacheKey, SharedRegex};
 use lazy_static::lazy_static;
 use regex_automata::meta::Regex as MetaRegex;
 use slotmap::SecondaryMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 extern crate num_cpus;
 
-lazy_static! {
-    static ref REGEX_CACHE_STORE: Arc<SharedPool<Box<RegexCaches>>> = Arc::new(SharedPool::new(
+fn new_regex_cache_pool() -> Arc<SharedPool<Box<RegexCaches>>> {
+    Arc::new(SharedPool::new(
         Box::new(|| Box::new(RegexCaches::new())),
-        num_cpus::get()
-    ));
+        num_cpus::get(),
+    ))
+}
+
+lazy_static! {
+    // `RwLock` lets `reset_regex_caches` swap in a fresh pool, dropping every thread's caches.
+    static ref REGEX_CACHE_STORE: RwLock<Arc<SharedPool<Box<RegexCaches>>>> =
+        RwLock::new(new_regex_cache_pool());
 }
 
 pub fn access_regex_caches<T>(func: impl FnOnce(&mut RegexCaches) -> T) -> T {
-    // This function isn't strictly necessary, but it makes it easier to change the implementation
-    // later
-    let mut caches = REGEX_CACHE_STORE.get();
+    // Clone the `Arc` under a short read lock so scanning holds no lock; a concurrent
+    // `reset_regex_caches` keeps this in-flight pool alive via the clone.
+    let pool = REGEX_CACHE_STORE.read().unwrap().clone();
+    let mut caches = pool.get();
     func(caches.get_ref())
+}
+
+/// Swaps in a fresh pool, dropping every thread's cached scratch. In-flight scans keep the
+/// old pool alive via their `Arc` clone; caches are recreated on the next scan.
+pub fn reset_regex_caches() {
+    *REGEX_CACHE_STORE.write().unwrap() = new_regex_cache_pool();
 }
 
 pub struct RegexCaches {
@@ -52,5 +65,32 @@ impl RegexCaches {
                 cache: regex.create_cache(),
                 captures: regex.create_captures(),
             })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::scanner::regex_rule::regex_store::get_memoized_regex;
+    use regex_automata::meta::Regex;
+
+    #[test]
+    fn reset_swaps_pool_and_still_serves_caches() {
+        let shared = get_memoized_regex("unique-reset-pattern", Regex::new).unwrap();
+        access_regex_caches(|caches| {
+            let _ = caches.get(&shared);
+        });
+
+        // Hold the old pool so its allocation can't be reused (flaky ptr compare), then
+        // confirm reset installs a different pool.
+        let old_pool = REGEX_CACHE_STORE.read().unwrap().clone();
+        reset_regex_caches();
+        let new_pool = REGEX_CACHE_STORE.read().unwrap().clone();
+        assert!(!Arc::ptr_eq(&old_pool, &new_pool));
+
+        // Fresh pool recreates caches on next access.
+        access_regex_caches(|caches| {
+            let _ = caches.get(&shared);
+        });
     }
 }


### PR DESCRIPTION
## Motivation

Regex scratch caches (the lazy-DFA buffers, tens of KB per rule) are pooled globally with one slot per CPU and live for the process lifetime. Each thread that scans lazily fills its slot with a cache per rule, so scratch memory scales with `rules × threads` and stays resident even when idle.

For episodic-scanning embedders (e.g. the Agent's datasecurity check) that build a scanner, scan, then drop it, there was no way to reclaim this: dropping the scanner leaves the pooled scratch behind, and a per-thread GC can only reach the calling thread's slot — not caches populated by other threads.

## Change

Add `reset_regex_caches()`: swaps the global pool for a fresh one under an `RwLock`, dropping every thread's cached scratch at once. Scans clone the pool `Arc` under a short read lock, so an in-flight scan keeps the old pool alive until it finishes — safe to call concurrently. Caches are lazily recreated on the next scan.

Call it when scanning is idle to return the scanner's scratch footprint to ~0, regardless of how many threads scanned.