### PR TITLE
sds-go: unmarshal JwtClaimsValidator config

### DIFF
--- a/sds-go/go/regex_rule.go
+++ b/sds-go/go/regex_rule.go
@@ -123,6 +123,51 @@ func NewJwtClaimsValidator(config JwtClaimsValidatorConfig) *SecondaryValidator 
 	}
 }
 
+// UnmarshalJSON handles deserialization from various JSON formats
+func (v *SecondaryValidator) UnmarshalJSON(data []byte) error {
+	// Try to unmarshal as a simple string first (legacy format)
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		v.Type = SecondaryValidatorType(str)
+		v.Config = nil
+		return nil
+	}
+
+	// Unmarshal as object using structured approach
+	var rawMap struct {
+		Type   string          `json:"type"`
+		Config json.RawMessage `json:"config"`
+	}
+	if err := json.Unmarshal(data, &rawMap); err != nil {
+		return fmt.Errorf("validator must be either a string or object: %v", err)
+	}
+
+	v.Type = SecondaryValidatorType(rawMap.Type)
+
+	// Handle configuration if present
+	if len(rawMap.Config) > 0 {
+		switch rawMap.Type {
+		case string(JwtValidatorType):
+			var jwtConfig JwtClaimsValidatorConfig
+			if err := json.Unmarshal(rawMap.Config, &jwtConfig); err != nil {
+				return fmt.Errorf("failed to unmarshal JWT config: %v", err)
+			}
+			v.Config = jwtConfig
+		default:
+			// For other validators, unmarshal as generic interface
+			var config interface{}
+			if err := json.Unmarshal(rawMap.Config, &config); err != nil {
+				return fmt.Errorf("failed to unmarshal config: %v", err)
+			}
+			v.Config = config
+		}
+	} else {
+		v.Config = nil
+	}
+
+	return nil
+}
+
 type PartialRedactionDirection string
 
 const (

--- a/sds-go/go/regex_rule_test.go
+++ b/sds-go/go/regex_rule_test.go
@@ -132,3 +132,98 @@ func TestRegexRuleConfigUnmarshalJSON_withPrecedence(t *testing.T) {
 		t.Fatalf("Precedence = %q, want %q", cfg.Precedence, PrecedenceGeneric)
 	}
 }
+
+func TestRegexRuleConfigUnmarshalJSON_withValidator(t *testing.T) {
+	raw := `{
+		"id": "r",
+		"pattern": "secret",
+		"validator": {"type": "LuhnChecksum"}
+	}`
+	var cfg RegexRuleConfig
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := NewSecondaryValidator("LuhnChecksum")
+	if !reflect.DeepEqual(cfg.SecondaryValidator, want) {
+		t.Fatalf("SecondaryValidator = %#v, want %#v", cfg.SecondaryValidator, want)
+	}
+}
+
+func TestRegexRuleConfigUnmarshalJSON_withJwtClaimsValidator(t *testing.T) {
+	raw := `{
+		"id": "r",
+		"pattern": "secret",
+		"validator": {
+			"type": "JwtClaimsValidator",
+			"config": {
+				"required_headers": {
+					"alg": {"type": "ExactValue", "config": "HS256"},
+					"typ": {"type": "Present"}
+				},
+				"required_claims": {
+					"app": {"type": "RegexMatch", "config": "test_\\w"},
+					"version": {"type": "ExactValue", "config": "2"},
+					"scope": {"type": "Present"}
+				}
+			}
+		}
+	}`
+	var cfg RegexRuleConfig
+	dec := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := NewJwtClaimsValidator(JwtClaimsValidatorConfig{
+		RequiredHeaders: map[string]ClaimRequirement{
+			"alg": ClaimRequirementExactValue{Value: "HS256"},
+			"typ": ClaimRequirementPresent{},
+		},
+		RequiredClaims: map[string]ClaimRequirement{
+			"app":     ClaimRequirementRegexMatch{Pattern: `test_\w`},
+			"version": ClaimRequirementExactValue{Value: "2"},
+			"scope":   ClaimRequirementPresent{},
+		},
+	})
+	if !reflect.DeepEqual(cfg.SecondaryValidator, want) {
+		t.Fatalf("SecondaryValidator = %#v, want %#v", cfg.SecondaryValidator, want)
+	}
+}
+
+func TestSecondaryValidatorUnmarshalJSON_legacyString(t *testing.T) {
+	var got SecondaryValidator
+	if err := json.Unmarshal([]byte(`"LuhnChecksum"`), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := SecondaryValidator{Type: LuhnChecksum}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestSecondaryValidatorMarshalJSON_jwtRoundTrip(t *testing.T) {
+	in := NewJwtClaimsValidator(JwtClaimsValidatorConfig{
+		RequiredHeaders: map[string]ClaimRequirement{
+			"alg": ClaimRequirementExactValue{Value: "HS256"},
+		},
+		RequiredClaims: map[string]ClaimRequirement{
+			"scope": ClaimRequirementPresent{},
+		},
+	})
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got SecondaryValidator
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(&got, in) {
+		t.Fatalf("round trip mismatch: got %#v, want %#v", &got, in)
+	}
+}


### PR DESCRIPTION
The Go bindings already constructed JwtClaimsValidator rules and sent them over FFI, but SecondaryValidator had no UnmarshalJSON, so loading a rule from JSON left Config as nested maps instead of JwtClaimsValidatorConfig.

For DATASEC-201