### PR TITLE
sds-go: add CustomHttpV2 third-party active checker

### DIFF
--- a/sds-go/go/regex_rule.go
+++ b/sds-go/go/regex_rule.go
@@ -26,55 +26,6 @@ type RegexRuleConfig struct {
 	IsSupportingRule        bool                     `json:"is_supporting_rule,omitempty"`
 }
 
-// ThirdPartyActiveChecker is used to validate if a given match is still active or not. It applies well to tokens that have an expiration date for instance.
-type ThirdPartyActiveChecker struct {
-	Type   string                        `json:"type"`
-	Config ThirdPartyActiveCheckerConfig `json:"config"`
-}
-
-type ThirdPartyActiveCheckerConfig struct {
-	*ThirdPartyActiveCheckerConfigAws
-	*ThirdPartyActiveCheckerConfigHttp
-}
-
-type Duration struct {
-	Seconds uint64 `json:"secs"`
-	Nanos   uint64 `json:"nanos"`
-}
-
-type ThirdPartyActiveCheckerConfigAws struct {
-	Kind           string   `json:"kind"`
-	AwsStsEndpoint string   `json:"aws_sts_endpoint"`
-	Timeout        Duration `json:"timeout"`
-}
-
-type StatusCodeRange struct {
-	Start int `json:"start"`
-	End   int `json:"end"`
-}
-
-type ThirdPartyActiveCheckerConfigHttp struct {
-	Endpoint               string            `json:"endpoint"`
-	Hosts                  []string          `json:"hosts,omitempty"`
-	Method                 string            `json:"http_method"`
-	RequestHeader          map[string]string `json:"request_headers"`
-	ValidHttpStatusCodes   []StatusCodeRange `json:"valid_http_status_code"`
-	InvalidHttpStatusCodes []StatusCodeRange `json:"invalid_http_status_code"`
-	Timeout                int               `json:"timeout_seconds"`
-}
-
-// MarshalJSON implements custom JSON marshaling to handle empty validation types
-func (t ThirdPartyActiveChecker) MarshalJSON() ([]byte, error) {
-	// If Type is empty, marshal as null to omit the field
-	if t.Type == "" {
-		return []byte("null"), nil
-	}
-
-	// Otherwise, marshal normally
-	type Alias ThirdPartyActiveChecker
-	return json.Marshal((Alias)(t))
-}
-
 type MatchActionType string
 type ReplacementType string
 type Precedence string
@@ -209,11 +160,12 @@ type MatchStatus string
 
 const (
 	// The ordering here is important, values further down the list have a higher priority when merging.
-	MatchStatusNotChecked   = MatchStatus("NotChecked")
-	MatchStatusNotAvailable = MatchStatus("NotAvailable")
-	MatchStatusInvalid      = MatchStatus("Invalid")
-	MatchStatusError        = MatchStatus("Error")
-	MatchStatusValid        = MatchStatus("Valid")
+	MatchStatusNotChecked            = MatchStatus("NotChecked")
+	MatchStatusNotAvailable          = MatchStatus("NotAvailable")
+	MatchStatusMissingDependentMatch = MatchStatus("MissingDependentMatch")
+	MatchStatusInvalid               = MatchStatus("Invalid")
+	MatchStatusError                 = MatchStatus("Error")
+	MatchStatusValid                 = MatchStatus("Valid")
 )
 
 // RuleMatch stores the matches reported by the core library.

