### PR TITLE
Improve match logging

### DIFF
--- a/sds/src/match_validation/http_validator_v2.rs
+++ b/sds/src/match_validation/http_validator_v2.rs
@@ -556,6 +556,7 @@ mod tests {
             suppressions: None,
             precedence: Precedence::default(),
             is_supporting_rule: false,
+            sds_rule_name: None,
         }
     }
 
@@ -1369,6 +1370,7 @@ calls:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                sds_rule_name: None,
             },
             RootCompiledRule {
                 inner: Box::new(MockCompiledRule),
@@ -1387,6 +1389,7 @@ calls:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                sds_rule_name: None,
             },
         ];
 
@@ -1496,6 +1499,7 @@ match_pairing:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                sds_rule_name: None,
             },
             RootCompiledRule {
                 inner: Box::new(MockCompiledRule),
@@ -1514,6 +1518,7 @@ match_pairing:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                sds_rule_name: None,
             },
         ];
 
@@ -1710,6 +1715,7 @@ match_pairing:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                sds_rule_name: None,
             },
             RootCompiledRule {
                 inner: Box::new(MockCompiledRule),
@@ -1728,6 +1734,7 @@ match_pairing:
                 suppressions: None,
                 precedence: Precedence::default(),
                 is_supporting_rule: false,
+                sds_rule_name: None,
             },
         ];
 

--- a/sds/src/scanner/metrics.rs
+++ b/sds/src/scanner/metrics.rs
@@ -1,16 +1,23 @@
 use crate::Labels;
 use metrics::{Counter, counter};
-use std::collections::BTreeMap;
+
+/// Looks up the value of a `"key:value"` tag entry by key, matching the format used by
+/// standard rule definitions (e.g. `sensitive_data:travis_ci_access_token`).
+fn get_tag_value<'a>(tags: &'a [String], key: &str) -> Option<&'a str> {
+    let prefix_len = key.len() + 1;
+    tags.iter().find_map(|tag| {
+        (tag.len() > prefix_len && tag.starts_with(key) && tag.as_bytes()[key.len()] == b':')
+            .then(|| &tag[prefix_len..])
+    })
+}
 
 /// Computes the `"{sensitive_data_category}/{sensitive_data}"` tag value for a rule from its
 /// `tags`. Missing `sensitive_data_category` falls back to `"missing_category"`. Missing
 /// `sensitive_data` yields `None`, since there's nothing meaningful to tag with.
