### PR TITLE
Introduce the new NonHexPlusTokenEfficiencyChecker

### DIFF
--- a/sds/src/scanner/regex_rule/config.rs
+++ b/sds/src/scanner/regex_rule/config.rs
@@ -266,6 +266,7 @@ pub enum SecondaryValidator {
     NhsCheckDigit,
     NirChecksum,
     NonHexChecker,
+    NonHexPlusTokenEfficiencyChecker,
     PolishNationalIdChecksum,
     PolishNipChecksum,
     PortugueseTaxIdChecksum,

--- a/sds/src/scanner/test/validators.rs
+++ b/sds/src/scanner/test/validators.rs
@@ -1,6 +1,6 @@
 use crate::SecondaryValidator::{
     ChineseIdChecksum, GithubTokenChecksum, IbanChecker, JwtExpirationChecker, NhsCheckDigit,
-    NonHexChecker, TokenEfficiencyCheck,
+    NonHexChecker, NonHexPlusTokenEfficiencyChecker, TokenEfficiencyCheck,
 };
 use crate::scanner::RootRuleConfig;
 use crate::{MatchAction, RegexRuleConfig, ScannerBuilder, SecondaryValidator};
@@ -230,4 +230,35 @@ fn test_token_efficiency_check_filters_identifiers() {
         "SOKXxs00k30PUuH4KLoDPNmwlQ4EwXKw LibraryWebpageUploadUr1RowStatus".to_string();
     assert_eq!(scanner_with.scan(&mut content).unwrap().len(), 1);
     assert_eq!(content, "[secret] LibraryWebpageUploadUr1RowStatus");
+}
+
+#[test]
+fn test_non_hex_plus_token_efficiency_checker_filters_hex_and_identifiers() {
+    let rule = RegexRuleConfig::new("[A-Za-z0-9]{16,}");
+    let match_action = MatchAction::Redact {
+        replacement: "[secret]".to_string(),
+    };
+
+    let rule_with_validator = RootRuleConfig::new(
+        rule.with_validator(Some(NonHexPlusTokenEfficiencyChecker))
+            .build(),
+    )
+    .match_action(match_action);
+
+    let scanner = ScannerBuilder::new(&[rule_with_validator]).build().unwrap();
+
+    // Pure hex is token-inefficient but must still be rejected for lacking a non-hex character.
+    let mut pure_hex = "0123456789abcdef0123456789abcdef".to_string();
+    assert_eq!(scanner.scan(&mut pure_hex).unwrap().len(), 0);
+    assert_eq!(pure_hex, "0123456789abcdef0123456789abcdef");
+
+    // Non-hex but token-efficient identifiers must still be rejected for reading as natural language.
+    let mut identifier = "LibraryWebpageUploadUr1RowStatus".to_string();
+    assert_eq!(scanner.scan(&mut identifier).unwrap().len(), 0);
+    assert_eq!(identifier, "LibraryWebpageUploadUr1RowStatus");
+
+    // A non-hex, token-inefficient value passes both checks.
+    let mut secret = "sk_live_SOKXxs00k30PUuH4KLoDPNmwlQ4EwXKw".to_string();
+    assert_eq!(scanner.scan(&mut secret).unwrap().len(), 1);
+    assert_eq!(secret, "sk_live_[secret]");
 }

--- a/sds/src/secondary_validation/mod.rs
+++ b/sds/src/secondary_validation/mod.rs
@@ -39,6 +39,7 @@ mod monero_address;
 mod nhs_check_digit;
 mod nir_checksum;
 mod non_hex_checker;
+mod non_hex_plus_token_efficiency_checker;
 mod polish_national_id_checksum;
 mod polish_nip_checksum;
 mod portuguese_tax_id_checksum;
@@ -105,6 +106,7 @@ pub use crate::secondary_validation::monero_address::MoneroAddress;
 pub use crate::secondary_validation::nhs_check_digit::NhsCheckDigit;
 pub use crate::secondary_validation::nir_checksum::NirChecksum;
 pub use crate::secondary_validation::non_hex_checker::NonHexChecker;
+pub use crate::secondary_validation::non_hex_plus_token_efficiency_checker::NonHexPlusTokenEfficiencyChecker;
 pub use crate::secondary_validation::polish_national_id_checksum::PolishNationalIdChecksum;
 pub use crate::secondary_validation::polish_nip_checksum::PolishNipChecksum;
 pub use crate::secondary_validation::portuguese_tax_id_checksum::PortugueseTaxIdChecksum;
@@ -261,6 +263,9 @@ impl SecondaryValidator {
             SecondaryValidator::NhsCheckDigit => Arc::new(NhsCheckDigit),
             SecondaryValidator::NirChecksum => Arc::new(NirChecksum),
             SecondaryValidator::NonHexChecker => Arc::new(NonHexChecker),
+            SecondaryValidator::NonHexPlusTokenEfficiencyChecker => {
+                Arc::new(NonHexPlusTokenEfficiencyChecker::new())
+            }
             SecondaryValidator::PolishNationalIdChecksum => Arc::new(PolishNationalIdChecksum),
             SecondaryValidator::PolishNipChecksum => Arc::new(PolishNipChecksum),
             SecondaryValidator::PortugueseTaxIdChecksum => Arc::new(PortugueseTaxIdChecksum),

--- a/sds/src/secondary_validation/non_hex_plus_token_efficiency_checker.rs
+++ b/sds/src/secondary_validation/non_hex_plus_token_efficiency_checker.rs
@@ -1,0 +1,73 @@
+use crate::secondary_validation::Validator;
+use crate::secondary_validation::non_hex_checker::NonHexChecker;
+use crate::secondary_validation::token_efficiency::TokenEfficiencyCheck;
+
+/// Combines `NonHexChecker` and `TokenEfficiencyCheck`: a match must contain a non-hex
+/// character AND be token-inefficient to be considered a valid secret.
+///
+/// Running both checks together lets a single rule drop pure-hex substrings and natural
+/// language/identifiers without declaring two separate secondary validators.
+pub struct NonHexPlusTokenEfficiencyChecker {
+    token_efficiency_check: TokenEfficiencyCheck,
+}
+
+impl NonHexPlusTokenEfficiencyChecker {
+    pub fn new() -> Self {
+        Self {
+            token_efficiency_check: TokenEfficiencyCheck::new(),
+        }
+    }
+}
+
+impl Default for NonHexPlusTokenEfficiencyChecker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Validator for NonHexPlusTokenEfficiencyChecker {
+    fn is_valid_match(&self, regex_match: &str) -> bool {
+        NonHexChecker.is_valid_match(regex_match)
+            && self.token_efficiency_check.is_valid_match(regex_match)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::secondary_validation::Validator;
+    use crate::secondary_validation::non_hex_plus_token_efficiency_checker::NonHexPlusTokenEfficiencyChecker;
+
+    #[test]
+    fn rejects_pure_hex_even_if_token_inefficient() {
+        // A random-looking hex string is token-inefficient, but pure hex must still be rejected.
+        assert!(
+            !NonHexPlusTokenEfficiencyChecker::new()
+                .is_valid_match("0123456789abcdef0123456789abcdef")
+        );
+    }
+
+    #[test]
+    fn rejects_non_hex_natural_language() {
+        // Contains non-hex characters (spaces), but reads as natural language.
+        assert!(
+            !NonHexPlusTokenEfficiencyChecker::new()
+                .is_valid_match("this is a normal sentence with common words")
+        );
+    }
+
+    #[test]
+    fn accepts_non_hex_token_inefficient_secret() {
+        assert!(
+            NonHexPlusTokenEfficiencyChecker::new()
+                .is_valid_match("sk_live_SOKXxs00k30PUuH4KLoDPNmwlQ4EwXKw")
+        );
+    }
+
+    #[test]
+    fn rejects_non_hex_camel_case_identifier() {
+        assert!(
+            !NonHexPlusTokenEfficiencyChecker::new()
+                .is_valid_match("LibraryWebpageUploadUr1RowStatus")
+        );
+    }
+}


### PR DESCRIPTION
The validator field can only hold a single value. This caused an issue with the introduction of the `TokenEfficiencyCheck` where we occasionally would want to introduce it to rules that were already using the `NonHexChecker`, forcing a choice.

Until we can update the format to allow multiple validators, this PR introduces a new `NonHexPlusTokenEfficiencyChecker` validator that chains the two.