--- a/sds-go/go/third_party_active_checker.go
+++ b/sds-go/go/third_party_active_checker.go
@@ -1,0 +1,324 @@
+package dd_sds
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+type ThirdPartyActiveCheckerType string
+
+const (
+	ThirdPartyActiveCheckerAws    = ThirdPartyActiveCheckerType("Aws")
+	ThirdPartyActiveCheckerHttp   = ThirdPartyActiveCheckerType("CustomHttp")
+	ThirdPartyActiveCheckerHttpV2 = ThirdPartyActiveCheckerType("CustomHttpV2")
+)
+
+type ThirdPartyActiveChecker struct {
+	Type   ThirdPartyActiveCheckerType   `json:"type"`
+	Config ThirdPartyActiveCheckerConfig `json:"config"`
+}
+
+type ThirdPartyActiveCheckerConfig struct {
+	*ThirdPartyActiveCheckerConfigAws
+	*ThirdPartyActiveCheckerConfigHttp
+	*ThirdPartyActiveCheckerConfigHttpV2
+}
+
+func NewThirdPartyActiveCheckerAws(kind ThirdPartyActiveCheckerKind, awsStsEndpoint string, timeout Duration) *ThirdPartyActiveChecker {
+	return &ThirdPartyActiveChecker{
+		Type: ThirdPartyActiveCheckerAws,
+		Config: ThirdPartyActiveCheckerConfig{
+			ThirdPartyActiveCheckerConfigAws: &ThirdPartyActiveCheckerConfigAws{
+				Kind:           kind,
+				AwsStsEndpoint: awsStsEndpoint,
+				Timeout:        timeout,
+			},
+		},
+	}
+}
+
+func NewThirdPartyActiveCheckerHttp(endpoint string, hosts []string, method ThirdPartyActiveCheckerHttpMethod, requestHeaders map[string]string, validHttpStatusCodes []StatusCodeRange, invalidHttpStatusCodes []StatusCodeRange, timeout int) *ThirdPartyActiveChecker {
+	return &ThirdPartyActiveChecker{
+		Type: ThirdPartyActiveCheckerHttp,
+		Config: ThirdPartyActiveCheckerConfig{
+			ThirdPartyActiveCheckerConfigHttp: &ThirdPartyActiveCheckerConfigHttp{
+				Endpoint:               endpoint,
+				Hosts:                  hosts,
+				Method:                 method,
+				RequestHeader:          requestHeaders,
+				ValidHttpStatusCodes:   validHttpStatusCodes,
+				InvalidHttpStatusCodes: invalidHttpStatusCodes,
+				Timeout:                timeout,
+			},
+		},
+	}
+}
+
+func NewThirdPartyActiveCheckerHttpV2(config ThirdPartyActiveCheckerConfigHttpV2) *ThirdPartyActiveChecker {
+	return &ThirdPartyActiveChecker{
+		Type: ThirdPartyActiveCheckerHttpV2,
+		Config: ThirdPartyActiveCheckerConfig{
+			ThirdPartyActiveCheckerConfigHttpV2: &config,
+		},
+	}
+}
+
+func (m ThirdPartyActiveChecker) IsThirdPartyActiveCheckerConfigAws() bool {
+	return m.Config.ThirdPartyActiveCheckerConfigAws != nil
+}
+
+func (m ThirdPartyActiveChecker) IsThirdPartyActiveCheckerConfigHttp() bool {
+	return m.Config.ThirdPartyActiveCheckerConfigHttp != nil
+}
+
+func (m ThirdPartyActiveChecker) IsThirdPartyActiveCheckerConfigHttpV2() bool {
+	return m.Config.ThirdPartyActiveCheckerConfigHttpV2 != nil
+}
+
+type ThirdPartyActiveCheckerConfigAws struct {
+	Kind           ThirdPartyActiveCheckerKind `json:"kind"`
+	AwsStsEndpoint string                      `json:"aws_sts_endpoint"`
+	Timeout        Duration                    `json:"timeout"`
+}
+
+type ThirdPartyActiveCheckerKind string
+
+const (
+	ThirdPartyActiveCheckerAwsId      = ThirdPartyActiveCheckerKind("AwsId")
+	ThirdPartyActiveCheckerAwsSecret  = ThirdPartyActiveCheckerKind("AwsSecret")
+	ThirdPartyActiveCheckerAwsSession = ThirdPartyActiveCheckerKind("AwsSession")
+)
+
+type ThirdPartyActiveCheckerHttpMethod string
+
+const (
+	MethodGet    = ThirdPartyActiveCheckerHttpMethod("GET")
+	MethodPost   = ThirdPartyActiveCheckerHttpMethod("POST")
+	MethodPut    = ThirdPartyActiveCheckerHttpMethod("PUT")
+	MethodDelete = ThirdPartyActiveCheckerHttpMethod("DELETE")
+	MethodPatch  = ThirdPartyActiveCheckerHttpMethod("PATCH")
+)
+
+type StatusCodeRange struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+type Duration struct {
+	Seconds uint64 `json:"secs"`
+	Nanos   uint64 `json:"nanos"`
+}
+
+type ThirdPartyActiveCheckerConfigHttp struct {
+	Endpoint               string                            `json:"endpoint"`
+	Hosts                  []string                          `json:"hosts,omitempty"`
+	Method                 ThirdPartyActiveCheckerHttpMethod `json:"http_method"`
+	RequestHeader          map[string]string                 `json:"request_headers"`
+	ValidHttpStatusCodes   []StatusCodeRange                 `json:"valid_http_status_code"`
+	InvalidHttpStatusCodes []StatusCodeRange                 `json:"invalid_http_status_code"`
+	Timeout                int                               `json:"timeout_seconds"`
+}
+
+type ThirdPartyActiveCheckerConfigHttpV2 struct {
+	MatchPairing *MatchPairingConfig                            `json:"match_pairing,omitempty"`
+	Provides     []ThirdPartyActiveCheckerConfigPairedValidator `json:"provides,omitempty"`
+	Calls        []HttpCallConfig                               `json:"calls,omitempty"`
+}
+
+type ThirdPartyActiveCheckerConfigPairedValidator struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+type MatchPairingConfig struct {
+	Kind       string            `json:"kind"`
+	Parameters map[string]string `json:"-"`
+}
+
+func (m MatchPairingConfig) MarshalJSON() ([]byte, error) {
+	result := make(map[string]interface{})
+	result["kind"] = m.Kind
+	for k, v := range m.Parameters {
+		result[k] = v
+	}
+	return json.Marshal(result)
+}
+
+func (m *MatchPairingConfig) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if kind, ok := raw["kind"].(string); ok {
+		m.Kind = kind
+		delete(raw, "kind")
+	}
+
+	m.Parameters = make(map[string]string)
+	for k, v := range raw {
+		if str, ok := v.(string); ok {
+			m.Parameters[k] = str
+		}
+	}
+
+	return nil
+}
+
+type HttpCallConfig struct {
+	Request  HttpRequestConfig  `json:"request"`
+	Response HttpResponseConfig `json:"response"`
+}
+
+type HttpRequestConfig struct {
+	Endpoint string            `json:"endpoint"`
+	Method   string            `json:"method"`
+	Hosts    []string          `json:"hosts,omitempty"`
+	Headers  map[string]string `json:"headers,omitempty"`
+	Body     *string           `json:"body,omitempty"`
+	Timeout  *Duration         `json:"timeout,omitempty"`
+}
+
+type HttpResponseConfig struct {
+	Conditions []ResponseCondition `json:"conditions"`
+}
+
+type ResponseCondition struct {
+	Type       string                  `json:"type"`
+	StatusCode *StatusCodeMatcher      `json:"status_code,omitempty"`
+	RawBody    *BodyMatcher            `json:"raw_body,omitempty"`
+	Body       map[string]*BodyMatcher `json:"body,omitempty"`
+}
+
+type StatusCodeMatcher struct {
+	Single *int             `json:"-"`
+	List   []int            `json:"-"`
+	Range  *StatusCodeRange `json:"-"`
+}
+
+type BodyMatcherType string
+
+const (
+	BodyMatcherPresent    BodyMatcherType = "Present"
+	BodyMatcherExactMatch BodyMatcherType = "ExactMatch"
+	BodyMatcherRegex      BodyMatcherType = "Regex"
+)
+
+type BodyMatcher struct {
+	Type   BodyMatcherType `json:"type"`
+	Config *string         `json:"config,omitempty"`
+}
+
+func (t ThirdPartyActiveChecker) MarshalJSON() ([]byte, error) {
+	if t.Type == "" {
+		return []byte("null"), nil
+	}
+
+	type Alias ThirdPartyActiveChecker
+	return json.Marshal((Alias)(t))
+}
+
+func (m ThirdPartyActiveCheckerConfig) MarshalJSON() ([]byte, error) {
+	if m.ThirdPartyActiveCheckerConfigAws != nil {
+		return json.Marshal(m.ThirdPartyActiveCheckerConfigAws)
+	}
+	if m.ThirdPartyActiveCheckerConfigHttpV2 != nil {
+		return json.Marshal(m.ThirdPartyActiveCheckerConfigHttpV2)
+	}
+	return json.Marshal(m.ThirdPartyActiveCheckerConfigHttp)
+}
+
+func (m StatusCodeMatcher) MarshalJSON() ([]byte, error) {
+	if m.Single != nil {
+		return json.Marshal(*m.Single)
+	}
+	if m.List != nil {
+		return json.Marshal(m.List)
+	}
+	if m.Range != nil {
+		return json.Marshal(m.Range)
+	}
+	return []byte("null"), nil
+}
+
+func (m *StatusCodeMatcher) UnmarshalJSON(data []byte) error {
+	var single int
+	if err := json.Unmarshal(data, &single); err == nil {
+		m.Single = &single
+		return nil
+	}
+
+	var list []int
+	if err := json.Unmarshal(data, &list); err == nil {
+		m.List = list
+		return nil
+	}
+
+	var rangeObj StatusCodeRange
+	if err := json.Unmarshal(data, &rangeObj); err == nil {
+		m.Range = &rangeObj
+		return nil
+	}
+
+	return fmt.Errorf("unable to unmarshal StatusCodeMatcher from: %s", string(data))
+}
+
+func (m ThirdPartyActiveCheckerConfigAws) MarshalJSON() ([]byte, error) {
+	o := map[string]interface{}{
+		"kind": string(m.Kind),
+	}
+
+	if m.Kind == ThirdPartyActiveCheckerAwsSecret {
+		o["aws_sts_endpoint"] = m.AwsStsEndpoint
+		o["timeout"] = m.Timeout
+	}
+
+	return json.Marshal(o)
+}
+
+func (m *ThirdPartyActiveChecker) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte("null")) {
+		*m = ThirdPartyActiveChecker{}
+		return nil
+	}
+
+	var rawMap struct {
+		Type   string          `json:"type"`
+		Config json.RawMessage `json:"config"`
+	}
+	if err := json.Unmarshal(data, &rawMap); err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(rawMap.Config))
+	decoder.DisallowUnknownFields()
+
+	switch rawMap.Type {
+	case "Aws":
+		m.Type = ThirdPartyActiveCheckerAws
+		var config ThirdPartyActiveCheckerConfigAws
+		if err := decoder.Decode(&config); err != nil {
+			return err
+		}
+		m.Config = ThirdPartyActiveCheckerConfig{ThirdPartyActiveCheckerConfigAws: &config}
+	case "CustomHttp":
+		m.Type = ThirdPartyActiveCheckerHttp
+		var config ThirdPartyActiveCheckerConfigHttp
+		if err := decoder.Decode(&config); err != nil {
+			return err
+		}
+		m.Config = ThirdPartyActiveCheckerConfig{ThirdPartyActiveCheckerConfigHttp: &config}
+	case "CustomHttpV2":
+		m.Type = ThirdPartyActiveCheckerHttpV2
+		var config ThirdPartyActiveCheckerConfigHttpV2
+		if err := decoder.Decode(&config); err != nil {
+			return err
+		}
+		m.Config = ThirdPartyActiveCheckerConfig{ThirdPartyActiveCheckerConfigHttpV2: &config}
+	default:
+		return fmt.Errorf("unknown third party active checker type: %s", rawMap.Type)
+	}
+
+	return nil
+}