-pub fn compute_sds_rule_name(tags: &BTreeMap<String, String>) -> Option<String> {
-    let sensitive_data = tags.get("sensitive_data")?;
-    let sensitive_data_category = tags
-        .get("sensitive_data_category")
-        .map(String::as_str)
-        .unwrap_or("missing_category");
+pub fn compute_sds_rule_name(tags: &[String]) -> Option<String> {
+    let sensitive_data = get_tag_value(tags, "sensitive_data")?;
+    let sensitive_data_category =
+        get_tag_value(tags, "sensitive_data_category").unwrap_or("missing_category");
     Some(format!("{sensitive_data_category}/{sensitive_data}"))
 }
 
@@ -66,25 +73,18 @@ impl ScannerMetrics {
 #[cfg(test)]
 mod test {
     use super::compute_sds_rule_name;
-    use std::collections::BTreeMap;
 
     #[test]
     fn compute_sds_rule_name_returns_none_for_empty_tags() {
-        assert_eq!(compute_sds_rule_name(&BTreeMap::new()), None);
+        assert_eq!(compute_sds_rule_name(&[]), None);
     }
 
     #[test]
     fn compute_sds_rule_name_concatenates_category_and_data() {
-        let tags = BTreeMap::from([
-            (
-                "sensitive_data_category".to_string(),
-                "credentials".to_string(),
-            ),
-            (
-                "sensitive_data".to_string(),
-                "travis_ci_access_token".to_string(),
-            ),
-        ]);
+        let tags = vec![
+            "sensitive_data_category:credentials".to_string(),
+            "sensitive_data:travis_ci_access_token".to_string(),
+        ];
         assert_eq!(
             compute_sds_rule_name(&tags),
             Some("credentials/travis_ci_access_token".to_string())
@@ -93,22 +93,30 @@ mod test {
 
     #[test]
     fn compute_sds_rule_name_returns_none_when_category_present_but_data_missing() {
-        let tags = BTreeMap::from([(
-            "sensitive_data_category".to_string(),
-            "credentials".to_string(),
-        )]);
+        let tags = vec!["sensitive_data_category:credentials".to_string()];
         assert_eq!(compute_sds_rule_name(&tags), None);
     }
 
     #[test]
     fn compute_sds_rule_name_falls_back_to_missing_category_when_category_absent() {
-        let tags = BTreeMap::from([(
-            "sensitive_data".to_string(),
-            "travis_ci_access_token".to_string(),
-        )]);
+        let tags = vec!["sensitive_data:travis_ci_access_token".to_string()];
         assert_eq!(
             compute_sds_rule_name(&tags),
             Some("missing_category/travis_ci_access_token".to_string())
         );
+    }
+
+    #[test]
+    fn compute_sds_rule_name_does_not_confuse_sensitive_data_category_with_sensitive_data() {
+        // "sensitive_data_category" starts with the "sensitive_data" key, so the lookup
+        // must not mistake one tag for the other.
+        let tags = vec!["sensitive_data_category:credentials".to_string()];
+        assert_eq!(compute_sds_rule_name(&tags), None);
+    }
+
+    #[test]
+    fn compute_sds_rule_name_ignores_malformed_tags_without_a_colon() {
+        let tags = vec!["sensitive_data".to_string()];
+        assert_eq!(compute_sds_rule_name(&tags), None);
     }
 }

--- a/sds/src/scanner/metrics.rs
+++ b/sds/src/scanner/metrics.rs
@@ -1,5 +1,18 @@
 use crate::Labels;
 use metrics::{Counter, counter};
+use std::collections::BTreeMap;
+
+/// Computes the `"{sensitive_data_category}/{sensitive_data}"` tag value for a rule from its
+/// `tags`. Missing `sensitive_data_category` falls back to `"missing_category"`. Missing
+/// `sensitive_data` yields `None`, since there's nothing meaningful to tag with.
+pub fn compute_sds_rule_name(tags: &BTreeMap<String, String>) -> Option<String> {
+    let sensitive_data = tags.get("sensitive_data")?;
+    let sensitive_data_category = tags
+        .get("sensitive_data_category")
+        .map(String::as_str)
+        .unwrap_or("missing_category");
+    Some(format!("{sensitive_data_category}/{sensitive_data}"))
+}
 
 #[derive(Clone)]
 pub struct RuleMetrics {
@@ -47,5 +60,55 @@ impl ScannerMetrics {
             suppressed_match_count: counter!("scanning.suppressed_match_count", labels.clone()),
             cpu_duration: counter!("scanning.cpu_duration", labels.clone()),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::compute_sds_rule_name;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn compute_sds_rule_name_returns_none_for_empty_tags() {
+        assert_eq!(compute_sds_rule_name(&BTreeMap::new()), None);
+    }
+
+    #[test]
+    fn compute_sds_rule_name_concatenates_category_and_data() {
+        let tags = BTreeMap::from([
+            (
+                "sensitive_data_category".to_string(),
+                "credentials".to_string(),
+            ),
+            (
+                "sensitive_data".to_string(),
+                "travis_ci_access_token".to_string(),
+            ),
+        ]);
+        assert_eq!(
+            compute_sds_rule_name(&tags),
+            Some("credentials/travis_ci_access_token".to_string())
+        );
+    }
+
+    #[test]
+    fn compute_sds_rule_name_returns_none_when_category_present_but_data_missing() {
+        let tags = BTreeMap::from([(
+            "sensitive_data_category".to_string(),
+            "credentials".to_string(),
+        )]);
+        assert_eq!(compute_sds_rule_name(&tags), None);
+    }
+
+    #[test]
+    fn compute_sds_rule_name_falls_back_to_missing_category_when_category_absent() {
+        let tags = BTreeMap::from([(
+            "sensitive_data".to_string(),
+            "travis_ci_access_token".to_string(),
+        )]);
+        assert_eq!(
+            compute_sds_rule_name(&tags),
+            Some("missing_category/travis_ci_access_token".to_string())
+        );
     }
 }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -32,7 +32,6 @@ use ahash::AHashMap;
 use futures::executor::block_on;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -109,8 +108,11 @@ pub struct RootRuleConfig<T> {
     precedence: Precedence,
     #[serde(default)]
     pub is_supporting_rule: bool,
+    /// Raw `"key:value"` strings, matching the format used by standard rule definitions
+    /// (e.g. `sensitive_data:travis_ci_access_token`). Not parsed into a map since no
+    /// producer of these values does so either; consumers parse the entries they need.
     #[serde(default)]
-    pub tags: BTreeMap<String, String>,
+    pub tags: Vec<String>,
     #[serde(flatten)]
     pub inner: T,
 }
@@ -139,7 +141,7 @@ impl<T> RootRuleConfig<T> {
             suppressions: None,
             precedence: Precedence::default(),
             is_supporting_rule: false,
-            tags: BTreeMap::new(),
+            tags: Vec::new(),
             inner,
         }
     }
@@ -192,7 +194,7 @@ impl<T> RootRuleConfig<T> {
         self
     }
 
-    pub fn tags(mut self, tags: BTreeMap<String, String>) -> Self {
+    pub fn tags(mut self, tags: Vec<String>) -> Self {
         self.tags = tags;
         self
     }

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -219,6 +219,10 @@ pub struct RootCompiledRule {
     pub suppressions: Option<CompiledSuppressions>,
     pub precedence: Precedence,
     pub is_supporting_rule: bool,
+    /// Precomputed `"{sensitive_data_category}/{sensitive_data}"` tag value derived from
+    /// the rule's `tags`, used to tag `scanning.match_count`. `None` when the rule has no
+    /// `sensitive_data` tag.
+    pub sds_rule_name: Option<String>,
 }
 
 impl RootCompiledRule {

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -31,6 +31,7 @@ use ahash::AHashMap;
 use futures::executor::block_on;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -107,6 +108,8 @@ pub struct RootRuleConfig<T> {
     precedence: Precedence,
     #[serde(default)]
     pub is_supporting_rule: bool,
+    #[serde(default)]
+    pub tags: BTreeMap<String, String>,
     #[serde(flatten)]
     pub inner: T,
 }
@@ -135,6 +138,7 @@ impl<T> RootRuleConfig<T> {
             suppressions: None,
             precedence: Precedence::default(),
             is_supporting_rule: false,
+            tags: BTreeMap::new(),
             inner,
         }
     }
@@ -149,6 +153,7 @@ impl<T> RootRuleConfig<T> {
             suppressions: self.suppressions,
             precedence: self.precedence,
             is_supporting_rule: self.is_supporting_rule,
+            tags: self.tags,
             inner: func(self.inner),
         }
     }
@@ -183,6 +188,11 @@ impl<T> RootRuleConfig<T> {
 
     pub fn is_supporting_rule(mut self, value: bool) -> Self {
         self.is_supporting_rule = value;
+        self
+    }
+
+    pub fn tags(mut self, tags: BTreeMap<String, String>) -> Self {
+        self.tags = tags;
         self
     }
 

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -1147,6 +1147,7 @@ impl ScannerBuilder<'_> {
                     suppressions: compiled_suppressions,
                     precedence: config.precedence,
                     is_supporting_rule: config.is_supporting_rule,
+                    sds_rule_name: metrics::compute_sds_rule_name(&config.tags),
                 })
             })
             .collect::<Result<Vec<RootCompiledRule>, CreateScannerError>>()?;

--- a/sds/src/scanner/mod.rs
+++ b/sds/src/scanner/mod.rs
@@ -27,6 +27,7 @@ pub use crate::secondary_validation::Validator;
 use crate::stats::GLOBAL_STATS;
 use crate::tokio::TOKIO_RUNTIME;
 use crate::{CreateScannerError, EncodeIndices, MatchAction, Path, ScannerError};
+use ::metrics::counter;
 use ahash::AHashMap;
 use futures::executor::block_on;
 use serde::{Deserialize, Serialize};
@@ -599,10 +600,26 @@ impl Scanner {
     ) {
         // Add number of scanned events
         self.metrics.num_scanned_events.increment(1);
-        // Add number of matches
-        self.metrics
-            .match_count
-            .increment(output_rule_matches.len() as u64);
+        // Add number of matches, tagged per rule so `sds_rule_name` can break down match counts
+        // by the rule's sensitive_data_category/sensitive_data tags.
+        let mut match_counts_by_rule: AHashMap<usize, u64> = AHashMap::new();
+        for rule_match in output_rule_matches {
+            *match_counts_by_rule
+                .entry(rule_match.rule_index)
+                .or_default() += 1;
+        }
+        for (rule_index, count) in match_counts_by_rule {
+            match self.rules[rule_index].sds_rule_name.as_deref() {
+                Some(sds_rule_name) => {
+                    let labels = self.labels.clone_with_labels(Labels::new(&[(
+                        "sds_rule_name",
+                        sds_rule_name.to_string(),
+                    )]));
+                    counter!("scanning.match_count", labels).increment(count);
+                }
+                None => self.metrics.match_count.increment(count),
+            }
+        }
 
         if let Some(io_duration) = io_duration {
             let total_duration = start.elapsed();

--- a/sds/src/scanner/test/metrics.rs
+++ b/sds/src/scanner/test/metrics.rs
@@ -62,6 +62,185 @@ fn should_submit_scanning_metrics() {
 }
 
 #[test]
+fn should_submit_match_count_metric_tagged_with_sds_rule_name() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    metrics::with_local_recorder(&recorder, || {
+        let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("secret").build())
+            .match_action(MatchAction::None)
+            .tags(BTreeMap::from([
+                (
+                    "sensitive_data_category".to_string(),
+                    "credentials".to_string(),
+                ),
+                (
+                    "sensitive_data".to_string(),
+                    "travis_ci_access_token".to_string(),
+                ),
+            ]));
+
+        let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
+        let mut content = SimpleEvent::Map(BTreeMap::from([(
+            "key1".to_string(),
+            SimpleEvent::String("secret".to_string()),
+        )]));
+
+        scanner.scan(&mut content).unwrap();
+    });
+
+    let snapshot = snapshotter.snapshot().into_hashmap();
+
+    let metric_name = "scanning.match_count";
+    let labels = vec![Label::new(
+        "sds_rule_name",
+        "credentials/travis_ci_access_token",
+    )];
+    let metric_value = snapshot
+        .get(&CompositeKey::new(
+            Counter,
+            Key::from_parts(metric_name, labels),
+        ))
+        .expect("tagged match_count metric not found");
+
+    assert_eq!(metric_value, &(None, None, DebugValue::Counter(1)));
+}
+
+#[test]
+fn should_submit_match_count_metric_with_missing_category_tag() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    metrics::with_local_recorder(&recorder, || {
+        let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("secret").build())
+            .match_action(MatchAction::None)
+            .tags(BTreeMap::from([(
+                "sensitive_data".to_string(),
+                "travis_ci_access_token".to_string(),
+            )]));
+
+        let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
+        let mut content = SimpleEvent::Map(BTreeMap::from([(
+            "key1".to_string(),
+            SimpleEvent::String("secret".to_string()),
+        )]));
+
+        scanner.scan(&mut content).unwrap();
+    });
+
+    let snapshot = snapshotter.snapshot().into_hashmap();
+
+    let metric_name = "scanning.match_count";
+    let labels = vec![Label::new(
+        "sds_rule_name",
+        "missing_category/travis_ci_access_token",
+    )];
+    let metric_value = snapshot
+        .get(&CompositeKey::new(
+            Counter,
+            Key::from_parts(metric_name, labels),
+        ))
+        .expect("tagged match_count metric not found");
+
+    assert_eq!(metric_value, &(None, None, DebugValue::Counter(1)));
+}
+
+#[test]
+fn should_submit_untagged_match_count_metric_when_sensitive_data_tag_is_missing() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    metrics::with_local_recorder(&recorder, || {
+        let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("secret").build())
+            .match_action(MatchAction::None)
+            .tags(BTreeMap::from([(
+                "sensitive_data_category".to_string(),
+                "credentials".to_string(),
+            )]));
+
+        let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
+        let mut content = SimpleEvent::Map(BTreeMap::from([(
+            "key1".to_string(),
+            SimpleEvent::String("secret".to_string()),
+        )]));
+
+        scanner.scan(&mut content).unwrap();
+    });
+
+    let snapshot = snapshotter.snapshot().into_hashmap();
+
+    let metric_name = "scanning.match_count";
+    let metric_value = snapshot
+        .get(&CompositeKey::new(Counter, Key::from_name(metric_name)))
+        .expect("untagged match_count metric not found");
+
+    assert_eq!(metric_value, &(None, None, DebugValue::Counter(1)));
+}
+
+#[test]
+fn should_submit_separately_tagged_match_count_metrics_for_multiple_rules() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    metrics::with_local_recorder(&recorder, || {
+        let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("secret").build())
+            .match_action(MatchAction::None)
+            .tags(BTreeMap::from([
+                (
+                    "sensitive_data_category".to_string(),
+                    "credentials".to_string(),
+                ),
+                (
+                    "sensitive_data".to_string(),
+                    "travis_ci_access_token".to_string(),
+                ),
+            ]));
+        let rule_1 = RootRuleConfig::new(RegexRuleConfig::new("foo").build())
+            .match_action(MatchAction::None)
+            .tags(BTreeMap::from([
+                ("sensitive_data_category".to_string(), "pii".to_string()),
+                ("sensitive_data".to_string(), "email".to_string()),
+            ]));
+
+        let scanner = ScannerBuilder::new(&[rule_0, rule_1]).build().unwrap();
+        let mut content = SimpleEvent::Map(BTreeMap::from([(
+            "key1".to_string(),
+            SimpleEvent::String("secret foo".to_string()),
+        )]));
+
+        scanner.scan(&mut content).unwrap();
+    });
+
+    let snapshot = snapshotter.snapshot().into_hashmap();
+
+    let metric_name = "scanning.match_count";
+
+    let credentials_labels = vec![Label::new(
+        "sds_rule_name",
+        "credentials/travis_ci_access_token",
+    )];
+    let credentials_metric_value = snapshot
+        .get(&CompositeKey::new(
+            Counter,
+            Key::from_parts(metric_name, credentials_labels),
+        ))
+        .expect("credentials match_count metric not found");
+    assert_eq!(
+        credentials_metric_value,
+        &(None, None, DebugValue::Counter(1))
+    );
+
+    let pii_labels = vec![Label::new("sds_rule_name", "pii/email")];
+    let pii_metric_value = snapshot
+        .get(&CompositeKey::new(
+            Counter,
+            Key::from_parts(metric_name, pii_labels),
+        ))
+        .expect("pii match_count metric not found");
+    assert_eq!(pii_metric_value, &(None, None, DebugValue::Counter(1)));
+}
+
+#[test]
 fn should_submit_excluded_match_metric() {
     let recorder = DebuggingRecorder::new();
     let snapshotter = recorder.snapshotter();

--- a/sds/src/scanner/test/metrics.rs
+++ b/sds/src/scanner/test/metrics.rs
@@ -69,16 +69,10 @@ fn should_submit_match_count_metric_tagged_with_sds_rule_name() {
     metrics::with_local_recorder(&recorder, || {
         let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("secret").build())
             .match_action(MatchAction::None)
-            .tags(BTreeMap::from([
-                (
-                    "sensitive_data_category".to_string(),
-                    "credentials".to_string(),
-                ),
-                (
-                    "sensitive_data".to_string(),
-                    "travis_ci_access_token".to_string(),
-                ),
-            ]));
+            .tags(vec![
+                "sensitive_data_category:credentials".to_string(),
+                "sensitive_data:travis_ci_access_token".to_string(),
+            ]);
 
         let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
         let mut content = SimpleEvent::Map(BTreeMap::from([(
@@ -114,10 +108,7 @@ fn should_submit_match_count_metric_with_missing_category_tag() {
     metrics::with_local_recorder(&recorder, || {
         let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("secret").build())
             .match_action(MatchAction::None)
-            .tags(BTreeMap::from([(
-                "sensitive_data".to_string(),
-                "travis_ci_access_token".to_string(),
-            )]));
+            .tags(vec!["sensitive_data:travis_ci_access_token".to_string()]);
 
         let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
         let mut content = SimpleEvent::Map(BTreeMap::from([(
@@ -153,10 +144,7 @@ fn should_submit_untagged_match_count_metric_when_sensitive_data_tag_is_missing(
     metrics::with_local_recorder(&recorder, || {
         let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("secret").build())
             .match_action(MatchAction::None)
-            .tags(BTreeMap::from([(
-                "sensitive_data_category".to_string(),
-                "credentials".to_string(),
-            )]));
+            .tags(vec!["sensitive_data_category:credentials".to_string()]);
 
         let scanner = ScannerBuilder::new(&[rule_0]).build().unwrap();
         let mut content = SimpleEvent::Map(BTreeMap::from([(
@@ -185,22 +173,16 @@ fn should_submit_separately_tagged_match_count_metrics_for_multiple_rules() {
     metrics::with_local_recorder(&recorder, || {
         let rule_0 = RootRuleConfig::new(RegexRuleConfig::new("secret").build())
             .match_action(MatchAction::None)
-            .tags(BTreeMap::from([
-                (
-                    "sensitive_data_category".to_string(),
-                    "credentials".to_string(),
-                ),
-                (
-                    "sensitive_data".to_string(),
-                    "travis_ci_access_token".to_string(),
-                ),
-            ]));
+            .tags(vec![
+                "sensitive_data_category:credentials".to_string(),
+                "sensitive_data:travis_ci_access_token".to_string(),
+            ]);
         let rule_1 = RootRuleConfig::new(RegexRuleConfig::new("foo").build())
             .match_action(MatchAction::None)
-            .tags(BTreeMap::from([
-                ("sensitive_data_category".to_string(), "pii".to_string()),
-                ("sensitive_data".to_string(), "email".to_string()),
-            ]));
+            .tags(vec![
+                "sensitive_data_category:pii".to_string(),
+                "sensitive_data:email".to_string(),
+            ]);
 
         let scanner = ScannerBuilder::new(&[rule_0, rule_1]).build().unwrap();
         let mut content = SimpleEvent::Map(BTreeMap::from([(


### PR DESCRIPTION
The current logging emit a metric for every match, but with almost no metadata.
This makes fleet monitoring challenging since an increase in activity can't be tied to a precise rule, and the performance of a given rule can't easily be isolated.

This change introduce a new `sds_rule_name` tag with the category and name of the rule