### PR TITLE
sds-go: add NotExpired JWT claim requirement

### DIFF
--- a/sds-go/go/jwt_claims_validator.go
+++ b/sds-go/go/jwt_claims_validator.go
@@ -62,6 +62,17 @@ func (c ClaimRequirementPresent) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// ClaimRequirementNotExpired represents a claim that must be present and not expired
+type ClaimRequirementNotExpired struct{}
+
+func (c ClaimRequirementNotExpired) claimRequirementType() string { return "NotExpired" }
+
+func (c ClaimRequirementNotExpired) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"type": "NotExpired",
+	})
+}
+
 // ClaimRequirementExactValue represents a claim that must have an exact string value
 type ClaimRequirementExactValue struct {
 	Value string
@@ -106,6 +117,8 @@ func UnmarshalClaimRequirement(data []byte) (ClaimRequirement, error) {
 	switch rawRequirement.Type {
 	case "Present":
 		return ClaimRequirementPresent{}, nil
+	case "NotExpired":
+		return ClaimRequirementNotExpired{}, nil
 	case "ExactValue":
 		return ClaimRequirementExactValue{Value: rawRequirement.Config}, nil
 	case "RegexMatch":

--- a/sds-go/go/jwt_claims_validator_test.go
+++ b/sds-go/go/jwt_claims_validator_test.go
@@ -97,6 +97,22 @@ func TestJwtClaimsValidatorConfig_UnmarshalJSON(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "config with not expired claim",
+			jsonData: `{
+				"required_claims": {
+					"exp": {"type": "NotExpired"}
+				},
+				"required_headers": {}
+			}`,
+			expected: JwtClaimsValidatorConfig{
+				RequiredClaims: map[string]ClaimRequirement{
+					"exp": ClaimRequirementNotExpired{},
+				},
+				RequiredHeaders: map[string]ClaimRequirement{},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -153,6 +169,7 @@ func TestJwtClaimsValidatorConfig_MarshalJSON(t *testing.T) {
 		RequiredClaims: map[string]ClaimRequirement{
 			"sub": ClaimRequirementPresent{},
 			"iss": ClaimRequirementExactValue{Value: "my-issuer"},
+			"exp": ClaimRequirementNotExpired{},
 		},
 		RequiredHeaders: map[string]ClaimRequirement{
 			"kid": ClaimRequirementExactValue{Value: "key-123"},
@@ -179,6 +196,10 @@ func TestJwtClaimsValidatorConfig_MarshalJSON(t *testing.T) {
 
 	if len(unmarshaledConfig.RequiredHeaders) != len(config.RequiredHeaders) {
 		t.Errorf("RequiredHeaders length after round-trip = %v, want %v", len(unmarshaledConfig.RequiredHeaders), len(config.RequiredHeaders))
+	}
+
+	if unmarshaledConfig.RequiredClaims["exp"].claimRequirementType() != "NotExpired" {
+		t.Errorf("RequiredClaims[exp] type after round-trip = %v, want NotExpired", unmarshaledConfig.RequiredClaims["exp"].claimRequirementType())
 	}
 }
 

--- a/sds-go/go/scanner_test.go
+++ b/sds-go/go/scanner_test.go
@@ -2,6 +2,8 @@ package dd_sds
 
 import (
 	"bytes"
+	"encoding/base64"
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -632,6 +634,45 @@ func TestJWTSecondaryValidator(t *testing.T) {
 		},
 	}
 	runTest(t, scannerWithChecksum, testData, false)
+
+	t.Run("not expired", func(t *testing.T) {
+		expired := jwtWithExp(1)
+		unexpired := jwtWithExp(4102444800)
+		event := expired + " " + unexpired
+
+		scanner, err := CreateScanner([]RuleConfig{
+			RegexRuleConfig{
+				Id:          "jwt_exp",
+				Pattern:     `eyJhbGciOiJub25lIn0\.[A-Za-z0-9_-]+\.sig`,
+				MatchAction: MatchAction{Type: MatchActionRedact, RedactionValue: "[redacted]"},
+				SecondaryValidator: NewJwtClaimsValidator(JwtClaimsValidatorConfig{
+					RequiredHeaders: map[string]ClaimRequirement{},
+					RequiredClaims: map[string]ClaimRequirement{
+						"exp": ClaimRequirementNotExpired{},
+					},
+				}),
+			},
+		})
+		if err != nil {
+			t.Fatal("failed to create the scanner:", err.Error())
+		}
+		defer scanner.Delete()
+
+		result, err := scanner.Scan([]byte(event))
+		if err != nil {
+			t.Fatal("failed to scan the event:", err.Error())
+		}
+		want := expired + " [redacted]"
+		if string(result.Event) != want {
+			t.Fatalf("expected mutated event %q, got %q", want, result.Event)
+		}
+	})
+}
+
+func jwtWithExp(exp int64) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, exp)))
+	return header + "." + payload + ".sig"
 }
 
 func TestThirdPartyActiveChecker(t *testing.T) {


### PR DESCRIPTION
The Rust ClaimRequirement enum already includes NotExpired, but the Go bindings only decoded Present, ExactValue, and RegexMatch. Unmarshaling a JwtClaimsValidator config with "type":"NotExpired" failed.

Add ClaimRequirementNotExpired with the same tagged-union JSON as Present.

[ticket](https://datadoghq.atlassian.net/browse/DATASEC-201?atlOrigin=eyJpIjoiZDAxZDk4YWJlNGFkNDY4ODljOTdmNjkzZTIzZjVmNDMiLCJwIjoiaiJ9)