### PR TITLE
sds-go: add Precedence to RegexRuleConfig

### DIFF
--- a/sds-go/go/regex_rule.go
+++ b/sds-go/go/regex_rule.go
@@ -17,6 +17,7 @@ type RegexRuleConfig struct {
 	Id                      string                   `json:"id"`
 	Pattern                 string                   `json:"pattern"`
 	MatchAction             MatchAction              `json:"match_action"`
+	Precedence              Precedence               `json:"precedence,omitempty"`
 	ProximityKeywords       *ProximityKeywordsConfig `json:"proximity_keywords,omitempty"`
 	Suppressions            Suppressions             `json:"suppressions,omitempty"`
 	SecondaryValidator      *SecondaryValidator      `json:"validator,omitempty"`
@@ -76,6 +77,7 @@ func (t ThirdPartyActiveChecker) MarshalJSON() ([]byte, error) {
 
 type MatchActionType string
 type ReplacementType string
+type Precedence string
 
 const (
 	MatchActionNone          = MatchActionType("None")
@@ -88,6 +90,10 @@ const (
 	ReplacementTypeHash         = ReplacementType("hash")
 	ReplacementTypePartialStart = ReplacementType("partial_beginning")
 	ReplacementTypePartialEnd   = ReplacementType("partial_end")
+
+	PrecedenceSpecific = Precedence("Specific")
+	PrecedenceGeneric  = Precedence("Generic")
+	PrecedenceCatchall = Precedence("Catchall")
 )
 
 type SecondaryValidatorType string

--- a/sds-go/go/regex_rule_test.go
+++ b/sds-go/go/regex_rule_test.go
@@ -115,3 +115,20 @@ func TestRegexRuleConfigUnmarshalJSON_withPatternCaptureGroups(t *testing.T) {
 		t.Fatalf("PatternCaptureGroups = %#v, want %#v", cfg.PatternCaptureGroups, want)
 	}
 }
+
+func TestRegexRuleConfigUnmarshalJSON_withPrecedence(t *testing.T) {
+	raw := `{
+		"id": "r",
+		"pattern": "secret",
+		"precedence": "Generic"
+	}`
+	var cfg RegexRuleConfig
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if cfg.Precedence != PrecedenceGeneric {
+		t.Fatalf("Precedence = %q, want %q", cfg.Precedence, PrecedenceGeneric)
+	}
+}

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -1097,3 +1097,55 @@ func TestScanWithOptions(t *testing.T) {
 		t.Fatalf("expected match validation status, got %q", result.Matches[0].MatchStatus)
 	}
 }
+
+func TestScanStringWithPrecedence(t *testing.T) {
+	rules := []RuleConfig{
+		RegexRuleConfig{Id: "catchall", Pattern: "secret", MatchAction: MatchAction{Type: MatchActionRedact, RedactionValue: "[CATCHALL]"}, Precedence: PrecedenceCatchall},
+		RegexRuleConfig{Id: "generic", Pattern: "secret", MatchAction: MatchAction{Type: MatchActionRedact, RedactionValue: "[GENERIC]"}, Precedence: PrecedenceGeneric},
+		RegexRuleConfig{Id: "specific", Pattern: "secret", MatchAction: MatchAction{Type: MatchActionRedact, RedactionValue: "[SPECIFIC]"}, Precedence: PrecedenceSpecific},
+	}
+
+	scanner, err := CreateScanner(rules)
+	if err != nil {
+		t.Fatal("failed to create the scanner:", err.Error())
+	}
+	defer scanner.Delete()
+
+	result, err := scanner.Scan([]byte("secret"))
+	if err != nil {
+		t.Fatal("failed to scan the event:", err.Error())
+	}
+	if string(result.Event) != "[SPECIFIC]" {
+		t.Fatalf("expected mutated event %q, got %q", "[SPECIFIC]", result.Event)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(result.Matches))
+	}
+	if result.Matches[0].RuleIdx != 2 {
+		t.Fatalf("expected RuleIdx 2, got %d", result.Matches[0].RuleIdx)
+	}
+}
+
+func TestScanStringWithDefaultPrecedence(t *testing.T) {
+	rules := []RuleConfig{
+		RegexRuleConfig{Id: "generic", Pattern: "secret", MatchAction: MatchAction{Type: MatchActionNone}, Precedence: PrecedenceGeneric},
+		RegexRuleConfig{Id: "specific", Pattern: "secret", MatchAction: MatchAction{Type: MatchActionNone}},
+	}
+
+	scanner, err := CreateScanner(rules)
+	if err != nil {
+		t.Fatal("failed to create the scanner:", err.Error())
+	}
+	defer scanner.Delete()
+
+	result, err := scanner.Scan([]byte("secret"))
+	if err != nil {
+		t.Fatal("failed to scan the event:", err.Error())
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(result.Matches))
+	}
+	if result.Matches[0].RuleIdx != 1 {
+		t.Fatalf("expected RuleIdx 1, got %d", result.Matches[0].RuleIdx)
+	}
+}


### PR DESCRIPTION
The Rust engine already tie-breaks overlapping matches of equal mutation priority with Catchall < Generic < Specific (default Specific), but the Go bindings never sent that field over FFI. Go callers therefore could not set rule precedence through this package.

Needed for [DATASEC-203](https://datadoghq.atlassian.net/browse/DATASEC-203).

[DATASEC-203]: https://datadoghq.atlassian.net/browse/DATASEC-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