### PR TITLE
[DSEC-232] Provide clear_all_caches

### DIFF
--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -111,8 +111,8 @@ pub use scanner::{
         SecondaryValidator,
     },
     regex_rule::{
-        RegexCacheKey, RegexCacheValue, RegexCaches, SharedRegex, clear_all_caches,
-        gc_regex_store, get_memoized_regex, reset_regex_caches,
+        RegexCacheKey, RegexCacheValue, RegexCaches, SharedRegex, clear_all_caches, gc_regex_store,
+        get_memoized_regex, reset_regex_caches,
     },
     scope::Scope,
 };

--- a/sds/src/lib.rs
+++ b/sds/src/lib.rs
@@ -111,8 +111,8 @@ pub use scanner::{
         SecondaryValidator,
     },
     regex_rule::{
-        RegexCacheKey, RegexCacheValue, RegexCaches, SharedRegex, get_memoized_regex,
-        reset_regex_caches,
+        RegexCacheKey, RegexCacheValue, RegexCaches, SharedRegex, clear_all_caches,
+        gc_regex_store, get_memoized_regex, reset_regex_caches,
     },
     scope::Scope,
 };

--- a/sds/src/scanner/regex_rule/mod.rs
+++ b/sds/src/scanner/regex_rule/mod.rs
@@ -4,6 +4,6 @@ mod regex_cache_store;
 mod regex_store;
 
 pub use regex_cache_store::{
-    RegexCacheValue, RegexCaches, access_regex_caches, reset_regex_caches,
+    RegexCacheValue, RegexCaches, access_regex_caches, clear_all_caches, reset_regex_caches,
 };
-pub use regex_store::{RegexCacheKey, SharedRegex, get_memoized_regex};
+pub use regex_store::{RegexCacheKey, SharedRegex, gc_regex_store, get_memoized_regex};

--- a/sds/src/scanner/regex_rule/regex_cache_store.rs
+++ b/sds/src/scanner/regex_rule/regex_cache_store.rs
@@ -1,5 +1,5 @@
 use crate::SharedPool;
-use crate::scanner::regex_rule::regex_store::{RegexCacheKey, SharedRegex};
+use crate::scanner::regex_rule::regex_store::{RegexCacheKey, SharedRegex, gc_regex_store};
 use lazy_static::lazy_static;
 use regex_automata::meta::Regex as MetaRegex;
 use slotmap::SecondaryMap;
@@ -31,6 +31,13 @@ pub fn access_regex_caches<T>(func: impl FnOnce(&mut RegexCaches) -> T) -> T {
 /// old pool alive via their `Arc` clone; caches are recreated on the next scan.
 pub fn reset_regex_caches() {
     *REGEX_CACHE_STORE.write().unwrap() = new_regex_cache_pool();
+}
+
+/// Clears both scanning caches: per-thread scratch (`reset_regex_caches`) and unreferenced
+/// compiled regexes (`gc_regex_store`). Call when idle to drop dd-sds to a near-zero footprint.
+pub fn clear_all_caches() {
+    reset_regex_caches();
+    gc_regex_store();
 }
 
 pub struct RegexCaches {

--- a/sds/src/scanner/regex_rule/regex_store.rs
+++ b/sds/src/scanner/regex_rule/regex_store.rs
@@ -34,6 +34,12 @@ pub fn get_memoized_regex<T>(
     get_memoized_regex_with_custom_store(pattern, regex_factory, &REGEX_STORE)
 }
 
+/// Drops store bookkeeping for regexes no longer referenced by any scanner (otherwise
+/// cleared only every `GC_FREQUENCY` inserts).
+pub fn gc_regex_store() {
+    REGEX_STORE.lock().unwrap().gc();
+}
+
 fn get_memoized_regex_with_custom_store<T>(
     pattern: &str,
     regex_factory: impl FnOnce(&str) -> Result<regex_automata::meta::Regex, T>,


### PR DESCRIPTION
## Motivation

Stacked on #376 (`reset_regex_caches`). Adds the second half so episodic embedders (build → scan → drop) can reclaim everything when idle.

- `gc_regex_store()` — drops compiled-regex store entries no longer referenced by any live scanner (otherwise only pruned every `GC_FREQUENCY` inserts).
- `clear_all_caches()` — resets the per-thread scratch pool and GCs the regex store in one call.

Made with [Cursor](https://cursor.com)