### PR TITLE
sds-go: map invalid pattern capture groups

### DIFF
--- a/sds-go/go/regex_rule.go
+++ b/sds-go/go/regex_rule.go
@@ -280,6 +280,7 @@ func NewPartialRedactRule(id string, pattern string, characterCount uint32, dire
 		Suppressions:            extraConfig.Suppressions,
 		SecondaryValidator:      extraConfig.SecondaryValidator,
 		ThirdPartyActiveChecker: extraConfig.ThirdPartyActiveChecker,
+		PatternCaptureGroups:    extraConfig.PatternCaptureGroups,
 		IsSupportingRule:        extraConfig.IsSupportingRule,
 	}
 }

--- a/sds-go/go/regex_rule_test.go
+++ b/sds-go/go/regex_rule_test.go
@@ -97,3 +97,30 @@ func TestRegexRuleConfigUnmarshalJSON_withMatchAction(t *testing.T) {
 		t.Fatalf("MatchAction.Type = %q, want %q", cfg.MatchAction.Type, MatchActionNone)
 	}
 }
+
+func TestRegexRuleConfigUnmarshalJSON_withPatternCaptureGroups(t *testing.T) {
+	raw := `{
+		"id": "r",
+		"pattern": "hello (?<sds_match>world)",
+		"pattern_capture_groups": ["sds_match"]
+	}`
+	var cfg RegexRuleConfig
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := []string{"sds_match"}
+	if !reflect.DeepEqual(cfg.PatternCaptureGroups, want) {
+		t.Fatalf("PatternCaptureGroups = %#v, want %#v", cfg.PatternCaptureGroups, want)
+	}
+}
+
+func TestNewPartialRedactRule_copiesPatternCaptureGroups(t *testing.T) {
+	extra := ExtraConfig{PatternCaptureGroups: []string{"sds_match"}}
+	got := NewPartialRedactRule("r", "secret", 4, FirstCharacters, extra)
+	want := []string{"sds_match"}
+	if !reflect.DeepEqual(got.PatternCaptureGroups, want) {
+		t.Fatalf("PatternCaptureGroups = %#v, want %#v", got.PatternCaptureGroups, want)
+	}
+}

--- a/sds-go/go/scanner.go
+++ b/sds-go/go/scanner.go
@@ -23,6 +23,7 @@ var (
 	ErrInvalidKeywords              error = fmt.Errorf("invalid keywords")
 	ErrInvalidMatchAction           error = fmt.Errorf("invalid match action")
 	ErrInvalidSuppressions          error = fmt.Errorf("invalid suppressions")
+	ErrInvalidPatternCaptureGroups  error = fmt.Errorf("invalid pattern capture groups")
 	ErrSupportingRuleHasMatchAction error = fmt.Errorf("supporting rules cannot have a match action other than None")
 )
 
@@ -118,6 +119,8 @@ func CreateScannerWithOptions(ruleConfigs []RuleConfig, options ScannerOptions) 
 			}
 		case -6: // rust: CreateScannerError::InvalidSuppressions
 			return nil, ErrInvalidSuppressions
+		case -7: // rust: CreateScannerError::InvalidPatternCaptureGroups
+			return nil, ErrInvalidPatternCaptureGroups
 		case -8: // rust: CreateScannerError::SupportingRuleHasMatchAction
 			return nil, ErrSupportingRuleHasMatchAction
 		}

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -1088,6 +1088,9 @@ func TestCreateScannerFailsOnEmptySdsMatchCaptureGroup(t *testing.T) {
 	if scanner != nil {
 		t.Fatal("on failed creation, the returned scanner should be nil")
 	}
+	if err != ErrInvalidPatternCaptureGroups {
+		t.Fatalf("err = %v, want ErrInvalidPatternCaptureGroups", err)
+	}
 }
 
 func TestSupportingRuleMatchExcludedFromOutput(t *testing.T) {


### PR DESCRIPTION
CreateScanner already forwarded pattern_capture_groups over FFI, but
InvalidPatternCaptureGroups (-7) fell through to ErrUnknown. Map that
code, copy the field through NewPartialRedactRule, and cover the JSON
path agentless uses to load rules.

For DATASEC-202

https://datadoghq.atlassian.net/browse/DATASEC-202