--- a/sds-go/go/third_party_active_checker_test.go
+++ b/sds-go/go/third_party_active_checker_test.go
@@ -1,0 +1,610 @@
+package dd_sds
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func compactJSON(t *testing.T, s string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, []byte(s)); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+func Test_ThirdPartyActiveChecker_CustomHttpV2_RoundTrip(t *testing.T) {
+	testCases := map[string]struct {
+		mv             ThirdPartyActiveChecker
+		expectedResult string
+	}{
+		"should successfully marshal a simple CustomHttpV2 validation": {
+			mv: ThirdPartyActiveChecker{
+				Type: ThirdPartyActiveCheckerHttpV2,
+				Config: ThirdPartyActiveCheckerConfig{
+					ThirdPartyActiveCheckerConfigHttpV2: &ThirdPartyActiveCheckerConfigHttpV2{
+						Calls: []HttpCallConfig{
+							{
+								Request: HttpRequestConfig{
+									Endpoint: "https://api.example.com/validate?token=$MATCH",
+									Method:   "GET",
+									Headers: map[string]string{
+										"User-Agent": "Datadog Match Validator",
+									},
+								},
+								Response: HttpResponseConfig{
+									Conditions: []ResponseCondition{
+										{
+											Type:       "valid",
+											StatusCode: &StatusCodeMatcher{Single: intPtr(200)},
+										},
+										{
+											Type:       "invalid",
+											StatusCode: &StatusCodeMatcher{Range: &StatusCodeRange{Start: 400, End: 500}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: `{
+				"type": "CustomHttpV2",
+				"config": {
+					"calls": [{
+						"request": {
+							"endpoint": "https://api.example.com/validate?token=$MATCH",
+							"method": "GET",
+							"headers": {
+								"User-Agent": "Datadog Match Validator"
+							}
+						},
+						"response": {
+							"conditions": [
+								{"type": "valid", "status_code": 200},
+								{"type": "invalid", "status_code": {"start": 400, "end": 500}}
+							]
+						}
+					}]
+				}
+			}`,
+		},
+		"should successfully marshal CustomHttpV2 with match pairing": {
+			mv: ThirdPartyActiveChecker{
+				Type: ThirdPartyActiveCheckerHttpV2,
+				Config: ThirdPartyActiveCheckerConfig{
+					ThirdPartyActiveCheckerConfigHttpV2: &ThirdPartyActiveCheckerConfigHttpV2{
+						MatchPairing: &MatchPairingConfig{
+							Kind: "vendorX",
+							Parameters: map[string]string{
+								"client_subdomain": "$CLIENT_SUBDOMAIN",
+								"client_id":        "$CLIENT_ID",
+							},
+						},
+						Calls: []HttpCallConfig{
+							{
+								Request: HttpRequestConfig{
+									Endpoint: "https://$CLIENT_SUBDOMAIN.vendor.com/api/v1/token/$MATCH",
+									Method:   "POST",
+									Headers: map[string]string{
+										"Authorization": "Basic $CLIENT_ID",
+										"Content-Type":  "application/json",
+									},
+								},
+								Response: HttpResponseConfig{
+									Conditions: []ResponseCondition{
+										{
+											Type:       "valid",
+											StatusCode: &StatusCodeMatcher{Single: intPtr(200)},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: `{
+				"type": "CustomHttpV2",
+				"config": {
+					"match_pairing": {
+						"client_id": "$CLIENT_ID",
+						"client_subdomain": "$CLIENT_SUBDOMAIN",
+						"kind": "vendorX"
+					},
+					"calls": [{
+						"request": {
+							"endpoint": "https://$CLIENT_SUBDOMAIN.vendor.com/api/v1/token/$MATCH",
+							"method": "POST",
+							"headers": {
+								"Authorization": "Basic $CLIENT_ID",
+								"Content-Type": "application/json"
+							}
+						},
+						"response": {
+							"conditions": [
+								{"type": "valid", "status_code": 200}
+							]
+						}
+					}]
+				}
+			}`,
+		},
+		"should successfully marshal CustomHttpV2 with status code list": {
+			mv: ThirdPartyActiveChecker{
+				Type: ThirdPartyActiveCheckerHttpV2,
+				Config: ThirdPartyActiveCheckerConfig{
+					ThirdPartyActiveCheckerConfigHttpV2: &ThirdPartyActiveCheckerConfigHttpV2{
+						Calls: []HttpCallConfig{
+							{
+								Request: HttpRequestConfig{
+									Endpoint: "https://api.example.com/check",
+									Method:   "GET",
+								},
+								Response: HttpResponseConfig{
+									Conditions: []ResponseCondition{
+										{
+											Type:       "valid",
+											StatusCode: &StatusCodeMatcher{List: []int{200, 201, 204}},
+										},
+										{
+											Type:       "invalid",
+											StatusCode: &StatusCodeMatcher{List: []int{401, 403, 404}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: `{
+				"type": "CustomHttpV2",
+				"config": {
+					"calls": [{
+						"request": {
+							"endpoint": "https://api.example.com/check",
+							"method": "GET"
+						},
+						"response": {
+							"conditions": [
+								{"type": "valid", "status_code": [200, 201, 204]},
+								{"type": "invalid", "status_code": [401, 403, 404]}
+							]
+						}
+					}]
+				}
+			}`,
+		},
+		"should successfully marshal CustomHttpV2 with body matchers": {
+			mv: ThirdPartyActiveChecker{
+				Type: ThirdPartyActiveCheckerHttpV2,
+				Config: ThirdPartyActiveCheckerConfig{
+					ThirdPartyActiveCheckerConfigHttpV2: &ThirdPartyActiveCheckerConfigHttpV2{
+						Calls: []HttpCallConfig{
+							{
+								Request: HttpRequestConfig{
+									Endpoint: "https://api.example.com/verify",
+									Method:   "GET",
+								},
+								Response: HttpResponseConfig{
+									Conditions: []ResponseCondition{
+										{
+											Type: "valid",
+											RawBody: &BodyMatcher{
+												Type:   BodyMatcherRegex,
+												Config: stringPtr("token_valid.*true"),
+											},
+										},
+										{
+											Type: "invalid",
+											RawBody: &BodyMatcher{
+												Type:   BodyMatcherExactMatch,
+												Config: stringPtr(`{"error":"unauthorized"}`),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: `{
+				"type": "CustomHttpV2",
+				"config": {
+					"calls": [{
+						"request": {
+							"endpoint": "https://api.example.com/verify",
+							"method": "GET"
+						},
+						"response": {
+							"conditions": [
+								{"type": "valid", "raw_body": {"type": "Regex", "config": "token_valid.*true"}},
+								{"type": "invalid", "raw_body": {"type": "ExactMatch", "config": "{\"error\":\"unauthorized\"}"}}
+							]
+						}
+					}]
+				}
+			}`,
+		},
+		"should successfully marshal a simple PairedValidator": {
+			mv: ThirdPartyActiveChecker{
+				Type: ThirdPartyActiveCheckerHttpV2,
+				Config: ThirdPartyActiveCheckerConfig{
+					ThirdPartyActiveCheckerConfigHttpV2: &ThirdPartyActiveCheckerConfigHttpV2{
+						Provides: []ThirdPartyActiveCheckerConfigPairedValidator{
+							{Kind: "vendorY", Name: "client_id"},
+						},
+					},
+				},
+			},
+			expectedResult: `{
+				"type": "CustomHttpV2",
+				"config": {
+					"provides": [
+						{"kind": "vendorY", "name": "client_id"}
+					]
+				}
+			}`,
+		},
+		"should successfully marshal CustomHttpV2 with request body": {
+			mv: ThirdPartyActiveChecker{
+				Type: ThirdPartyActiveCheckerHttpV2,
+				Config: ThirdPartyActiveCheckerConfig{
+					ThirdPartyActiveCheckerConfigHttpV2: &ThirdPartyActiveCheckerConfigHttpV2{
+						Calls: []HttpCallConfig{
+							{
+								Request: HttpRequestConfig{
+									Endpoint: "https://api.example.com/verify",
+									Method:   "GET",
+									Body:     stringPtr(`{"token":"$MATCH"}`),
+								},
+								Response: HttpResponseConfig{
+									Conditions: []ResponseCondition{
+										{
+											Type: "valid",
+											RawBody: &BodyMatcher{
+												Type:   BodyMatcherRegex,
+												Config: stringPtr("token_valid.*true"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: `{
+				"type": "CustomHttpV2",
+				"config": {
+					"calls": [{
+						"request": {
+							"endpoint": "https://api.example.com/verify",
+							"method": "GET",
+							"body": "{\"token\":\"$MATCH\"}"
+						},
+						"response": {
+							"conditions": [
+								{"type": "valid", "raw_body": {"type": "Regex", "config": "token_valid.*true"}}
+							]
+						}
+					}]
+				}
+			}`,
+		},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			b, err := json.Marshal(tt.mv)
+			if err != nil {
+				t.Fatal("json marshalling failed")
+			}
+
+			expected := compactJSON(t, tt.expectedResult)
+			if expected != string(b) {
+				t.Errorf("Expected %s, got %s", expected, string(b))
+			}
+
+			var roundTripActionChecker ThirdPartyActiveChecker
+			err = json.Unmarshal(b, &roundTripActionChecker)
+			if err != nil {
+				t.Fatal(fmt.Errorf("json unmarshalling failed %w", err))
+			}
+			if tt.mv.Type != roundTripActionChecker.Type {
+				t.Errorf("Wrong type: Expected %#v, got %#v", tt.mv.Type, roundTripActionChecker.Type)
+			}
+			if roundTripActionChecker.Config.ThirdPartyActiveCheckerConfigHttpV2 == nil {
+				t.Errorf("Expected httpV2 config, got nil")
+			}
+			if !reflect.DeepEqual(tt.mv.Config.ThirdPartyActiveCheckerConfigHttpV2, roundTripActionChecker.Config.ThirdPartyActiveCheckerConfigHttpV2) {
+				t.Errorf("Wrong HttpV2 config: Expected %#v, got %#v", tt.mv.Config.ThirdPartyActiveCheckerConfigHttpV2, roundTripActionChecker.Config.ThirdPartyActiveCheckerConfigHttpV2)
+			}
+		})
+	}
+}
+
+func Test_ThirdPartyActiveChecker_CustomHttpV2_RequestBodyRejected(t *testing.T) {
+	rawChecker := `{"type":"CustomHttpV2","config":{"calls":[{"request":{"endpoint":"https://api.example.com/verify","request_body":"{\"token\":\"$MATCH\"}"},"response":{"conditions":[{"type":"valid","raw_body":{"type":"Regex","config":"token_valid.*true"}}]}}]}}`
+
+	var checker ThirdPartyActiveChecker
+	err := json.Unmarshal([]byte(rawChecker), &checker)
+	if err == nil {
+		t.Fatal("Expected unmarshal to fail because request_body is not supported")
+	}
+}
+
+func createCustomHTTPV2Scanner(t *testing.T, config ThirdPartyActiveCheckerConfigHttpV2) *Scanner {
+	t.Helper()
+
+	scanner, err := CreateScanner([]RuleConfig{
+		RegexRuleConfig{
+			Id:                      "rule_secret",
+			Pattern:                 "secret_[a-z0-9]+",
+			MatchAction:             MatchAction{Type: MatchActionNone},
+			ThirdPartyActiveChecker: *NewThirdPartyActiveCheckerHttpV2(config),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to build scanner: %v", err)
+	}
+	t.Cleanup(scanner.Delete)
+	return scanner
+}
+
+func scanSingleMatchStatus(t *testing.T, scanner *Scanner, event string) MatchStatus {
+	t.Helper()
+
+	result, err := scanner.ScanWithOptions([]byte(event), ScanCallOptions{ValidateMatching: true})
+	if err != nil {
+		t.Fatalf("Failed to scan event: %v", err)
+	}
+	if len(result.Matches) != 1 {
+		t.Fatalf("Expected 1 match, got %d", len(result.Matches))
+	}
+	return result.Matches[0].MatchStatus
+}
+
+func Test_ThirdPartyActiveChecker_CustomHttpV2_Integration_StatusCodeAndRange(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/validate" {
+			t.Fatalf("Expected path /validate, got %s", r.URL.Path)
+		}
+		token := r.URL.Query().Get("token")
+		if token == "secret_ok" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"valid"}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	scanner := createCustomHTTPV2Scanner(t, ThirdPartyActiveCheckerConfigHttpV2{
+		Calls: []HttpCallConfig{
+			{
+				Request: HttpRequestConfig{
+					Endpoint: server.URL + "/validate?token=$MATCH",
+					Method:   "GET",
+				},
+				Response: HttpResponseConfig{
+					Conditions: []ResponseCondition{
+						{
+							Type:       "valid",
+							StatusCode: &StatusCodeMatcher{Single: intPtr(http.StatusOK)},
+						},
+						{
+							Type:       "invalid",
+							StatusCode: &StatusCodeMatcher{Range: &StatusCodeRange{Start: 400, End: 500}},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	validStatus := scanSingleMatchStatus(t, scanner, "secret_ok")
+	if validStatus != MatchStatusValid {
+		t.Fatalf("Expected %q, got %q", MatchStatusValid, validStatus)
+	}
+
+	invalidStatus := scanSingleMatchStatus(t, scanner, "secret_bad")
+	if invalidStatus != MatchStatusInvalid {
+		t.Fatalf("Expected %q, got %q", MatchStatusInvalid, invalidStatus)
+	}
+}
+
+func Test_ThirdPartyActiveChecker_CustomHttpV2_Integration_BodyAndHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("Expected method POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/verify" {
+			t.Fatalf("Expected path /verify, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Expected Authorization header to be %q, got %q", "Bearer secret", got)
+		}
+		if got := r.Header.Get("X-API-Key"); got != "custom_key" {
+			t.Fatalf("Expected X-API-Key header to be %q, got %q", "custom_key", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Expected body to be readable, got %v", err)
+		}
+		defer r.Body.Close()
+		if got := string(body); got != "secret" {
+			t.Fatalf("Expected body to be %q, got %q", "secret", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":"success","token_valid":true}`))
+	}))
+	defer server.Close()
+
+	scanner, err := CreateScanner([]RuleConfig{
+		RegexRuleConfig{
+			Id:          "rule_secret",
+			Pattern:     "secret",
+			MatchAction: MatchAction{Type: MatchActionNone},
+			ThirdPartyActiveChecker: *NewThirdPartyActiveCheckerHttpV2(ThirdPartyActiveCheckerConfigHttpV2{
+				Calls: []HttpCallConfig{
+					{
+						Request: HttpRequestConfig{
+							Endpoint: server.URL + "/verify",
+							Method:   "POST",
+							Headers: map[string]string{
+								"Authorization": "Bearer $MATCH",
+								"X-API-Key":     "custom_key",
+							},
+							Body: stringPtr(`$MATCH`),
+						},
+						Response: HttpResponseConfig{
+							Conditions: []ResponseCondition{
+								{
+									Type:       "valid",
+									StatusCode: &StatusCodeMatcher{Single: intPtr(http.StatusOK)},
+									RawBody: &BodyMatcher{
+										Type:   BodyMatcherRegex,
+										Config: stringPtr(`token_valid.*true`),
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to build scanner: %v", err)
+	}
+	defer scanner.Delete()
+
+	status := scanSingleMatchStatus(t, scanner, "secret")
+	if status != MatchStatusValid {
+		t.Fatalf("Expected %q, got %q", MatchStatusValid, status)
+	}
+}
+
+func Test_ThirdPartyActiveChecker_MatchPairing_Integration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/validate" {
+			t.Errorf("Expected path /validate, got %s", r.URL.Path)
+		}
+		token := r.URL.Query().Get("token")
+		clientID := r.URL.Query().Get("client_id")
+		if token == "secret" && clientID == "cid_abc123" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	mainRule := RegexRuleConfig{
+		Id:          "main",
+		Pattern:     "secret",
+		MatchAction: MatchAction{Type: MatchActionNone},
+		ThirdPartyActiveChecker: *NewThirdPartyActiveCheckerHttpV2(ThirdPartyActiveCheckerConfigHttpV2{
+			MatchPairing: &MatchPairingConfig{
+				Kind: "vendorX",
+				Parameters: map[string]string{
+					"client_id": "$CLIENT_ID",
+				},
+			},
+			Calls: []HttpCallConfig{
+				{
+					Request: HttpRequestConfig{
+						Endpoint: server.URL + "/validate?token=$MATCH&client_id=$CLIENT_ID",
+						Method:   "GET",
+					},
+					Response: HttpResponseConfig{
+						Conditions: []ResponseCondition{
+							{
+								Type:       "valid",
+								StatusCode: &StatusCodeMatcher{Single: intPtr(http.StatusOK)},
+							},
+							{
+								Type:       "invalid",
+								StatusCode: &StatusCodeMatcher{Single: intPtr(http.StatusUnauthorized)},
+							},
+						},
+					},
+				},
+			},
+		}),
+	}
+
+	pairedRule := RegexRuleConfig{
+		Id:               "supporting",
+		Pattern:          `cid_[a-z0-9]+`,
+		MatchAction:      MatchAction{Type: MatchActionNone},
+		IsSupportingRule: true,
+		ThirdPartyActiveChecker: *NewThirdPartyActiveCheckerHttpV2(ThirdPartyActiveCheckerConfigHttpV2{
+			Provides: []ThirdPartyActiveCheckerConfigPairedValidator{
+				{
+					Kind: "vendorX",
+					Name: "client_id",
+				},
+			},
+		}),
+	}
+
+	scanner, err := CreateScanner([]RuleConfig{mainRule, pairedRule})
+	if err != nil {
+		t.Fatalf("Failed to build scanner: %v", err)
+	}
+	defer scanner.Delete()
+
+	t.Run("valid secret with correct paired client_id resolves to Valid", func(t *testing.T) {
+		result, err := scanner.ScanEventsMapWithOptions(map[string]interface{}{
+			"token":     "secret",
+			"client_id": "cid_abc123",
+		}, ScanCallOptions{ValidateMatching: true})
+		if err != nil {
+			t.Fatalf("Failed to scan event: %v", err)
+		}
+
+		if len(result.Matches) != 1 {
+			t.Fatalf("Expected 1 match, got %d", len(result.Matches))
+		}
+		if result.Matches[0].MatchStatus != MatchStatusValid {
+			t.Fatalf("Expected main rule match status %q, got %q", MatchStatusValid, result.Matches[0].MatchStatus)
+		}
+	})
+
+	t.Run("secret without paired client_id resolves to MissingDependentMatch", func(t *testing.T) {
+		result, err := scanner.ScanEventsMapWithOptions(map[string]interface{}{
+			"token": "secret",
+		}, ScanCallOptions{ValidateMatching: true})
+		if err != nil {
+			t.Fatalf("Failed to scan event: %v", err)
+		}
+
+		if len(result.Matches) != 1 {
+			t.Fatalf("Expected 1 match, got %d", len(result.Matches))
+		}
+		if result.Matches[0].MatchStatus != MatchStatusMissingDependentMatch {
+			t.Fatalf("Expected %q when paired validator not present, got %q", MatchStatusMissingDependentMatch, result.Matches[0].MatchStatus)
+		}
+	})
+}


### PR DESCRIPTION
The Rust engine already accepts CustomHttpV2, but the Go FFI only modeled AWS and CustomHttp v1, so v2 configs (calls, match pairing, provides) could not be constructed or scanned through the bindings.

Add Go types and JSON matching the Rust serde shape, plus round-trip and httptest coverage for status codes, request body/headers, and match pairing.

[ticket](https://datadoghq.atlassian.net/browse/DATASEC-32)